### PR TITLE
New "settings_address" setting

### DIFF
--- a/Development/cpprest/api_router.h
+++ b/Development/cpprest/api_router.h
@@ -23,17 +23,17 @@ namespace web
                 // RAII helper for http_listener sessions (could be extracted to another header)
                 typedef pplx::open_close_guard<http_listener> http_listener_guard;
 
+#if defined(_WIN32) && !defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
+                const auto host_wildcard = _XPLATSTR("*"); // "weak wildcard"
+#else
+                const auto host_wildcard = _XPLATSTR("0.0.0.0");
+#endif
+
                 // using namespace api_router_using_declarations; // to make defining routers less verbose
                 namespace api_router_using_declarations {}
-
-                inline web::uri make_listener_uri(int port)
+                inline web::uri make_listener_uri(const utility::string_t& address, int port)
                 {
-#if defined(_WIN32) && !defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
-                    auto host_wildcard = _XPLATSTR("*"); // "weak wildcard"
-#else
-                    auto host_wildcard = _XPLATSTR("0.0.0.0");
-#endif
-                    return web::uri_builder().set_scheme(_XPLATSTR("http")).set_host(host_wildcard).set_port(port).to_uri();
+                    return web::uri_builder().set_scheme(_XPLATSTR("http")).set_host(address).set_port(port).to_uri();
                 }
 
                 typedef std::unordered_map<utility::string_t, utility::string_t> route_parameters;

--- a/Development/cpprest/test/api_router_test.cpp
+++ b/Development/cpprest/test/api_router_test.cpp
@@ -10,7 +10,7 @@ BST_TEST_CASE(testMakeListenerUri)
 #if defined(_WIN32) && !defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
     BST_REQUIRE_STRING_EQUAL("http://*:42/", utility::us2s(web::http::experimental::listener::make_listener_uri(42).to_string()));
 #else
-    BST_REQUIRE_STRING_EQUAL("http://0.0.0.0:42/", utility::us2s(web::http::experimental::listener::make_listener_uri(42).to_string()));
+    BST_REQUIRE_STRING_EQUAL("http://0.0.0.0:42/", utility::us2s(web::http::experimental::listener::make_listener_uri(web::http::experimental::listener::host_wildcard, 42).to_string()));
 #endif
 }
 

--- a/Development/nmos/api_utils.cpp
+++ b/Development/nmos/api_utils.cpp
@@ -386,9 +386,9 @@ namespace nmos
     }
 
     // construct an http_listener on the specified port, using the specified API to handle all requests
-    web::http::experimental::listener::http_listener make_api_listener(int port, web::http::experimental::listener::api_router& api, web::http::experimental::listener::http_listener_config config, slog::base_gate& gate)
+    web::http::experimental::listener::http_listener make_api_listener(const char *address, int port, web::http::experimental::listener::api_router& api, web::http::experimental::listener::http_listener_config config, slog::base_gate& gate)
     {
-        web::http::experimental::listener::http_listener api_listener(web::http::experimental::listener::make_listener_uri(port), std::move(config));
+        web::http::experimental::listener::http_listener api_listener(web::http::experimental::listener::make_listener_uri(address, port), std::move(config));
         nmos::support_api(api_listener, api, gate);
         return api_listener;
     }

--- a/Development/nmos/api_utils.h
+++ b/Development/nmos/api_utils.h
@@ -89,7 +89,7 @@ namespace nmos
 
     // construct an http_listener on the specified port, modifying the specified API to handle all requests
     // (including CORS preflight requests via "OPTIONS") - captures api by reference!
-    web::http::experimental::listener::http_listener make_api_listener(int port, web::http::experimental::listener::api_router& api, web::http::experimental::listener::http_listener_config config, slog::base_gate& gate);
+    web::http::experimental::listener::http_listener make_api_listener(const utility::char_t* address, int port, web::http::experimental::listener::api_router& api, web::http::experimental::listener::http_listener_config config, slog::base_gate& gate);
 
     namespace details
     {

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -121,6 +121,10 @@ namespace nmos
 
             const web::json::field_as_integer_or settings_port{ U("settings_port"), 3209 };
             const web::json::field_as_integer_or logging_port{ U("logging_port"), 5106 };
+            
+            // addresses (or host names?) on which to listen for each API
+
+            const web::json::field_as_string settings_address{ U("settings_address") };
 
             // port numbers [registry]: ports on which to listen for each API
             // see http_port


### PR DESCRIPTION
Proof-of-concept: new "settings_address" setting to make it possible to specify the (one) IP address to which the settings API will be bound at start-up.

I've limited my changes to this one setting not (only) because I'm lazy, but because I expect there will be compilation problems on other platforms and would rather give you the chance to sort those out before other services get the ability to be bound to a specific address. Furthermore, the settings API was the interface I really wanted to specifically bind the listening address of.