### PR TITLE
Fixing compilation problems when the flag -Wswitch-default on dependent proj

### DIFF
--- a/Development/cpprest/json_ops.h
+++ b/Development/cpprest/json_ops.h
@@ -122,6 +122,7 @@ namespace web
                 case web::json::value::Object: return lhs.as_object() < rhs.as_object();
                 case web::json::value::Array: return lhs.as_array() < rhs.as_array();
                 case web::json::value::Null: return false;
+                default: return false;
                 }
             }
             return false;


### PR DESCRIPTION
it is a very minor problem that I have fixed on my side by removing the flag, but I dont think it would be a problem to have this extra default line on this switch case. main reason for it is that the switch case code is on the header file.