### PR TITLE
Added #ifdef __cpluscplus to protect .c files from boost C++ header

### DIFF
--- a/Development/cpprest/details/boost_u_workaround.h
+++ b/Development/cpprest/details/boost_u_workaround.h
@@ -1,6 +1,8 @@
 // Workaround for conflict between the 'U' macro and some uses of U as e.g. a template parameter in Boost libraries
 #pragma once
+#ifdef __cplusplus
 #include "cpprest/details/push_undef_u.h"
 // See https://stackoverflow.com/questions/43245055/issue-with-boost-1-64-and-visual-studio-2017
 #include <boost/move/detail/type_traits.hpp>
 #include "cpprest/details/pop_u.h"
+#endif


### PR DESCRIPTION
I have a .c file in my application and while the 
/FI\"${NMOS_CPP_DIR}/cpprest/details/boost_u_workaround.h\" 

in NmosCppCommon.cmake seems like it should only apply to C++ files, in practice, it seems to apply to .C files also, even when they have been marked as having the LANGUAGE C.

set_source_files_properties (example.c PROPERTIES LANGUAGE C)

By adding #ifdef __cplusplus in the boost_u_workaround.h file, the fight with Cmake is avoided and the the .c file avoids the errors which occur when the boost file type_traits.hpp is included in a C file.