### PR TITLE
App hooks 4

### DIFF
--- a/Development/CMakeLists.txt
+++ b/Development/CMakeLists.txt
@@ -18,6 +18,7 @@ include (${NMOS_CPP_DIR}/cmake/NmosCppLibraries.cmake)
 set(NMOS_CPP_NODE_SOURCES
     ${NMOS_CPP_DIR}/nmos-cpp-node/main.cpp
     ${NMOS_CPP_DIR}/nmos-cpp-node/node_implementation.cpp
+    ${NMOS_CPP_DIR}/nmos-cpp-node/node_main_thread.cpp
     )
 set(NMOS_CPP_NODE_HEADERS
     ${NMOS_CPP_DIR}/nmos-cpp-node/node_implementation.h

--- a/Development/nmos-cpp-node/main.cpp
+++ b/Development/nmos-cpp-node/main.cpp
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
         // stored in a map and a call to "get_defaults_for_autos" retrieves those saved values
         // A real app may get these values in a different way that allows resources to change
         // This function can be called before or after the connection_resource is added to the model
-        [&map_resource_id_default_autos](nmos::resource& connection_resource, const nmos::resource& node_resource, web::json::value& endpoint_active, const nmos::experimental::app_hooks& app_hooks) -> void
+        [&map_resource_id_default_autos](nmos::resource& connection_resource, const nmos::resource& node_resource, web::json::value& endpoint_active) -> void
         {
             auto type = connection_resource.type;
 
@@ -349,7 +349,7 @@ void node_initial_resources(nmos::node_model& model, slog::base_gate& gate,
         set_defaults_for_autos (sender_id, sender_auto_defaults);
 
         auto connection_sender = nmos::make_connection_sender(sender_id, true);
-        app_hooks.resolve_auto(connection_sender, sender, connection_sender.data[nmos::fields::endpoint_active], app_hooks);
+        app_hooks.resolve_auto(connection_sender, sender, connection_sender.data[nmos::fields::endpoint_active]);
         node_set_connection_sender_transportfile(connection_sender, sdp_params);
 
         set_base_sdp_params (connection_sender, sdp_params);
@@ -379,7 +379,7 @@ void node_initial_resources(nmos::node_model& model, slog::base_gate& gate,
         set_defaults_for_autos (receiver_id, receiver_auto_defaults);
         
         auto connection_receiver = nmos::make_connection_receiver(receiver_id, true);
-        app_hooks.resolve_auto(connection_receiver, receiver, connection_receiver.data[nmos::fields::endpoint_active], app_hooks);
+        app_hooks.resolve_auto(connection_receiver, receiver, connection_receiver.data[nmos::fields::endpoint_active]);
 
         insert_resource_after(delay_millis, model.node_resources, std::move(receiver), gate);
         insert_resource_after(delay_millis, model.connection_resources, std::move(connection_receiver), gate);
@@ -416,7 +416,7 @@ void node_initial_resources(nmos::node_model& model, slog::base_gate& gate,
         set_defaults_for_autos (audio_sender_id, sender_auto_defaults);
 
         auto connection_sender = nmos::make_connection_sender(audio_sender_id, false);
-        app_hooks.resolve_auto(connection_sender, sender, connection_sender.data[nmos::fields::endpoint_active], app_hooks);
+        app_hooks.resolve_auto(connection_sender, sender, connection_sender.data[nmos::fields::endpoint_active]);
         node_set_connection_sender_transportfile(connection_sender, sdp_params);
 
         set_base_sdp_params (connection_sender, sdp_params);
@@ -443,7 +443,7 @@ void node_initial_resources(nmos::node_model& model, slog::base_gate& gate,
         set_defaults_for_autos (audio_receiver_id, receiver_auto_defaults);
         
         auto connection_receiver = nmos::make_connection_receiver(audio_receiver_id, false);
-        app_hooks.resolve_auto(connection_receiver, receiver, connection_receiver.data[nmos::fields::endpoint_active], app_hooks);
+        app_hooks.resolve_auto(connection_receiver, receiver, connection_receiver.data[nmos::fields::endpoint_active]);
 
         insert_resource_after(delay_millis, model.node_resources, std::move(receiver), gate);
         insert_resource_after(delay_millis, model.connection_resources, std::move(connection_receiver), gate);
@@ -482,7 +482,7 @@ void node_initial_resources(nmos::node_model& model, slog::base_gate& gate,
         
         auto connection_temperature_ws_sender = nmos::make_connection_events_websocket_sender(temperature_ws_sender_id, device_id, temperature_source_id, model.settings);
         // there may currently be no "auto" values to resolve for the WebSocket sender, but even so
-        app_hooks.resolve_auto(connection_temperature_ws_sender, temperature_ws_sender, connection_temperature_ws_sender.data[nmos::fields::endpoint_active], app_hooks);
+        app_hooks.resolve_auto(connection_temperature_ws_sender, temperature_ws_sender, connection_temperature_ws_sender.data[nmos::fields::endpoint_active]);
 
         insert_resource_after(delay_millis, model.node_resources, std::move(temperature_source), gate);
         insert_resource_after(delay_millis, model.node_resources, std::move(temperature_flow), gate);

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -17,187 +17,19 @@
 #include "nmos/transport.h"
 #include "sdp/sdp.h"
 
-// as part of activation, the sender /transportfile should be updated based on the active transport parameters
-void set_connection_sender_transportfile(nmos::resource& connection_sender, const nmos::sdp_parameters& sdp_params);
 
 // This is an example of how to integrate the nmos-cpp library with a device-specific underlying implementation.
 // It constructs and inserts a node resource and some sub-resources into the model, based on the model settings,
 // and then waits for sender/receiver activations or shutdown.
-void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate)
+void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate, const nmos::experimental::app_hooks& app_hooks)
 {
     using web::json::value;
     using web::json::value_of;
-
-    const auto seed_id = nmos::with_read_lock(model.mutex, [&] { return nmos::experimental::fields::seed_id(model.settings); });
-    auto node_id = nmos::make_repeatable_id(seed_id, U("/x-nmos/node/self"));
-    auto device_id = nmos::make_repeatable_id(seed_id, U("/x-nmos/node/device/0"));
-    auto source_id = nmos::make_repeatable_id(seed_id, U("/x-nmos/node/source/0"));
-    auto flow_id = nmos::make_repeatable_id(seed_id, U("/x-nmos/node/flow/0"));
-    auto sender_id = nmos::make_repeatable_id(seed_id, U("/x-nmos/node/sender/0"));
-    auto receiver_id = nmos::make_repeatable_id(seed_id, U("/x-nmos/node/receiver/0"));
-    auto temperature_source_id = nmos::make_repeatable_id(seed_id, U("/x-nmos/node/source/1"));
-    auto temperature_flow_id = nmos::make_repeatable_id(seed_id, U("/x-nmos/node/flow/1"));
-    auto temperature_ws_sender_id = nmos::make_repeatable_id(seed_id, U("/x-nmos/node/sender/1"));
+    
+    // Initialize the app and create initial resources
+    app_hooks.initialize(model, gate);
 
     auto lock = model.write_lock(); // in order to update the resources
-
-    // any delay between updates to the model resources is unnecessary
-    // this just serves as a slightly more realistic example!
-    const unsigned int delay_millis{ 10 };
-
-    const auto insert_resource_after = [&model, &lock](unsigned int milliseconds, nmos::resources& resources, nmos::resource&& resource, slog::base_gate& gate)
-    {
-        if (!nmos::details::wait_for(model.shutdown_condition, lock, std::chrono::milliseconds(milliseconds), [&] { return model.shutdown; }))
-        {
-            const std::pair<nmos::id, nmos::type> id_type{ resource.id, resource.type };
-            const bool success = insert_resource(resources, std::move(resource)).second;
-
-            if (success)
-                slog::log<slog::severities::info>(gate, SLOG_FLF) << "Updated model with " << id_type;
-            else
-                slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Model update error: " << id_type;
-
-            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Notifying node behaviour thread"; // and anyone else who cares...
-            model.notify();
-        }
-    };
-
-    // although which properties may need to be defaulted depends on the resource type,
-    // the default value will almost always be different for each resource
-    const auto resolve_auto = [&](const std::pair<nmos::id, nmos::type>& id_type, value& endpoint_active)
-    {
-        auto& transport_params = endpoint_active[nmos::fields::transport_params];
-
-        // "In some cases the behaviour is more complex, and may be determined by the vendor."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
-        if (sender_id == id_type.first)
-        {
-            nmos::details::resolve_auto(transport_params[0], nmos::fields::source_ip, [] { return value::string(U("192.168.255.0")); });
-            nmos::details::resolve_auto(transport_params[1], nmos::fields::source_ip, [] { return value::string(U("192.168.255.1")); });
-            nmos::details::resolve_auto(transport_params[0], nmos::fields::destination_ip, [] { return value::string(U("239.255.255.0")); });
-            nmos::details::resolve_auto(transport_params[1], nmos::fields::destination_ip, [] { return value::string(U("239.255.255.1")); });
-        }
-        else if (receiver_id == id_type.first)
-        {
-            nmos::details::resolve_auto(transport_params[0], nmos::fields::interface_ip, [] { return value::string(U("192.168.255.2")); });
-            nmos::details::resolve_auto(transport_params[1], nmos::fields::interface_ip, [] { return value::string(U("192.168.255.3")); });
-        }
-        else if (temperature_ws_sender_id == id_type.first)
-        {
-            nmos::details::resolve_auto(transport_params[0], nmos::fields::connection_uri, [&] { return value::string(nmos::make_events_ws_api_connection_uri(device_id, model.settings).to_string()); });
-        }
-
-        nmos::resolve_auto(id_type.second, transport_params);
-    };
-
-    // example node
-    {
-        auto node = nmos::make_node(node_id, model.settings);
-        // add one example network interface
-        node.data[U("interfaces")] = value_of({ value_of({ { U("chassis_id"), value::null() }, { U("port_id"), U("ff-ff-ff-ff-ff-ff") }, { U("name"), U("example") } }) });
-        insert_resource_after(delay_millis, model.node_resources, std::move(node), gate);
-    }
-
-    // example device
-    {
-        const auto senders = 0 <= nmos::fields::events_port(model.settings)
-            ? std::vector<nmos::id>{ sender_id, temperature_ws_sender_id }
-            : std::vector<nmos::id>{ sender_id };
-        const auto receivers = std::vector<nmos::id>{ receiver_id };
-        insert_resource_after(delay_millis, model.node_resources, nmos::make_device(device_id, node_id, senders, receivers, model.settings), gate);
-    }
-
-    // example source, flow and sender
-    nmos::sdp_parameters sdp_params;
-    {
-        auto source = nmos::make_video_source(source_id, device_id, { 25, 1 }, model.settings);
-
-        auto flow = nmos::make_raw_video_flow(flow_id, source_id, device_id, model.settings);
-        // add example network interface binding for both primary and secondary
-
-        auto sender = nmos::make_sender(sender_id, flow_id, device_id, { U("example"), U("example") }, model.settings);
-        // add example "natural grouping" hint
-        web::json::push_back(sender.data[U("tags")][nmos::fields::group_hint], nmos::make_group_hint({ U("example"), U("sender 0") }));
-
-        sdp_params = nmos::make_sdp_parameters(source.data, flow.data, sender.data, { U("PRIMARY"), U("SECONDARY") });
-
-        auto connection_sender = nmos::make_connection_sender(sender_id, true);
-        resolve_auto({ connection_sender.id, connection_sender.type }, connection_sender.data[nmos::fields::endpoint_active]);
-        set_connection_sender_transportfile(connection_sender, sdp_params);
-
-        insert_resource_after(delay_millis, model.node_resources, std::move(source), gate);
-        insert_resource_after(delay_millis, model.node_resources, std::move(flow), gate);
-        insert_resource_after(delay_millis, model.node_resources, std::move(sender), gate);
-        insert_resource_after(delay_millis, model.connection_resources, std::move(connection_sender), gate);
-    }
-
-    // example receiver
-    {
-        // add example network interface binding for both primary and secondary
-        auto receiver = nmos::make_video_receiver(receiver_id, device_id, nmos::transports::rtp_mcast, { U("example"), U("example") }, model.settings);
-        // add example "natural grouping" hint
-        web::json::push_back(receiver.data[U("tags")][nmos::fields::group_hint], nmos::make_group_hint({ U("example"), U("receiver 0") }));
-
-        auto connection_receiver = nmos::make_connection_receiver(receiver_id, true);
-        resolve_auto({ connection_receiver.id, connection_receiver.type }, connection_receiver.data[nmos::fields::endpoint_active]);
-
-        insert_resource_after(delay_millis, model.node_resources, std::move(receiver), gate);
-        insert_resource_after(delay_millis, model.connection_resources, std::move(connection_receiver), gate);
-    }
-
-    // example temperature source, sender, flow
-    if (0 <= nmos::fields::events_port(model.settings))
-    {
-        auto temperature_source = nmos::make_data_source(temperature_source_id, device_id, { 1, 1 }, model.settings);
-        // hmm, IS-07 suggests an additional "event_type" attribute in the IS-04 source,
-        // but that's not yet even incorporated in IS-04 v1.3-dev
-        // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/4.0.%20Core%20models.md#2-is-04-highlights
-        // and https://github.com/AMWA-TV/nmos-discovery-registration/issues/88
-
-        // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/3.0.%20Event%20types.md#231-measurements
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/examples/eventsapi-v1.0-type-number-measurement-get-200.json
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/examples/eventsapi-v1.0-state-number-rational-get-200.json
-        auto events_temperature_type = nmos::make_events_number_type({ -200, 10 }, { 1000, 10 }, { 1, 10 }, U("C"));
-        auto events_temperature_state = nmos::make_events_number_state(temperature_source_id, { 201, 10 });
-        auto events_temperature_source = nmos::make_events_source(temperature_source_id, events_temperature_state, events_temperature_type);
-
-        auto temperature_flow = nmos::make_data_flow(temperature_flow_id, temperature_source_id, device_id, nmos::media_types::application_json, model.settings);
-        // hmm, empty string isn't a valid uri
-        // see https://github.com/AMWA-TV/nmos-event-tally/issues/38
-        auto manifest_href = U("");
-        auto temperature_ws_sender = nmos::make_sender(temperature_ws_sender_id, temperature_flow_id, nmos::transports::websocket, device_id, manifest_href, { U("example") }, model.settings);
-        auto connection_temperature_ws_sender = nmos::make_connection_events_websocket_sender(temperature_ws_sender_id, device_id, temperature_source_id, model.settings);
-        // there may currently be no "auto" values to resolve for the WebSocket sender, but even so
-        resolve_auto({ connection_temperature_ws_sender.id, connection_temperature_ws_sender.type }, connection_temperature_ws_sender.data[nmos::fields::endpoint_active]);
-
-        insert_resource_after(delay_millis, model.node_resources, std::move(temperature_source), gate);
-        insert_resource_after(delay_millis, model.node_resources, std::move(temperature_flow), gate);
-        insert_resource_after(delay_millis, model.node_resources, std::move(temperature_ws_sender), gate);
-        insert_resource_after(delay_millis, model.connection_resources, std::move(connection_temperature_ws_sender), gate);
-        insert_resource_after(delay_millis, model.events_resources, std::move(events_temperature_source), gate);
-    }
-
-    auto cancellation_source = pplx::cancellation_token_source();
-    auto token = cancellation_source.get_token();
-    auto temperature_events = pplx::do_while([&]
-    {
-        return pplx::complete_after(std::chrono::seconds(1), token).then([&]
-        {
-            auto lock = model.write_lock();
-
-            modify_resource(model.events_resources, temperature_source_id, [&](nmos::resource& resource)
-            {
-                // make example temperature data ... \/\/\/\/ ... around 200
-                auto value = 175.0 + std::abs(nmos::tai_now().seconds % 100 - 50);
-                // i.e. 17.5-22.5 C
-                nmos::fields::endpoint_state(resource.data) = nmos::make_events_number_state(temperature_source_id, { value, 10 });
-            });
-
-            model.notify();
-
-            return true;
-        });
-    }, token);
 
     auto most_recent_update = nmos::tai_min();
     auto earliest_scheduled_activation = (nmos::tai_clock::time_point::max)();
@@ -207,9 +39,21 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate)
         // wait for the thread to be interrupted because there may be new scheduled activations, or immediate activations to process
         // or because the server is being shut down
         // or because it's time for the next scheduled activation
-        model.wait_until(lock, earliest_scheduled_activation, [&] { return model.shutdown || most_recent_update < nmos::most_recent_update(model.connection_resources); });
+        // or because the application has work to do (presumably nmos related)
+        model.wait_until(lock, earliest_scheduled_activation, [&] { 
+            return model.shutdown || 
+                most_recent_update < nmos::most_recent_update(model.connection_resources) ||
+                app_hooks.check_for_work(); 
+        });
         if (model.shutdown) break;
 
+        bool notify = false;
+        
+        // Have the application process any work that it has (might not have any work)
+        // set the notify flag if the app says it is needed
+        if (app_hooks.process_work())
+            notify = true;
+                                   
         auto& by_updated = model.connection_resources.get<nmos::tags::updated>();
 
         // go through all connection resources
@@ -220,8 +64,6 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate)
         const auto now = nmos::tai_clock::now();
 
         earliest_scheduled_activation = (nmos::tai_clock::time_point::max)();
-
-        bool notify = false;
 
         // since modify reorders the resource in this index, use for_each_reversed
         detail::for_each_reversed(by_updated.begin(), by_updated.end(), [&](const nmos::resource& resource)
@@ -280,12 +122,16 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate)
 
             // Update the IS-05 connection resource
 
-            nmos::modify_resource(model.connection_resources, resource.id, [&resolve_auto, &sdp_params, &activation_time, &active, &connected_id](nmos::resource& connection_resource)
+            nmos::modify_resource(model.connection_resources, resource.id, [&](nmos::resource& connection_resource)
             {
                 const std::pair<nmos::id, nmos::type> id_type{ connection_resource.id, connection_resource.type };
                 nmos::set_connection_resource_active(connection_resource, [&](web::json::value& endpoint_active)
                 {
-                    resolve_auto(id_type, endpoint_active);
+                    auto found = model.node_resources.find (connection_resource.id);
+                    nmos::resource node_resource;
+                    if (found != model.node_resources.end())
+                        node_resource = (*found);
+                    app_hooks.resolve_auto(connection_resource, node_resource, endpoint_active, app_hooks);
                     active = nmos::fields::master_enable(endpoint_active);
                     // Senders indicate the connected receiver_id, receivers indicate the connected sender_id
                     auto& connected_id_or_null = nmos::types::sender == id_type.second ? nmos::fields::receiver_id(endpoint_active) : nmos::fields::sender_id(endpoint_active);
@@ -298,7 +144,7 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate)
                 // see https://github.com/AMWA-TV/nmos-event-tally/issues/36
                 if (nmos::types::sender == id_type.second && nmos::fields::endpoint_constraints(connection_resource.data).has_field(nmos::fields::rtp_enabled))
                 {
-                    set_connection_sender_transportfile(connection_resource, sdp_params);
+                    node_set_connection_sender_transportfile(connection_resource, app_hooks.get_base_sdp_params(resource));
                 }
             });
 
@@ -310,6 +156,9 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate)
             });
 
             notify = true;
+            
+            // Tell the application that the resource has been updated
+            app_hooks.resource_activation(resource);            
         });
 
         if ((nmos::tai_clock::time_point::max)() != earliest_scheduled_activation)
@@ -327,14 +176,10 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate)
         most_recent_update = nmos::most_recent_update(model.connection_resources);
     }
 
-    cancellation_source.cancel();
-    // wait without the lock since it is also used by the background tasks
-    nmos::details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
-    temperature_events.wait();
 }
 
 // as part of activation, the sender /transportfile should be updated based on the active transport parameters
-void set_connection_sender_transportfile(nmos::resource& connection_sender, const nmos::sdp_parameters& sdp_params)
+void node_set_connection_sender_transportfile(nmos::resource& connection_sender, const nmos::sdp_parameters& sdp_params)
 {
     auto& transport_params = connection_sender.data[nmos::fields::endpoint_active][nmos::fields::transport_params];
     auto session_description = nmos::make_session_description(sdp_params, transport_params);

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -131,7 +131,7 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate, 
                     nmos::resource node_resource;
                     if (found != model.node_resources.end())
                         node_resource = (*found);
-                    app_hooks.resolve_auto(connection_resource, node_resource, endpoint_active, app_hooks);
+                    app_hooks.resolve_auto(connection_resource, node_resource, endpoint_active);
                     active = nmos::fields::master_enable(endpoint_active);
                     // Senders indicate the connected receiver_id, receivers indicate the connected sender_id
                     auto& connected_id_or_null = nmos::types::sender == id_type.second ? nmos::fields::receiver_id(endpoint_active) : nmos::fields::sender_id(endpoint_active);

--- a/Development/nmos-cpp-node/node_implementation.h
+++ b/Development/nmos-cpp-node/node_implementation.h
@@ -1,6 +1,10 @@
 #ifndef NMOS_CPP_NODE_NODE_IMPLEMENTATION_H
 #define NMOS_CPP_NODE_NODE_IMPLEMENTATION_H
 
+#include "nmos/id.h"
+#include "nmos/resource.h"
+#include "nmos/sdp_utils.h"
+
 namespace slog
 {
     class base_gate;
@@ -9,11 +13,59 @@ namespace slog
 namespace nmos
 {
     struct node_model;
+    
+    namespace experimental
+    {
+        // a set of call-back functions into the application. 
+        struct app_hooks
+        {
+            // Function to initialize the application providing the model and gate.
+            // typically only called once
+            // Initial resources can be created here
+            std::function<void(node_model& model, slog::base_gate& gate)> initialize;
+
+            // Function to check if the application has "work" to do
+            // Work can be the creation, deletion, or modification of various resources
+            // Returns true to indicate that there is work to be done.
+            std::function<bool()> check_for_work;
+
+            // Function to perform the work that the application has queued up
+            // Work can be the creation, deletion, or modification of various resources
+            // The app only changes resources within the context of these callbacks
+            // Returns true if model.notify() should be called
+            std::function<bool()> process_work;
+
+            // Function to tell the app about a resource activation
+            // The app may need to do its own processing with respect to making and breaking connections
+            // or changing resources
+            // Returns true if model.notify() should be called
+            std::function<bool(const resource& resource)> resource_activation;
+
+            // Function to retrieve the base_sdp_params for a particular sender
+            // Called when senders are being activated
+            // The app can either retrieve the params saved statically at init time or get
+            // the params more dynamically if the params could actually change in the app
+            std::function<sdp_parameters(const nmos::resource& resource)> get_base_sdp_params;
+
+            // Function to resolve the use of "auto" in various transport params to real values in
+            // both senders and receivers.
+            // The function could call get_defaults_for_autos which can either retrieve static or dynamic values
+            std::function<void(resource& connection_resource, const resource& node_resource, web::json::value& endpoint_active, const app_hooks& app_hooks)>  resolve_auto;
+        };
+    }
 }
+
+// This function exists so that the main() does not have to be included and collide with the apps main()
+int node_main_thread(int argc, char* argv[], const nmos::experimental::app_hooks& app_hooks);
 
 // This is an example of how to integrate the nmos-cpp library with a device-specific underlying implementation.
 // It constructs and inserts a node resource and some sub-resources into the model, based on the model settings,
 // and then waits for sender/receiver activations or shutdown.
-void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate);
+void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate, const nmos::experimental::app_hooks& app_hooks);
+
+// as part of activation, the sender /transportfile should be updated based on the active transport parameters
+void node_set_connection_sender_transportfile(nmos::resource& connection_sender, const nmos::sdp_parameters& sdp_params);
+
+
 
 #endif

--- a/Development/nmos-cpp-node/node_implementation.h
+++ b/Development/nmos-cpp-node/node_implementation.h
@@ -50,7 +50,7 @@ namespace nmos
             // Function to resolve the use of "auto" in various transport params to real values in
             // both senders and receivers.
             // The function could call get_defaults_for_autos which can either retrieve static or dynamic values
-            std::function<void(resource& connection_resource, const resource& node_resource, web::json::value& endpoint_active, const app_hooks& app_hooks)>  resolve_auto;
+            std::function<void(resource& connection_resource, const resource& node_resource, web::json::value& endpoint_active)>  resolve_auto;
         };
     }
 }

--- a/Development/nmos-cpp-node/node_main_thread.cpp
+++ b/Development/nmos-cpp-node/node_main_thread.cpp
@@ -1,0 +1,223 @@
+#include <fstream>
+#include <iostream>
+#include "cpprest/ws_listener.h"
+#include "cpprest/ws_utils.h"
+#include "nmos/admin_ui.h"
+#include "nmos/api_utils.h"
+#include "nmos/connection_api.h"
+#include "nmos/events_api.h"
+#include "nmos/events_ws_api.h"
+#include "nmos/log_gate.h"
+#include "nmos/logging_api.h"
+#include "nmos/model.h"
+#include "nmos/node_api.h"
+#include "nmos/node_behaviour.h"
+#include "nmos/node_resources.h"
+#include "nmos/process_utils.h"
+#include "nmos/server_utils.h"
+#include "nmos/settings_api.h"
+#include "nmos/slog.h"
+#include "nmos/thread_utils.h"
+#include "node_implementation.h"
+
+int node_main_thread(int argc, char* argv[], const nmos::experimental::app_hooks& app_hooks)
+
+{
+    // Construct our data models including mutexes to protect them
+
+    nmos::node_model node_model;
+
+    nmos::experimental::log_model log_model;
+
+    // Streams for logging, initially configured to write errors to stderr and to discard the access log
+    std::filebuf error_log_buf;
+    std::ostream error_log(std::cerr.rdbuf());
+    std::filebuf access_log_buf;
+    std::ostream access_log(&access_log_buf);
+
+    // Logging should all go through this logging gateway
+    nmos::experimental::log_gate gate(error_log, access_log, log_model);
+
+    try
+    {
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Starting nmos-cpp node";
+
+        // Settings can be passed on the command-line, directly or in a configuration file, and a few may be changed dynamically by PATCH to /settings/all on the Settings API
+        //
+        // * "logging_level": integer value, between 40 (least verbose, only fatal messages) and -40 (most verbose)
+        // * "registry_address": used to construct request URLs for registry APIs (if not discovered via DNS-SD)
+        //
+        // E.g.
+        //
+        // # ./nmos-cpp-node "{\"logging_level\":-40}"
+        // # ./nmos-cpp-node config.json
+        // # curl -X PATCH -H "Content-Type: application/json" http://localhost:3209/settings/all -d "{\"logging_level\":-40}"
+        // # curl -X PATCH -H "Content-Type: application/json" http://localhost:3209/settings/all -T config.json
+
+        if (argc > 1)
+        {
+            std::error_code error;
+            node_model.settings = web::json::value::parse(utility::s2us(argv[1]), error);
+            if (error)
+            {
+                std::ifstream file(argv[1]);
+                node_model.settings = web::json::value::parse(file, error);
+            }
+            if (error || !node_model.settings.is_object())
+            {
+                slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Bad command-line settings [" << error << "]";
+                return -1;
+            }
+        }
+
+        // Prepare run-time default settings (different than header defaults)
+
+        nmos::insert_node_default_settings(node_model.settings);
+
+        // copy to the logging settings
+        // hmm, this is a bit icky, but simplest for now
+        log_model.settings = node_model.settings;
+
+        // the logging level is a special case because we want to turn it into an atomic value
+        // that can be read by logging statements without locking the mutex protecting the settings
+        log_model.level = nmos::fields::logging_level(log_model.settings);
+
+        // Reconfigure the logging streams according to settings
+        // (obviously, until this point, the logging gateway has its default behaviour...)
+
+        if (!nmos::fields::error_log(node_model.settings).empty())
+        {
+            error_log_buf.open(nmos::fields::error_log(node_model.settings), std::ios_base::out | std::ios_base::app);
+            auto lock = log_model.write_lock();
+            error_log.rdbuf(&error_log_buf);
+        }
+
+        if (!nmos::fields::access_log(node_model.settings).empty())
+        {
+            access_log_buf.open(nmos::fields::access_log(node_model.settings), std::ios_base::out | std::ios_base::app);
+            auto lock = log_model.write_lock();
+            access_log.rdbuf(&access_log_buf);
+        }
+
+        // Log the process ID and the API addresses we'll be using
+
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Process ID: " << nmos::details::get_process_id();
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Initial settings: " << node_model.settings.serialize();
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Configuring nmos-cpp node with its primary Node API at: " << nmos::get_host(node_model.settings) << ":" << nmos::fields::node_port(node_model.settings);
+
+        // Set up the APIs, assigning them to the configured ports
+
+        const auto server_secure = nmos::experimental::fields::server_secure(node_model.settings);
+
+        typedef std::pair<utility::string_t, int> address_port;
+        std::map<address_port, web::http::experimental::listener::api_router> port_routers;
+
+        // Configure the Settings API
+
+        const address_port settings_address(nmos::experimental::fields::settings_address(node_model.settings), nmos::experimental::fields::settings_port(node_model.settings));
+        port_routers[settings_address].mount({}, nmos::experimental::make_settings_api(node_model, log_model, gate));
+
+        // Configure the Logging API
+
+        const address_port logging_address(nmos::experimental::fields::logging_address(node_model.settings), nmos::experimental::fields::logging_port(node_model.settings));
+        port_routers[logging_address].mount({}, nmos::experimental::make_logging_api(log_model, gate));
+
+        // Configure the Node API
+
+        nmos::node_api_target_handler target_handler = nmos::make_node_api_target_handler(node_model);
+        port_routers[{ {}, nmos::fields::node_port(node_model.settings) }].mount({}, nmos::make_node_api(node_model, target_handler, gate));
+
+        // start the underlying implementation and set up the node resources
+        auto node_resources = nmos::details::make_thread_guard([&] { node_implementation_thread(node_model, gate, app_hooks); }, [&] { node_model.controlled_shutdown(); });
+
+        // Configure the Connection API
+
+        port_routers[{ {}, nmos::fields::connection_port(node_model.settings) }].mount({}, nmos::make_connection_api(node_model, gate));
+
+        // Configure the Events API
+        port_routers[{ {}, nmos::fields::events_port(node_model.settings) }].mount({}, nmos::make_events_api(node_model, gate));
+
+        nmos::websockets node_websockets;
+
+        auto websocket_config = nmos::make_websocket_listener_config(node_model.settings);
+        websocket_config.set_log_callback(nmos::make_slog_logging_callback(gate));
+        web::websockets::experimental::listener::validate_handler events_ws_validate_handler = nmos::make_events_ws_validate_handler(node_model, gate);
+        web::websockets::experimental::listener::open_handler events_ws_open_handler = nmos::make_events_ws_open_handler(node_model, node_websockets, gate);
+        web::websockets::experimental::listener::close_handler events_ws_close_handler = nmos::make_events_ws_close_handler(node_model, node_websockets, gate);
+        web::websockets::experimental::listener::message_handler events_ws_message_handler = nmos::make_events_ws_message_handler(node_model, node_websockets, gate);
+        auto events_ws_uri = web::websockets::experimental::listener::make_listener_uri(server_secure, web::websockets::experimental::listener::host_wildcard, nmos::experimental::server_port(nmos::fields::events_ws_port(node_model.settings), node_model.settings));
+        web::websockets::experimental::listener::websocket_listener events_ws_listener(events_ws_uri, websocket_config);
+        events_ws_listener.set_validate_handler(std::ref(events_ws_validate_handler));
+        events_ws_listener.set_open_handler(std::ref(events_ws_open_handler));
+        events_ws_listener.set_close_handler(std::ref(events_ws_close_handler));
+        events_ws_listener.set_message_handler(std::ref(events_ws_message_handler));
+
+        // Set up the listeners for each API port
+
+       auto http_config = nmos::make_http_listener_config(node_model.settings);
+
+        std::vector<web::http::experimental::listener::http_listener> port_listeners;
+        for (auto& port_router : port_routers)
+        {
+            // default empty string means the wildcard address
+            const auto& router_address = !port_router.first.first.empty() ? port_router.first.first : web::http::experimental::listener::host_wildcard;
+            // map the configured client port to the server port on which to listen
+            // hmm, this should probably also take account of the address
+            port_listeners.push_back(nmos::make_api_listener(server_secure, router_address, nmos::experimental::server_port(port_router.first.second, node_model.settings), port_router.second, http_config, gate));
+        }
+
+        // Open the API ports
+
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing for connections";
+
+        std::vector<web::http::experimental::listener::http_listener_guard> port_guards;
+        for (auto& port_listener : port_listeners)
+        {
+            if (0 <= port_listener.uri().port()) port_guards.push_back({ port_listener });
+        }
+        web::websockets::experimental::listener::websocket_listener_guard events_ws_guard;
+        if (0 <= events_ws_listener.uri().port()) events_ws_guard = { events_ws_listener };
+
+        // Start up node operation (including the mDNS advertisements) once all NMOS APIs are open
+
+        auto node_behaviour = nmos::details::make_thread_guard([&] { nmos::node_behaviour_thread(node_model, gate); }, [&] { node_model.controlled_shutdown(); });
+        auto send_events_ws_messages = nmos::details::make_thread_guard([&] { nmos::send_events_ws_messages_thread(events_ws_listener, node_model, node_websockets, gate); }, [&] { node_model.controlled_shutdown(); });
+        auto erase_expired_resources = nmos::details::make_thread_guard([&] { nmos::erase_expired_events_resources_thread(node_model, gate); }, [&] { node_model.controlled_shutdown(); });
+
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Ready for connections";
+
+        // Wait for a process termination signal
+        nmos::details::wait_term_signal();
+
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Closing connections";
+    }
+    catch (const web::json::json_exception& e)
+    {
+        // most likely from incorrect types in the command line settings
+        slog::log<slog::severities::error>(gate, SLOG_FLF) << "JSON error: " << e.what();
+    }
+    catch (const web::http::http_exception& e)
+    {
+        slog::log<slog::severities::error>(gate, SLOG_FLF) << "HTTP error: " << e.what() << " [" << e.error_code() << "]";
+    }
+    catch (const std::system_error& e)
+    {
+        slog::log<slog::severities::error>(gate, SLOG_FLF) << "System error: " << e.what() << " [" << e.code() << "]";
+    }
+    catch (const std::runtime_error& e)
+    {
+        slog::log<slog::severities::error>(gate, SLOG_FLF) << "Implementation error: " << e.what();
+    }
+    catch (const std::exception& e)
+    {
+        slog::log<slog::severities::error>(gate, SLOG_FLF) << "Unexpected exception: " << e.what();
+    }
+    catch (...)
+    {
+        slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Unexpected unknown exception";
+    }
+
+    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Stopping nmos-cpp node";
+
+    return 0;
+}


### PR DESCRIPTION
This is similar to the App hooks 3 except based on current code. The change is mostly rearranging some files. 

- App startup in main.cpp has mostly moved intact to the new file node_main_thread.cpp.
- The code in main.cpp represents the code specific to the sample application. 
  - It provides some sample application hook functions and then starts up the main thread.
  - The sample resources are created and managed within main.cpp
- The code in node_implementation.cpp is mostly intact except for these two types of changes
  - The code to create and manage the sample resources has moved to main.cpp
  - Calls to the application hooks are placed at strategic locations.

- The code to periodically update the sample events is in main.cpp. The code which used to directly update the events now indicates that there is work to do and then does the work when the application hook is called.

I ran the tests and get the same results as the master code. Lots of assertions but the tests pass.

I have noticed that when the application (both the master and the changed code in this pull request) is terminated (press the exit button in upper right of the console window on windows) that the application will frequently take an exception. Assume there is a thread someplace referring to an object which has been deleted but not sure.

