### PR TITLE
gcc needs specific namespace for boost::join

### DIFF
--- a/Development/nmos/connection_api.cpp
+++ b/Development/nmos/connection_api.cpp
@@ -60,7 +60,7 @@ namespace nmos
             static const web::json::experimental::json_validator validator
             {
                 nmos::experimental::load_json_schema,
-                boost::copy_range<std::vector<web::uri>>(boost::join(
+                boost::copy_range<std::vector<web::uri>>(boost::range::join(
                     is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, _1, nmos::types::sender)),
                     is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, _1, nmos::types::receiver))
                 ))


### PR DESCRIPTION
When compiling with gcc I get following error:

```
nmos-cpp/Development/nmos/connection_api.cpp:66:17: error: call of overload, const nmos::type&), boost::_bi::list2<boost::arg<1>, boost::_bi::value<nmos::type> > >, const std::set<nmos_version&, const nmos::type&), boost::_bi::list2<boost::arg<1>, boost::_bi::value<nmos::type> > >, const std:
                 ))
                 ^
In file included from /opt/boost/include/boost/algorithm/string.hpp:24:0,
                 from /usr/local/include/cpprest/asyncrt_utils.h:31,
                 from /usr/local/include/cpprest/json.h:25,
                 from /usr/local/include/cpprest/http_msg.h:22,
                 from /usr/local/include/cpprest/http_listener.h:19,
                 from /home/alexei/source/software/nmos/nmos-cpp/Development/cpprest/api_router.h:8,
                 from /home/alexei/source/software/nmos/nmos-cpp/Development/nmos/connection_api.h:4,
                 from /home/alexei/source/software/nmos/nmos-cpp/Development/nmos/connection_api.cpp:1:
/opt/boost/include/boost/algorithm/string/join.hpp:46:9: note: candidate: typename boost::range_value<T>::typtransformed_range<boost::_bi::bind_t<web::uri, web::uri (*)(const nmos::api_version&, const nmos::type&), booost::range_detail::transformed_range<boost::_bi::bind_t<web::uri, web::uri (*)(const nmos::api_version&, conson> >; typename boost::range_value<T>::type = web::uri]
         join(
         ^~~~
In file included from /home/alexei/source/software/nmos/nmos-cpp/Development/nmos/connection_api.cpp:3:0:
/opt/boost/include/boost/range/join.hpp:66:1: note: candidate: boost::range::joined_range<const SinglePassRanRange1 = boost::range_detail::transformed_range<boost::_bi::bind_t<web::uri, web::uri (*)(const nmos::api_ver::api_version> >; SinglePassRange2 = boost::range_detail::transformed_range<boost::_bi::bind_t<web::uri, web:pe> > >, const std::set<nmos::api_version> >]
 join(const SinglePassRange1& r1, const SinglePassRange2& r2)
 ^~~~

```