### PR TITLE
IS-07 websocket sender example implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Development/build

--- a/Development/cmake/NmosCppLibraries.cmake
+++ b/Development/cmake/NmosCppLibraries.cmake
@@ -509,6 +509,8 @@ set(NMOS_CPP_NMOS_SOURCES
     ${NMOS_CPP_DIR}/nmos/client_utils.cpp
     ${NMOS_CPP_DIR}/nmos/components.cpp
     ${NMOS_CPP_DIR}/nmos/connection_api.cpp
+    ${NMOS_CPP_DIR}/nmos/events_api.cpp
+    ${NMOS_CPP_DIR}/nmos/events_ws_api.cpp
     ${NMOS_CPP_DIR}/nmos/filesystem_route.cpp
     ${NMOS_CPP_DIR}/nmos/group_hint.cpp
     ${NMOS_CPP_DIR}/nmos/id.cpp
@@ -548,6 +550,8 @@ set(NMOS_CPP_NMOS_HEADERS
     ${NMOS_CPP_DIR}/nmos/copyable_atomic.h
     ${NMOS_CPP_DIR}/nmos/connection_api.h
     ${NMOS_CPP_DIR}/nmos/device_type.h
+    ${NMOS_CPP_DIR}/nmos/events_api.h
+    ${NMOS_CPP_DIR}/nmos/events_ws_api.h
     ${NMOS_CPP_DIR}/nmos/filesystem_route.h
     ${NMOS_CPP_DIR}/nmos/format.h
     ${NMOS_CPP_DIR}/nmos/group_hint.h
@@ -556,6 +560,7 @@ set(NMOS_CPP_NMOS_HEADERS
     ${NMOS_CPP_DIR}/nmos/interlace_mode.h
     ${NMOS_CPP_DIR}/nmos/is04_versions.h
     ${NMOS_CPP_DIR}/nmos/is05_versions.h
+    ${NMOS_CPP_DIR}/nmos/is07_versions.h
     ${NMOS_CPP_DIR}/nmos/json_fields.h
     ${NMOS_CPP_DIR}/nmos/json_schema.h
     ${NMOS_CPP_DIR}/nmos/log_manip.h

--- a/Development/cpprest/ws_listener.h
+++ b/Development/cpprest/ws_listener.h
@@ -53,6 +53,8 @@ namespace web
                 typedef std::function<void(const utility::string_t&, const connection_id&)> open_handler;
                 // a close handler gets the resource path and the connection id
                 typedef std::function<void(const utility::string_t&, const connection_id&)> close_handler;
+                // a message handler gets the resource path, connection id and message payload
+                typedef std::function<void(const utility::string_t&, const connection_id&, const utility::string_t&)> message_handler;
 
                 class websocket_listener
                 {
@@ -63,9 +65,13 @@ namespace web
                     void set_validate_handler(validate_handler handler);
                     void set_open_handler(open_handler handler);
                     void set_close_handler(close_handler handler);
+                    void set_message_handler(message_handler handler);
 
                     pplx::task<void> open();
                     pplx::task<void> close();
+
+                    //Closing individual connection when no health command is received(IS-07)
+                    pplx::task<void> close(const connection_id& connection);
 
                     pplx::task<void> send(const connection_id& connection, websocket_outgoing_message message);
                     //pplx::task<websocket_incoming_message> receive(const connection_id& connection);

--- a/Development/nmos-cpp-node/node_implementation.h
+++ b/Development/nmos-cpp-node/node_implementation.h
@@ -15,5 +15,6 @@ namespace nmos
 // It constructs and inserts a node resource and some sub-resources into the model, based on the model settings,
 // and then waits for sender/receiver activations or shutdown.
 void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate);
+void node_update_temperature_thread(nmos::node_model& model, slog::base_gate& gate);
 
 #endif

--- a/Development/nmos/api_downgrade.cpp
+++ b/Development/nmos/api_downgrade.cpp
@@ -2,6 +2,7 @@
 
 #include <map>
 #include "nmos/is04_versions.h"
+#include "nmos/is07_versions.h"
 #include "nmos/resource.h"
 
 namespace nmos
@@ -116,6 +117,12 @@ namespace nmos
                 {
                     { nmos::is04_versions::v1_0, { U("id"), U("ws_href"), U("max_update_rate_ms"), U("persist"), U("resource_path"), U("params") } },
                     { nmos::is04_versions::v1_1, { U("secure") } }
+                }
+            },
+            {
+                nmos::types::event_restapi,
+                {
+                    { nmos::is07_versions::v1_0, { U("id"), U("state"), U("type") } },
                 }
             }
         };

--- a/Development/nmos/api_utils.cpp
+++ b/Development/nmos/api_utils.cpp
@@ -149,7 +149,8 @@ namespace nmos
             { U("flows"), nmos::types::flow },
             { U("senders"), nmos::types::sender },
             { U("receivers"), nmos::types::receiver },
-            { U("subscriptions"), nmos::types::subscription }
+            { U("subscriptions"), nmos::types::subscription },
+            { U("events"), nmos::types::event_restapi }
         };
         return types_from_resourceType.at(resourceType);
     }
@@ -166,6 +167,7 @@ namespace nmos
             { nmos::types::sender, U("senders") },
             { nmos::types::receiver, U("receivers") },
             { nmos::types::subscription, U("subscriptions") },
+            { nmos::types::event_restapi, U("events") },
             { nmos::types::grain, {} } // subscription websocket grains aren't exposed via the Query API
         };
         return resourceTypes_from_type.at(type);

--- a/Development/nmos/api_utils.h
+++ b/Development/nmos/api_utils.h
@@ -5,6 +5,7 @@
 #include <set>
 #include "cpprest/api_router.h"
 #include "cpprest/regex_utils.h"
+#include "nmos/resources.h"
 
 namespace slog
 {
@@ -51,6 +52,9 @@ namespace nmos
         const route_pattern stagingType = make_route_pattern(U("stagingType"), U("active|staged"));
 
         const route_pattern resourceId = make_route_pattern(U("resourceId"), U("[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"));
+
+        // IS-07 Events-api "state" or "type" part of the url
+        const route_pattern eventsApiSubResource = make_route_pattern(U("eventsApiSubResource"), U("state|type"));
     }
 
     // Note that a resourceType does not have the same value as a "proper" type, use this mapping instead!
@@ -98,6 +102,9 @@ namespace nmos
     {
         return make_api_listener(web::http::experimental::listener::host_wildcard, port, api, config, gate);
     }
+
+    // Used in websocket APIs
+    resources::iterator find_subscription(resources& resources, const utility::string_t& ws_resource_path);
 
     namespace details
     {

--- a/Development/nmos/connection_api.cpp
+++ b/Development/nmos/connection_api.cpp
@@ -553,6 +553,7 @@ namespace nmos
                 // On successful staging/activation, this copy will also be used for the response.
 
                 auto merged = nmos::fields::endpoint_staged(resource->data);
+                auto constraints = nmos::fields::endpoint_constraints(resource->data);
 
                 // "In the case where the transport file and transport parameters are updated in the same PATCH request
                 // transport parameters specified in the request object take precedence over those in the transport file."
@@ -564,7 +565,7 @@ namespace nmos
                 // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/ConnectionAPI.raml#L344-L363
 
                 auto& transport_file = nmos::fields::transport_file(patch);
-                if (!transport_file.is_null() && !transport_file.as_object().empty())
+                if (!transport_file.is_null() && !transport_file.as_object().empty() && constraints.has_field(nmos::fields::rtp_enabled))
                 {
                     const auto transport_type_data = details::get_transport_type_data(transport_file);
 

--- a/Development/nmos/events_api.cpp
+++ b/Development/nmos/events_api.cpp
@@ -34,7 +34,7 @@ namespace nmos
             set_reply(res, status_codes::OK,
                 web::json::serialize_if(resources,
                     match,
-                    [](const nmos::resources::value_type& resource) { return resource.data.at(U("id")); }),
+                    [](const nmos::resources::value_type& resource) { return value::string(resource.data.at(U("id")).as_string() + "/"); }),
                 U("application/json"));
             return pplx::task_from_result(true);
         });

--- a/Development/nmos/events_api.cpp
+++ b/Development/nmos/events_api.cpp
@@ -1,0 +1,117 @@
+#include "nmos/events_api.h"
+
+#include "nmos/api_utils.h"
+#include "nmos/format.h"
+#include "nmos/is07_versions.h"
+#include "nmos/model.h"
+
+namespace nmos
+{
+
+    web::http::experimental::listener::api_router make_unmounted_events_api(const nmos::node_model& model, slog::base_gate& gate_) {
+        using namespace web::http::experimental::listener::api_router_using_declarations;
+        using web::json::value;
+
+        api_router events_api;
+
+        // check for supported API version
+        const auto versions = with_read_lock(model.mutex, [&model] { return nmos::is07_versions::from_settings(model.settings); });
+        events_api.support(U(".*"), details::make_api_version_handler(versions, gate_));
+
+        events_api.support(U("/?"), methods::GET, [](http_request, http_response res, const string_t&, const route_parameters&)
+        {
+            set_reply(res, status_codes::OK, nmos::make_sub_routes_body({ U("sources/") }, res));
+            return pplx::task_from_result(true);
+        });
+
+        events_api.support(U("/sources/?"), methods::GET, [&model](http_request req, http_response res, const string_t&, const route_parameters& parameters)
+        {
+            auto lock = model.read_lock();
+            auto& resources = model.node_resources;
+
+            const auto match = [](const nmos::resources::value_type& resource) { return resource.type == nmos::types::source && resource.data.at(U("format")) == value::string(nmos::formats::data.name) && resource.data.has_field(U("event_type")); };
+
+            set_reply(res, status_codes::OK,
+                web::json::serialize_if(resources,
+                    match,
+                    [](const nmos::resources::value_type& resource) { return resource.data.at(U("id")); }),
+                U("application/json"));
+            return pplx::task_from_result(true);
+        });
+
+        events_api.support(U("/sources/") + nmos::patterns::resourceId.pattern + U("/?"), methods::GET, [&model, &gate_](http_request req, http_response res, const string_t&, const route_parameters& parameters)
+        {
+            nmos::api_gate gate(gate_, req, parameters);
+            auto lock = model.read_lock();
+            auto& resources = model.event_resources;
+
+            const string_t resourceId = parameters.at(nmos::patterns::resourceId.name);
+            auto resource = find_resource(resources, { resourceId, nmos::types::event_restapi });
+            if (resources.end() != resource)
+            {
+                slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Returning resource: " << resourceId;
+                set_reply(res, status_codes::OK, nmos::make_sub_routes_body({ U("state/"), U("type/") }, res));
+            }
+            else
+            {
+                set_reply(res, status_codes::NotFound);
+            }
+            return pplx::task_from_result(true);
+        });
+
+        events_api.support(U("/sources/") + nmos::patterns::resourceId.pattern + U("/") + nmos::patterns::eventsApiSubResource.pattern + U("/?"), methods::GET, [&model, &gate_](http_request req, http_response res, const string_t&, const route_parameters& parameters)
+        {
+            nmos::api_gate gate(gate_, req, parameters);
+            auto lock = model.read_lock();
+            auto& resources = model.event_resources;
+
+            const string_t resourceId = parameters.at(nmos::patterns::resourceId.name);
+            const string_t eventsApiSubResource = parameters.at(nmos::patterns::eventsApiSubResource.name);
+            auto resource = find_resource(resources, { resourceId, nmos::types::event_restapi });
+            if (resources.end() != resource)
+            {
+                slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Returning resource: " << resourceId;
+                set_reply(res, status_codes::OK, resource->data.at(eventsApiSubResource));
+            }
+            else
+            {
+                set_reply(res, status_codes::NotFound);
+            }
+            return pplx::task_from_result(true);
+        });
+
+        return events_api;
+    }
+
+    web::http::experimental::listener::api_router make_events_api(const nmos::node_model& model, slog::base_gate& gate)
+    {
+        using namespace web::http::experimental::listener::api_router_using_declarations;
+
+        api_router events_api;
+
+        events_api.support(U("/?"), methods::GET, [](http_request, http_response res, const string_t&, const route_parameters&)
+        {
+            set_reply(res, status_codes::OK, nmos::make_sub_routes_body({ U("x-nmos/") }, res));
+            return pplx::task_from_result(true);
+        });
+
+        events_api.support(U("/x-nmos/?"), methods::GET, [](http_request, http_response res, const string_t&, const route_parameters&)
+        {
+            set_reply(res, status_codes::OK, nmos::make_sub_routes_body({ U("events/") }, res));
+            return pplx::task_from_result(true);
+        });
+
+        const auto versions = with_read_lock(model.mutex, [&model] { return nmos::is07_versions::from_settings(model.settings); });
+        events_api.support(U("/x-nmos/events/?"), methods::GET, [versions](http_request, http_response res, const string_t&, const route_parameters&)
+        {
+            set_reply(res, status_codes::OK, nmos::make_sub_routes_body(nmos::make_api_version_sub_routes(versions), res));
+            return pplx::task_from_result(true);
+        });
+
+        events_api.mount(U("/x-nmos/events/")+ nmos::patterns::version.pattern, make_unmounted_events_api(model, gate));
+
+        return events_api;
+    }
+
+
+}

--- a/Development/nmos/events_api.h
+++ b/Development/nmos/events_api.h
@@ -1,0 +1,16 @@
+#ifndef NMOS_EVENTS_API_H
+#define NMOS_EVENTS_API_H
+
+#include <atomic>
+#include "cpprest/api_router.h"
+#include "nmos/slog.h" // for slog::base_gate and slog::severity, etc.
+
+// IS-07 Rest api exposing state and event types
+namespace nmos
+{
+    struct node_model;
+
+    web::http::experimental::listener::api_router make_events_api(const nmos::node_model& model, slog::base_gate& gate);
+}
+
+#endif

--- a/Development/nmos/events_ws_api.cpp
+++ b/Development/nmos/events_ws_api.cpp
@@ -47,7 +47,7 @@ namespace nmos
             const auto connection_senders = by_type.equal_range(nmos::details::has_data(nmos::types::sender));
             auto connection_sender = std::find_if(connection_senders.first, connection_senders.second, [&ws_resource_path](const nmos::resources::value_type& resource)
             {
-                auto first_transport_param = resource.data.at(nmos::fields::endpoint_staged).at(nmos::fields::transport_params).at(0);
+                auto first_transport_param = resource.data.at(nmos::fields::endpoint_active).at(nmos::fields::transport_params).at(0);
 
                 // Checking if connection resource have ws_resource:_path in its connection_uri
                 return first_transport_param.has_field(nmos::fields::connection_uri) && first_transport_param.at(nmos::fields::connection_uri).as_string().find(ws_resource_path) != std::string::npos;

--- a/Development/nmos/events_ws_api.cpp
+++ b/Development/nmos/events_ws_api.cpp
@@ -1,0 +1,382 @@
+#include "nmos/events_ws_api.h"
+
+#include "nmos/api_utils.h"
+#include "nmos/is07_versions.h"
+#include "nmos/log_manip.h"
+#include "nmos/model.h"
+#include "nmos/query_utils.h"
+#include "nmos/rational.h"
+#include "nmos/thread_utils.h" // for wait_until
+#include "nmos/slog.h"
+#include "nmos/version.h"
+
+namespace nmos
+{
+    class ws_api_gate : public details::omanip_gate
+    {
+    public:
+        // apart from the gate, arguments are copied in order that this object is safely copyable
+        ws_api_gate(slog::base_gate& gate, const utility::string_t& ws_resource_path)
+            : details::omanip_gate(gate, slog::omanip([=](std::ostream& os) { os << nmos::stash_request_uri(ws_resource_path); }))
+        {}
+        virtual ~ws_api_gate() {}
+    };
+
+    resources::iterator find_subscription(resources& resources, const utility::string_t& ws_resource_path)
+    {
+        auto& by_type = resources.get<tags::type>();
+        const auto subscriptions = by_type.equal_range(details::has_data(nmos::types::subscription));
+        auto resource = std::find_if(subscriptions.first, subscriptions.second, [&ws_resource_path](const nmos::resources::value_type& resource)
+        {
+            return ws_resource_path == nmos::fields::ws_href(resource.data);
+        });
+        return subscriptions.second != resource ? resources.project<0>(resource) : resources.end();
+    }
+
+    web::websockets::experimental::listener::validate_handler make_eventntally_ws_validate_handler(nmos::node_model& model, slog::base_gate& gate_)
+    {
+        return [&model, &gate_](const utility::string_t& ws_resource_path)
+        {
+            nmos::ws_api_gate gate(gate_, ws_resource_path);
+            auto lock = model.read_lock();
+            auto& resources = model.connection_resources;
+
+            slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Validating websocket connection to: " << ws_resource_path;
+
+            auto& by_type = resources.get<nmos::tags::type>();
+            const auto connection_senders = by_type.equal_range(nmos::details::has_data(nmos::types::sender));
+            auto connection_sender = std::find_if(connection_senders.first, connection_senders.second, [&ws_resource_path](const nmos::resources::value_type& resource)
+            {
+                auto first_transport_param = resource.data.at(nmos::fields::endpoint_staged).at(nmos::fields::transport_params).at(0);
+
+                // Checking if connection resource have ws_resource:_path in its connection_uri
+                return first_transport_param.has_field(nmos::fields::connection_uri) && first_transport_param.at(nmos::fields::connection_uri).as_string().find(ws_resource_path) != std::string::npos;
+            });
+
+            const bool has_subscription = connection_senders.second != connection_sender;
+
+            if (!has_subscription) slog::log<slog::severities::error>(gate, SLOG_FLF) << "Invalid websocket connection to: " << ws_resource_path;
+            return has_subscription;
+        };
+    }
+
+    web::websockets::experimental::listener::open_handler make_eventntally_ws_open_handler(nmos::node_model& model, nmos::websockets& websockets, slog::base_gate& gate_)
+    {
+        using utility::string_t;
+        using web::json::value;
+
+        return [&model, &websockets, &gate_](const utility::string_t& ws_resource_path, const web::websockets::experimental::listener::connection_id& connection_id)
+        {
+            nmos::ws_api_gate gate(gate_, ws_resource_path);
+            auto lock = model.write_lock();
+            auto& resources = model.event_resources;
+
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Opening websocket connection to: " << ws_resource_path;
+
+            // Screating subscription
+            value subscription_data;
+            nmos::id subscription_id = nmos::make_id();
+            subscription_data[nmos::fields::id] = value::string(subscription_id);
+            subscription_data[nmos::fields::resource_path] = value::string(U("/nonexistentyet"));
+            subscription_data[nmos::fields::params] = value::object();
+            subscription_data[nmos::fields::max_update_rate_ms] = 0;
+            resource subscription{ is07_versions::v1_0, nmos::types::subscription, subscription_data, false };
+
+            //Creating grain, 1-1 relationship with subscription.
+            value grain_data;
+            nmos::id grain_id = nmos::make_id();
+            grain_data[nmos::fields::id] = value::string(grain_id);
+            grain_data[nmos::fields::subscription_id] = value::string(subscription_id);
+
+            //Creating empty grain data
+            grain_data[U("message")] = details::make_grain(subscription.id, subscription.id, U(""));
+            nmos::fields::message_grain_data(grain_data) = make_resource_events(resources, subscription.version, subscription.data.at(nmos::fields::resource_path).as_string(), subscription.data.at(U("params")));
+
+            // never expire the grain resource, they are only deleted when the connection is closed
+            resource grain{ subscription.version, nmos::types::grain, grain_data, false };
+
+            insert_resource(resources, std::move(subscription));
+            insert_resource(resources, std::move(grain));
+
+            // never expire a subscription while it has connections
+            // note, since health is mutable, no need for:
+            // model.resources.modify(subscription, [](nmos::resource& subscription){ subscription.health = health_forever; });
+            subscription.health = health_forever;
+
+            websockets.insert({ grain_id, connection_id });
+
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Creating websocket connection: " << grain_id << " to subscription: " << subscription.id;
+
+            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Notifying events websockets thread"; // and anyone else who cares...
+            model.notify();
+        };
+    }
+
+  web::websockets::experimental::listener::message_handler make_eventntally_ws_message_handler(nmos::node_model& model, nmos::websockets& websockets, slog::base_gate& gate_)
+    {
+        using utility::string_t;
+        using web::json::value;
+        using web::json::value_of;
+        return [&model, &websockets, &gate_](const utility::string_t& ws_resource_path, const web::websockets::experimental::listener::connection_id& connection_id, const utility::string_t& message_payload)
+        {
+            nmos::ws_api_gate gate(gate_, ws_resource_path);
+            auto lock = model.write_lock();
+            auto& resources = model.event_resources;
+
+            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Got message " << message_payload << " on path " << ws_resource_path;
+
+            auto websocket = websockets.right.find(connection_id);
+            if (websockets.right.end() != websocket)
+            {
+                auto grain = find_resource(resources, { websocket->second, nmos::types::grain });
+
+                if (resources.end() != grain)
+                {
+                    const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
+                    if (resources.end() != subscription) {
+                        try {
+                            auto body = value::parse(message_payload);
+                            auto command = body[nmos::fields::command];
+                            if (command == value::string(U("subscription"))) {
+                                modify_resource(resources, subscription->id, [&body](nmos::resource& resource)
+                                {
+                                    resource.data[nmos::fields::resource_path] = value::string(U("/events"));
+                                    utility::ostringstream_t rqlQuery;
+                                    rqlQuery << U("in(id,(");
+
+                                    for (const auto& sourceId : body.at("sources").as_array()) {
+                                        rqlQuery << sourceId.as_string() << ",";
+                                    }
+
+                                    rqlQuery << U("))");
+
+                                    resource.data[nmos::fields::params] = value_of({{ U("query.rql"), rqlQuery.str() }});
+                                });
+
+                                // Send back all events data when user sends "subscription" command
+                                const string_t resource_path = nmos::fields::resource_path(subscription->data);
+                                auto grain_data = make_resource_events(resources, subscription->version, resource_path, subscription->data.at(U("params")));
+                                auto grain_message = details::make_grain(subscription->id, subscription->id, U("/events/"));
+                                modify_resource(resources, grain->id, [&grain_data, &grain_message](nmos::resource& resource)
+                                {
+                                    resource.data[U("message")] = grain_message;
+                                    nmos::fields::message_grain_data(resource.data) = grain_data;
+                                });
+
+                                // Starting health countdown here
+                                const auto health = nmos::health_now();
+                                set_resource_health(resources, subscription->id, health);
+
+                                slog::log<slog::severities::info>(gate, SLOG_FLF) << "Received new IS-07 subscription command for sources " << body.at("sources").serialize();
+                                model.notify();
+                            } else if (command == value::string(U("health"))) {
+                                const auto health = nmos::health_now();
+                                set_resource_health(resources, subscription->id, health);
+
+                                resources.modify(grain, [&resources](nmos::resource& grain)
+                                {
+                                    nmos::tai tai = nmos::tai_now();
+                                    // Saving "health"-command response here, so the reply-thread can send the update to the client
+                                    auto& message_grain = grain.data[U("message")][U("grain")];
+                                    message_grain[U("health_reply")] = value_of ({
+                                        { U("timing"), value_of ({
+                                            { U("creation_timestamp"), std::to_string(tai.seconds) + U(":") + std::to_string(tai.nanoseconds) }
+                                        })},
+                                        { U("message_type"), U("health") }
+                                    });
+                                    grain.updated = strictly_increasing_update(resources);
+                                });
+
+                                slog::log<slog::severities::info>(gate, SLOG_FLF) << "Received new IS-07 health command command";
+                                
+                            }
+                        } catch (const web::json::json_exception& e) {
+                            slog::log<slog::severities::warning>(gate, SLOG_FLF) << "Got malformed IS-07 command json: " << e.what();
+                        }
+                    }
+                }
+
+            }
+            
+            return;            
+        };
+    }
+
+
+    web::websockets::experimental::listener::close_handler make_eventntally_ws_close_handler(nmos::node_model& model, nmos::websockets& websockets, slog::base_gate& gate_)
+    {
+        return [&model, &websockets, &gate_](const utility::string_t& ws_resource_path, const web::websockets::experimental::listener::connection_id& connection_id)
+        {
+            nmos::ws_api_gate gate(gate_, ws_resource_path);
+            auto lock = model.write_lock();
+            auto& resources = model.event_resources;
+
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Closing websocket connection to: " << ws_resource_path;
+
+            auto websocket = websockets.right.find(connection_id);
+            if (websockets.right.end() != websocket)
+            {
+                auto grain = find_resource(resources, { websocket->second, nmos::types::grain });
+
+                if (grain != resources.end()) {
+                    const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
+                    if (resources.end() != subscription) {
+                        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Deleting websocket connection with subscription_id: " << subscription->id;
+                        // This should erase grain too, as a subscription's subresource
+                        erase_resource(resources, subscription->id, false);   
+                    }
+                }
+
+                websockets.right.erase(websocket);
+            }
+        };
+    }
+
+    void send_eventntally_ws_events_thread(web::websockets::experimental::listener::websocket_listener& listener, nmos::node_model& model, nmos::websockets& websockets, slog::base_gate& gate_)
+    {
+        nmos::details::omanip_gate gate(gate_, nmos::stash_category(nmos::categories::send_eventntally_ws_events));
+
+        using utility::string_t;
+        using web::json::value;
+
+        // could start out as a shared/read lock, only upgraded to an exclusive/write lock when a grain in the resources is actually modified
+        auto lock = model.write_lock();
+        auto& condition = model.condition;
+        auto& shutdown = model.shutdown;
+        auto& resources = model.event_resources;
+
+        tai most_recent_message{};
+        auto earliest_necessary_update = (tai_clock::time_point::max)();
+
+        for (;;)
+        {
+            // wait for the thread to be interrupted either because there are resource changes, or because the server is being shut down
+            // or because message sending was throttled earlier
+            details::wait_until(condition, lock, earliest_necessary_update, [&]{ return shutdown || most_recent_message < most_recent_update(resources); });
+            if (shutdown) break;
+            most_recent_message = most_recent_update(resources);
+
+            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Got notification on query websockets thread";
+
+            earliest_necessary_update = (tai_clock::time_point::max)();
+
+            std::vector<std::pair<web::websockets::experimental::listener::connection_id, web::websockets::experimental::listener::websocket_outgoing_message>> outgoing_messages;
+
+            for (const auto& websocket : websockets.left)
+            {
+                // for each websocket connection that has valid grain and subscription resources
+                const auto grain = find_resource(resources, { websocket.first, nmos::types::grain });
+                if (resources.end() == grain) {
+                    // Connection has expired
+                    listener.close(websocket.second);
+                    continue;
+                }
+                const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
+                if (resources.end() == subscription) continue;
+
+                if (!grain->data.has_field(U("message"))) continue;
+                auto& message_grain = grain->data.at(U("message")).at(U("grain"));
+                if (message_grain.has_field(U("health_reply")) && !message_grain.at(U("health_reply")).is_null()) {
+                    auto serialized = utility::us2s(message_grain.at(U("health_reply")).serialize());
+                    web::websockets::experimental::listener::websocket_outgoing_message message;
+                    message.set_utf8_message(serialized);    
+                    outgoing_messages.push_back({ websocket.second, message });
+                }
+
+                auto events = nmos::fields::message_grain_data(grain->data);
+                if (0 != events.size()) {
+                    // Sending just last state event to the websocket
+                    auto serialized = utility::us2s(events.at(events.size()-1).at("post").at(nmos::fields::event_restapi_state).serialize());
+                    web::websockets::experimental::listener::websocket_outgoing_message message;
+                    message.set_utf8_message(serialized);
+
+                    outgoing_messages.push_back({ websocket.second, message });
+                }
+
+                // reset the grain for next time
+                resources.modify(grain, [](nmos::resource& grain)
+                {
+                    // Removing all events here since we are interested in sending just the last event.
+                    nmos::fields::message_grain_data(grain.data) = value::array();
+                    grain.data[U("message")][U("grain")][U("health_reply")] = value::null();
+                });
+            }
+
+            // send the messages without the lock on resources
+            details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
+
+            if (!outgoing_messages.empty()) slog::log<slog::severities::info>(gate, SLOG_FLF) << "Sending " << outgoing_messages.size() << " websocket messages";
+
+            for (auto& outgoing_message : outgoing_messages)
+            {
+                // hmmm, no way to cancel this currently...
+                auto send = listener.send(outgoing_message.first, outgoing_message.second).then([&](pplx::task<void> finally)
+                {
+                    try
+                    {
+                        finally.get();
+                    }
+                    catch (const web::websockets::experimental::listener::websocket_exception& e)
+                    {
+                        slog::log<slog::severities::error>(gate, SLOG_FLF) << "WebSockets error: " << e.what() << " [" << e.error_code() << "]";
+                    }
+                });
+                // current websocket_listener implementation is synchronous in any case, but just to make clear...
+                // for now, wait for the message to be sent
+                send.wait();
+            }
+        }
+    }
+
+    void erase_expired_resources_thread(nmos::node_model& model, slog::base_gate& gate_) {
+        nmos::details::omanip_gate gate(gate_, nmos::stash_category(nmos::categories::eventntally_ws_expiry));
+
+        // start out as a shared/read lock, only upgraded to an exclusive/write lock when an expired resource actually needs to be deleted from the resources
+        auto lock = model.read_lock();
+        auto& shutdown_condition = model.shutdown_condition;
+        auto& shutdown = model.shutdown;
+        auto& resources = model.event_resources;
+
+        auto least_health = nmos::least_health(resources);
+
+        // wait until the next node could potentially expire, or the server is being shut down
+        // (since health is truncated to seconds, and we want to be certain the expiry interval has passed, there's an extra second to wait here)
+        while (!shutdown_condition.wait_until(lock, time_point_from_health(least_health.first + nmos::fields::eventntally_expiry_interval(model.settings) + 1), [&]{ return shutdown; }))
+        {
+            // hmmm, it needs to be possible to enable/disable periodic logging like this independently of the severity...
+            slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "At " << nmos::make_version(nmos::tai_now()) << ", the IS-07 event machinery contains " << nmos::put_resources_statistics(resources);
+
+            // most nodes will have had a heartbeat during the wait, so the least health will have been increased
+            // so this thread will be able to go straight back to waiting
+            auto expire_health = health_now() - nmos::fields::eventntally_expiry_interval(model.settings);
+            auto forget_health = expire_health - nmos::fields::eventntally_expiry_interval(model.settings);
+            least_health = nmos::least_health(resources);
+            if (least_health.first >= expire_health && least_health.second >= forget_health) continue;
+
+            // otherwise, there's actually work to do...
+
+            details::reverse_lock_guard<nmos::read_lock> unlock(lock);
+            // note, without atomic upgrade, another thread may preempt hence the need to recalculate expire_health/forget_health and least_health
+            auto upgrade = model.write_lock();
+
+            expire_health = health_now() - nmos::fields::registration_expiry_interval(model.settings);
+            forget_health = expire_health - nmos::fields::registration_expiry_interval(model.settings);
+
+            // forget all resources expired in the previous interval
+            forget_erased_resources(resources, forget_health);
+
+            // expire all nodes for which there hasn't been a heartbeat in the last expiry interval
+            const auto expired = erase_expired_resources(resources, expire_health, false);
+
+            if (0 != expired)
+            {
+                slog::log<slog::severities::info>(gate, SLOG_FLF) << expired << " resources have expired";
+
+                slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Notifying query websockets thread"; // and anyone else who cares...
+                model.notify();
+            }
+
+            least_health = nmos::least_health(resources);
+        }
+    }
+}

--- a/Development/nmos/events_ws_api.cpp
+++ b/Development/nmos/events_ws_api.cpp
@@ -188,7 +188,8 @@ namespace nmos
                                 });
 
                                 slog::log<slog::severities::info>(gate, SLOG_FLF) << "Received new IS-07 health command command";
-                                
+
+                                model.notify();
                             }
                         } catch (const web::json::json_exception& e) {
                             slog::log<slog::severities::warning>(gate, SLOG_FLF) << "Got malformed IS-07 command json: " << e.what();
@@ -284,9 +285,8 @@ namespace nmos
                 }
 
                 auto events = nmos::fields::message_grain_data(grain->data);
-                if (0 != events.size()) {
-                    // Sending just last state event to the websocket
-                    auto serialized = utility::us2s(events.at(events.size()-1).at("post").at(nmos::fields::event_restapi_state).serialize());
+                for (auto i = 0; i < events.size(); i++) {
+                    auto serialized = utility::us2s(events.at(i).at("post").at(nmos::fields::event_restapi_state).serialize());
                     web::websockets::experimental::listener::websocket_outgoing_message message;
                     message.set_utf8_message(serialized);
 

--- a/Development/nmos/events_ws_api.h
+++ b/Development/nmos/events_ws_api.h
@@ -1,0 +1,32 @@
+#ifndef NMOS_EVENTS_WS_API_H
+#define NMOS_EVENTS_WS_API_H
+
+#include <boost/bimap.hpp>
+#include "cpprest/json.h"
+#include "cpprest/ws_listener.h" // for web::websockets::experimental::listener::connection_id, etc.
+#include "nmos/id.h"
+
+namespace slog
+{
+    class base_gate;
+}
+
+// Query API websocket implementation
+// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.2.%20Behaviour%20-%20Querying.md
+namespace nmos
+{
+    struct node_model;
+    struct tai;
+
+    typedef boost::bimap<nmos::id, web::websockets::experimental::listener::connection_id> websockets;
+
+    web::websockets::experimental::listener::validate_handler make_eventntally_ws_validate_handler(nmos::node_model& model, slog::base_gate& gate);
+    web::websockets::experimental::listener::open_handler make_eventntally_ws_open_handler(nmos::node_model& model, nmos::websockets& websockets, slog::base_gate& gate);
+    web::websockets::experimental::listener::close_handler make_eventntally_ws_close_handler(nmos::node_model& model, nmos::websockets& websockets, slog::base_gate& gate);
+    web::websockets::experimental::listener::message_handler make_eventntally_ws_message_handler(nmos::node_model& model, nmos::websockets& websockets, slog::base_gate& gate);
+
+    void send_eventntally_ws_events_thread(web::websockets::experimental::listener::websocket_listener& listener, nmos::node_model& model, nmos::websockets& websockets, slog::base_gate& gate);
+    void erase_expired_resources_thread(nmos::node_model& model, slog::base_gate& gate_);
+}
+
+#endif

--- a/Development/nmos/is07_versions.h
+++ b/Development/nmos/is07_versions.h
@@ -1,0 +1,26 @@
+#ifndef NMOS_IS07_VERSIONS_H
+#define NMOS_IS07_VERSIONS_H
+
+#include <set>
+#include <boost/range/adaptor/transformed.hpp>
+#include "nmos/api_version.h"
+#include "nmos/settings.h"
+
+namespace nmos
+{
+    namespace is07_versions
+    {
+        const api_version v1_0{ 1, 0 };
+
+        const std::set<api_version> all{ nmos::is07_versions::v1_0 };
+
+        inline std::set<api_version> from_settings(const nmos::settings& settings)
+        {
+            return settings.has_field(nmos::fields::is07_versions)
+                ? boost::copy_range<std::set<api_version>>(nmos::fields::is07_versions(settings) | boost::adaptors::transformed([](const web::json::value& v) { return nmos::parse_api_version(v.as_string()); }))
+                : nmos::is07_versions::all;
+        }
+    }
+}
+
+#endif

--- a/Development/nmos/json_fields.h
+++ b/Development/nmos/json_fields.h
@@ -69,6 +69,8 @@ namespace nmos
         // source_audio
         const web::json::field_as_array channels{ U("channels") };
         const web::json::field_as_string_or symbol{ U("symbol"), U("") }; // or nmos::channel_symbol?
+        // source IS-07 event
+        const web::json::field_as_string_or event_type{ U("event_type"), U("") };
 
         // lots more to be sorted!
         const web::json::field_as_string node_id{ U("node_id") };
@@ -99,6 +101,14 @@ namespace nmos
         const web::json::field<tai> origin_timestamp{ U("origin_timestamp") };
         const web::json::field<tai> sync_timestamp{ U("sync_timestamp") };
         const web::json::field_as_string topic{ U("topic") };
+
+        // for IS-07
+        const web::json::field_as_array sources{ U("sources") };
+        const web::json::field_as_string command{ U("command") };
+        const web::json::field_as_string health{ U("health") };
+        const web::json::field_as_string timestamp{ U("timestamp") };
+        const web::json::field_as_value event_restapi_state{ U("state") };
+        const web::json::field_as_value event_restapi_type{ U("type") };
 
         // IS-05 Connection Management
 
@@ -133,6 +143,13 @@ namespace nmos
         const web::json::field_as_value_or rtcp_destination_port{ U("rtcp_destination_port"), {} }; // string or integer
         const web::json::field_as_value_or rtcp_source_port{ U("rtcp_source_port"), {} }; // string or integer
         const web::json::field_as_value_or fec_mode{ U("fec_mode"), {} }; // string
+        const web::json::field_as_value_or connection_uri{ U("connection_uri"), {} }; // string
+        const web::json::field_as_value_or ext_is_07_source_id{ U("ext_is_07_source_id"), {} }; // string
+        const web::json::field_as_value_or ext_is_07_rest_api_url{ U("ext_is_07_rest_api_url"), {} }; // string
+        const web::json::field_as_value_or source_host{ U("source_host"), {} }; // string
+        const web::json::field_as_value_or broker_topic{ U("broker_topic"), {} }; // string
+        const web::json::field_as_value_or destination_host{ U("destination_host"), {} }; // string
+
     }
 
     // Fields for experimental extensions

--- a/Development/nmos/log_manip.h
+++ b/Development/nmos/log_manip.h
@@ -39,7 +39,8 @@ namespace nmos
                 << by_type.count(details::has_data(types::sender)) << " senders, "
                 << by_type.count(details::has_data(types::receiver)) << " receivers, "
                 << by_type.count(details::has_data(types::subscription)) << " subscriptions, "
-                << by_type.count(details::has_data(types::grain)) << " grains), "
+                << by_type.count(details::has_data(types::grain)) << " grains, "
+                << by_type.count(details::has_data(types::event_restapi)) << " events), "
                 << "most recent update: " << make_version(most_recent_update(resources)) << ", least health: " << least_health(resources).first << ", "
                 << by_type.count(false) << " non-extant resources";
         });

--- a/Development/nmos/media_type.h
+++ b/Development/nmos/media_type.h
@@ -27,6 +27,7 @@ namespace nmos
         const media_type audio_L24 = audio_L(24);
 
         // Data media types
+		const media_type application_json{ U("application/json") };
 
         const media_type video_smpte291{ U("video/smpte291") };
     }

--- a/Development/nmos/model.h
+++ b/Development/nmos/model.h
@@ -106,6 +106,9 @@ namespace nmos
         // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/schemas/v1.0-sender-response-schema.json
         // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/schemas/v1.0-receiver-response-schema.json
         nmos::resources connection_resources;
+
+        //IS-07 events_api resources. Contains "state" and "type" fields for each source. Also websocket subscription(url path) and grains(individual connections)
+        nmos::resources event_resources;
     };
 
     struct registry_model : model

--- a/Development/nmos/node_resources.cpp
+++ b/Development/nmos/node_resources.cpp
@@ -474,8 +474,6 @@ namespace nmos
             const auto unconstrained = value::object();
             return value_of({
                 { nmos::fields::broker_topic, unconstrained },
-                { nmos::fields::source_host, unconstrained },
-                { nmos::fields::source_port, unconstrained },
                 { nmos::fields::destination_host, unconstrained },
                 { nmos::fields::destination_port, unconstrained },
                 { nmos::fields::ext_is_07_rest_api_url, unconstrained },
@@ -590,6 +588,7 @@ namespace nmos
         auto data = details::make_connection_resource_core(sender_id, false);
 		data[nmos::fields::endpoint_constraints] = details::legs_of(details::make_connection_websocket_sender_core_constraints(), false);
 		data[nmos::fields::endpoint_staged][nmos::fields::receiver_id] = value::null();
+        data[nmos::fields::endpoint_staged][nmos::fields::master_enable] = value::boolean(false);
 
         auto host = nmos::fields::host_address(settings);
         auto connection_uri = web::uri_builder()
@@ -604,7 +603,9 @@ namespace nmos
                             .set_port(nmos::fields::events_port(settings))
                             .set_path(U("/x-nmos/events/")+ make_api_version(version) + U("/sources/") + source_id)
                             .to_string();
-		data[nmos::fields::endpoint_staged][nmos::fields::transport_params] = details::legs_of(details::make_connection_websocket_sender_staged_core_parameter_set(connection_uri, source_id, rest_api_url), false);
+        auto transport_params = details::legs_of(details::make_connection_websocket_sender_staged_core_parameter_set(connection_uri, source_id, rest_api_url), false);
+        data[nmos::fields::endpoint_staged][nmos::fields::transport_params] = transport_params;
+        data[nmos::fields::endpoint_active] = data[nmos::fields::endpoint_staged];
 
 		return{ is05_versions::v1_1, types::sender, data, false };
 	}
@@ -619,6 +620,7 @@ namespace nmos
         auto data = details::make_connection_resource_core(sender_id, false);
         data[nmos::fields::endpoint_constraints] = details::legs_of(details::make_connection_mqtt_sender_core_constraints(), false);
         data[nmos::fields::endpoint_staged][nmos::fields::receiver_id] = value::null();
+        data[nmos::fields::endpoint_staged][nmos::fields::master_enable] = value::boolean(false);
 
         auto host = nmos::fields::host_address(settings);
        
@@ -629,7 +631,9 @@ namespace nmos
                             .set_path(U("/x-nmos/events/")+ make_api_version(version) + U("/sources/") + source_id)
                             .to_string();
         auto broker_topic = U("/x-nmos/source/") + source_id;
-        data[nmos::fields::endpoint_staged][nmos::fields::transport_params] = details::legs_of(details::make_connection_mqtt_sender_staged_core_parameter_set(broker_topic, destination_host, destination_port, rest_api_url), false);
+        auto transport_params = details::legs_of(details::make_connection_mqtt_sender_staged_core_parameter_set(broker_topic, destination_host, destination_port, rest_api_url), false);
+        data[nmos::fields::endpoint_staged][nmos::fields::transport_params] = transport_params;
+        data[nmos::fields::endpoint_active] = data[nmos::fields::endpoint_staged];
 
         return{ is05_versions::v1_1, types::sender, data, false };
     }

--- a/Development/nmos/node_resources.h
+++ b/Development/nmos/node_resources.h
@@ -32,11 +32,20 @@ namespace nmos
     nmos::resource make_video_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
 
+	// See https://amwa-tv.github.io/nmos-event-tally/tags/v1.0/docs/4.0._Core_models.html#21-sources
+	nmos::resource make_event_source(const nmos::id& id, const nmos::id& device_id, const utility::string_t& event_type, const nmos::settings& settings);
+
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.1-dev/docs/6.0.%20Event%20and%20tally%20rest%20api.md
+    nmos::resource make_restapi_event(const nmos::id& source_id, const web::json::value& type, const web::json::value& state);
+
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_audio.json
     nmos::resource make_audio_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const std::vector<nmos::channel>& channels, const nmos::settings& settings);
 
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/APIs/schemas/flow_core.json
     nmos::resource make_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
+
+	// See https://amwa-tv.github.io/nmos-event-tally/tags/v1.0/docs/4.0._Core_models.html#22-flows
+    nmos::resource make_event_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/APIs/schemas/flow_video.json
     nmos::resource make_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const nmos::settings& settings);
@@ -74,6 +83,9 @@ namespace nmos
     nmos::resource make_sdianc_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
     nmos::resource make_connection_sender(const nmos::id& id, bool smpte2022_7);
+    nmos::resource make_connection_websocket_sender(const nmos::id& id, const nmos::id& device_id, const nmos::id& source_id, const nmos::settings& settings);
+    nmos::resource make_connection_mqtt_sender(const nmos::id& sender_id, const utility::string_t& destination_host, const utility::string_t& destination_port, const nmos::id& source_id, const nmos::settings& settings);
+
     web::json::value make_connection_sender_transportfile(const utility::string_t& transportfile);
     web::json::value make_connection_sender_transportfile(const web::uri& transportfile);
     // transportfile may be URL or the contents of the SDP file (yeah, yuck)

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -39,6 +39,9 @@ namespace nmos
         // is05_versions [node]: used to specify the enabled API versions for a version-locked configuration
         const web::json::field_as_array is05_versions{ U("is05_versions") }; // when omitted, nmos::is05_versions::all is used
 
+        // is07_versions [node]: used to specify the enabled API versions for a version-locked configuration
+        const web::json::field_as_array is07_versions{ U("is07_versions") }; // when omitted, nmos::is07_versions::all is used
+
         // pri [registry, node]: used for the 'pri' TXT record; specifying nmos::service_priorities::no_priority (maximum value) disables advertisement completely
         const web::json::field_as_integer_or pri{ U("pri"), 100 }; // default to highest_development_priority
 
@@ -64,10 +67,12 @@ namespace nmos
 
         const web::json::field_as_integer_or query_port{ U("query_port"), 3211 };
         const web::json::field_as_integer_or query_ws_port{ U("query_ws_port"), 3213 };
+        const web::json::field_as_integer_or eventntally_ws_port{ U("eventntally_ws_port"), 3217 };
         // registration_port [node]: used to construct request URLs for the registry's Registration API (if not discovered via DNS-SD)
         const web::json::field_as_integer_or registration_port{ U("registration_port"), 3210 };
         const web::json::field_as_integer_or node_port{ U("node_port"), 3212 };
         const web::json::field_as_integer_or connection_port{ U("connection_port"), 3215 };
+        const web::json::field_as_integer_or events_port{ U("events_port"), 3216 };
         const web::json::field_as_integer_or system_port{ U("system_port"), 10641 };
 
         // listen_backlog [registry, node]: the maximum length of the queue of pending connections, or zero for the implementation default (the implementation may not honour this value)
@@ -86,6 +91,10 @@ namespace nmos
         // "Registration APIs should use a garbage collection interval of 12 seconds by default (triggered just after two failed heartbeats at the default 5 second interval)."
         // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
         const web::json::field_as_integer_or registration_expiry_interval{ U("registration_expiry_interval"), 12 };
+
+        // "The server is expected to check health commands and after a 12 seconds timeout (2 consecutive missed health commands plus 2 seconds to allow for latencies) it should clear the subscriptions for that particular client and close the websocket connection. The server is also required to respond to a heartbeat within 5 seconds of receiving the health command."
+        // See https://amwa-tv.github.io/nmos-event-tally/tags/v1.0/docs/5.2._Transport_-_Websocket.html
+        const web::json::field_as_integer_or eventntally_expiry_interval{ U("eventntally_expiry_interval"), 12 };
 
         // registration_request_max [node]: timeout for interactions with the Registration API /resource endpoint
         const web::json::field_as_integer_or registration_request_max{ U("registration_request_max"), 30 };

--- a/Development/nmos/slog.h
+++ b/Development/nmos/slog.h
@@ -37,8 +37,11 @@ namespace nmos
         // categories that identify threads of execution
         const category node_behaviour{ "node_behaviour" };
         const category registration_expiry{ "registration_expiry" };
+        const category eventntally_ws_expiry{ "eventntally_ws_expiry" };
         const category send_query_ws_events{ "send_query_ws_events" };
         const category receive_query_ws_events{ "receive_query_ws_events" };
+        const category send_eventntally_ws_events{ "send_eventntally_ws_events" };
+        const category receive_eventntally_ws_events{ "receive_eventntally_ws_events" };
 
         // other categories may be defined ad-hoc
     }

--- a/Development/nmos/transport.h
+++ b/Development/nmos/transport.h
@@ -16,6 +16,8 @@ namespace nmos
         const transport rtp_ucast{ U("urn:x-nmos:transport:rtp.ucast") };
         const transport rtp_mcast{ U("urn:x-nmos:transport:rtp.mcast") };
         const transport dash{ U("urn:x-nmos:transport:dash") };
+        const transport mqtt{ U("urn:x-nmos:transport:mqtt") };
+        const transport websocket{ U("urn:x-nmos:transport:websocket") };
     }
 }
 

--- a/Development/nmos/type.h
+++ b/Development/nmos/type.h
@@ -32,6 +32,9 @@ namespace nmos
 
         // the System API global configuration resource
         const type global{ U("global") };
+
+        // IS-07 events_api resource
+        const type event_restapi{ U("event_restapi") };
     }
 }
 


### PR DESCRIPTION
Using ideas from Registry to track changes on IS-07 events resources and push to connected ws-clients, namely create new subscription-grain pair for every connected websocket cient and register rql-query for relevant sourceIds tht client provides via "subscription" command.
Piggybacking "health"-message replies on the grain-data.

Skeleton MQTT sender without actual implementation(scary to link another 3rdparty library:)