### PR TITLE
Fix wrong type for `active` field in senders and receivers

### DIFF
--- a/Development/nmos/node_resources.cpp
+++ b/Development/nmos/node_resources.cpp
@@ -197,7 +197,7 @@ namespace nmos
 
             value subscription;
             subscription[U("receiver_id")] = value::null();
-            subscription[U("active")] = value(false);
+            subscription[U("active")] = value::boolean(false);
             data[U("subscription")] = subscription;
 
             return{ is04_versions::v1_2, types::sender, data, false };
@@ -228,7 +228,7 @@ namespace nmos
 
             value subscription;
             subscription[U("sender_id")] = value::null();
-            subscription[U("active")] = value(false);
+            subscription[U("active")] = value::boolean(false);
             data[U("subscription")] = subscription;
 
             // nmos-discovery-registration/APIs/schemas/receiver_video.json

--- a/Development/nmos/node_resources.cpp
+++ b/Development/nmos/node_resources.cpp
@@ -197,7 +197,7 @@ namespace nmos
 
             value subscription;
             subscription[U("receiver_id")] = value::null();
-            subscription[U("active")] = false;
+            subscription[U("active")] = value(false);
             data[U("subscription")] = subscription;
 
             return{ is04_versions::v1_2, types::sender, data, false };
@@ -228,7 +228,7 @@ namespace nmos
 
             value subscription;
             subscription[U("sender_id")] = value::null();
-            subscription[U("active")] = false;
+            subscription[U("active")] = value(false);
             data[U("subscription")] = subscription;
 
             // nmos-discovery-registration/APIs/schemas/receiver_video.json

--- a/Development/nmos/query_api.cpp
+++ b/Development/nmos/query_api.cpp
@@ -235,7 +235,7 @@ namespace nmos
                     // "NB: Default should be 'false' if the API is being presented via HTTP, and 'true' for HTTPS"
                     if (!data.has_field(nmos::fields::secure))
                     {
-                        data[nmos::fields::secure] = false; // for now, no means to detect the API protocol?
+                        data[nmos::fields::secure] = value::boolean(false); // for now, no means to detect the API protocol?
                     }
 
                     // for now, only support HTTP


### PR DESCRIPTION
There is no implicit `web::json::value` constructor for `bool`s, but there are implicit constructors for numbers. C++ implicit conversions strike again! Result: the Node API server delivers a JSON value with `"active": 0` instead of `"active": false`