### PR TITLE
Move IS-05 Connection API activation thread from example 'node_implementation' into nmos module

### DIFF
--- a/Development/cmake/NmosCppLibraries.cmake
+++ b/Development/cmake/NmosCppLibraries.cmake
@@ -567,6 +567,7 @@ set(NMOS_CPP_NMOS_SOURCES
     ${NMOS_CPP_DIR}/nmos/api_utils.cpp
     ${NMOS_CPP_DIR}/nmos/client_utils.cpp
     ${NMOS_CPP_DIR}/nmos/components.cpp
+    ${NMOS_CPP_DIR}/nmos/connection_activation.cpp
     ${NMOS_CPP_DIR}/nmos/connection_api.cpp
     ${NMOS_CPP_DIR}/nmos/connection_resources.cpp
     ${NMOS_CPP_DIR}/nmos/events_api.cpp
@@ -611,6 +612,7 @@ set(NMOS_CPP_NMOS_HEADERS
     ${NMOS_CPP_DIR}/nmos/colorspace.h
     ${NMOS_CPP_DIR}/nmos/components.h
     ${NMOS_CPP_DIR}/nmos/copyable_atomic.h
+    ${NMOS_CPP_DIR}/nmos/connection_activation.h
     ${NMOS_CPP_DIR}/nmos/connection_api.h
     ${NMOS_CPP_DIR}/nmos/connection_resources.h
     ${NMOS_CPP_DIR}/nmos/device_type.h

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -1,9 +1,8 @@
 #include "node_implementation.h"
 
 #include "pplx/pplx_utils.h" // for pplx::complete_after, etc.
-#include "detail/for_each_reversed.h"
-#include "nmos/activation_mode.h"
-#include "nmos/connection_api.h"
+#include "nmos/connection_activation.h"
+#include "nmos/connection_api.h" // for nmos::resolve_rtp_auto, etc.
 #include "nmos/connection_resources.h"
 #include "nmos/events_resources.h"
 #include "nmos/group_hint.h"
@@ -13,17 +12,8 @@
 #include "nmos/node_resources.h"
 #include "nmos/sdp_utils.h"
 #include "nmos/slog.h"
-#include "nmos/thread_utils.h"
 #include "nmos/transport.h"
 #include "sdp/sdp.h"
-
-// a connection_resource_auto_resolver overwrites every instance of "auto" in the specified transport_params array for the specified (IS-04/IS-05) sender/connection_sender or receiver/connection_receiver
-typedef std::function<void(const nmos::resource&, const nmos::resource&, web::json::value&)> connection_resource_auto_resolver;
-
-// a connection_sender_transportfile_setter updates the specified /transportfile endpoint for the specified (IS-04/IS-05) sender/connection_sender
-typedef std::function<void(const nmos::resource&, const nmos::resource&, web::json::value&)> connection_sender_transportfile_setter;
-
-void connection_activation_thread(nmos::node_model& model, connection_resource_auto_resolver resolve_auto, connection_sender_transportfile_setter set_transportfile, slog::base_gate& gate);
 
 // This is an example of how to integrate the nmos-cpp library with a device-specific underlying implementation.
 // It constructs and inserts a node resource and some sub-resources into the model, based on the model settings,
@@ -211,7 +201,7 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate)
     {
         nmos::details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
 
-        connection_activation_thread(model, [&resolve_auto](const nmos::resource& resource, const nmos::resource& connection_resource, web::json::value& transport_params)
+        nmos::connection_activation_thread(model, [&resolve_auto](const nmos::resource& resource, const nmos::resource& connection_resource, web::json::value& transport_params)
         {
             resolve_auto({ connection_resource.id, connection_resource.type }, transport_params);
         }, [&set_transportfile](const nmos::resource& sender, const nmos::resource& connection_sender, web::json::value& endpoint_transportfile)
@@ -224,136 +214,4 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate)
     // wait without the lock since it is also used by the background tasks
     nmos::details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
     temperature_events.wait();
-}
-
-void connection_activation_thread(nmos::node_model& model, connection_resource_auto_resolver resolve_auto, connection_sender_transportfile_setter set_transportfile, slog::base_gate& gate)
-{
-    auto lock = model.write_lock(); // in order to update the resources
-
-    auto most_recent_update = nmos::tai_min();
-    auto earliest_scheduled_activation = (nmos::tai_clock::time_point::max)();
-
-    for (;;)
-    {
-        // wait for the thread to be interrupted because there may be new scheduled activations, or immediate activations to process
-        // or because the server is being shut down
-        // or because it's time for the next scheduled activation
-        model.wait_until(lock, earliest_scheduled_activation, [&] { return model.shutdown || most_recent_update < nmos::most_recent_update(model.connection_resources); });
-        if (model.shutdown) break;
-
-        auto& by_updated = model.connection_resources.get<nmos::tags::updated>();
-
-        // go through all connection resources
-        // process any immediate activations
-        // process any scheduled activations whose requested_time has passed
-        // identify the next scheduled activation
-
-        const auto now = nmos::tai_clock::now();
-
-        earliest_scheduled_activation = (nmos::tai_clock::time_point::max)();
-
-        bool notify = false;
-
-        // since modify reorders the resource in this index, use for_each_reversed
-        detail::for_each_reversed(by_updated.begin(), by_updated.end(), [&](const nmos::resource& resource)
-        {
-            if (!resource.has_data()) return;
-
-            const std::pair<nmos::id, nmos::type> id_type{ resource.id, resource.type };
-
-            auto& staged = nmos::fields::endpoint_staged(resource.data);
-            auto& staged_activation = nmos::fields::activation(staged);
-            auto& staged_mode_or_null = nmos::fields::mode(staged_activation);
-
-            if (staged_mode_or_null.is_null()) return;
-
-            const nmos::activation_mode staged_mode{ staged_mode_or_null.as_string() };
-
-            if (nmos::activation_modes::activate_scheduled_absolute == staged_mode ||
-                nmos::activation_modes::activate_scheduled_relative == staged_mode)
-            {
-                auto& staged_activation_time = nmos::fields::activation_time(staged_activation);
-                const auto scheduled_activation = nmos::time_point_from_tai(nmos::parse_version(staged_activation_time.as_string()));
-
-                if (scheduled_activation < now)
-                {
-                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Processing scheduled activation for " << id_type;
-                }
-                else
-                {
-                    if (scheduled_activation < earliest_scheduled_activation)
-                    {
-                        earliest_scheduled_activation = scheduled_activation;
-                    }
-
-                    return;
-                }
-            }
-            else if (nmos::activation_modes::activate_immediate == staged_mode)
-            {
-                // check for cancelled in-flight immediate activation
-                if (nmos::fields::requested_time(staged_activation).is_null()) return;
-                // check for processed in-flight immediate activation
-                if (!nmos::fields::activation_time(staged_activation).is_null()) return;
-
-                slog::log<slog::severities::info>(gate, SLOG_FLF) << "Processing immediate activation for " << id_type;
-            }
-            else
-            {
-                slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Unexpected activation mode for " << id_type;
-                return;
-            }
-
-            const auto activation_time = nmos::tai_now();
-
-            bool active = false;
-            nmos::id connected_id;
-
-            // Update the IS-05 connection resource
-
-            nmos::modify_resource(model.connection_resources, resource.id, [&](nmos::resource& connection_resource)
-            {
-                const std::pair<nmos::id, nmos::type> id_type{ connection_resource.id, connection_resource.type };
-                auto matching_resource = find_resource(model.node_resources, id_type);
-                if (model.node_resources.end() == matching_resource)
-                {
-                    throw std::logic_error("matching IS-04 resource not found");
-                }
-
-                nmos::set_connection_resource_active(connection_resource, [&](web::json::value& endpoint_active)
-                {
-                    resolve_auto(*matching_resource, connection_resource, nmos::fields::transport_params(endpoint_active));
-                    active = nmos::fields::master_enable(endpoint_active);
-                    // Senders indicate the connected receiver_id, receivers indicate the connected sender_id
-                    auto& connected_id_or_null = nmos::types::sender == id_type.second ? nmos::fields::receiver_id(endpoint_active) : nmos::fields::sender_id(endpoint_active);
-                    if (!connected_id_or_null.is_null()) connected_id = connected_id_or_null.as_string();
-                }, activation_time);
-
-                set_transportfile(*matching_resource, connection_resource, connection_resource.data[nmos::fields::endpoint_transportfile]);
-            });
-
-            // Update the IS-04 resource
-
-            nmos::modify_resource(model.node_resources, resource.id, [&activation_time, &active, &connected_id](nmos::resource& resource)
-            {
-                nmos::set_resource_subscription(resource, active, connected_id, activation_time);
-            });
-
-            notify = true;
-        });
-
-        if ((nmos::tai_clock::time_point::max)() != earliest_scheduled_activation)
-        {
-            slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Next scheduled activation is at " << nmos::make_version(nmos::tai_from_time_point(earliest_scheduled_activation))
-                << " in about " << std::fixed << std::setprecision(3) << std::chrono::duration_cast<std::chrono::duration<double>>(earliest_scheduled_activation - now).count() << " seconds time";
-        }
-
-        if (notify)
-        {
-            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Notifying node behaviour thread"; // and anyone else who cares...
-            model.notify();
-        }
-
-        most_recent_update = nmos::most_recent_update(model.connection_resources);
-    }
 }

--- a/Development/nmos-cpp-node/node_implementation.h
+++ b/Development/nmos-cpp-node/node_implementation.h
@@ -1,6 +1,10 @@
 #ifndef NMOS_CPP_NODE_NODE_IMPLEMENTATION_H
 #define NMOS_CPP_NODE_NODE_IMPLEMENTATION_H
 
+#include "nmos/connection_activation.h"
+#include "nmos/resources.h" // just a forward declaration of nmos::resources
+#include "nmos/settings.h" // just a forward declaration of nmos::settings
+
 namespace slog
 {
     class base_gate;
@@ -13,7 +17,13 @@ namespace nmos
 
 // This is an example of how to integrate the nmos-cpp library with a device-specific underlying implementation.
 // It constructs and inserts a node resource and some sub-resources into the model, based on the model settings,
-// and then waits for sender/receiver activations or shutdown.
+// starts background tasks to emit regular events from the temperature event source and then waits for shutdown.
 void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate);
+
+// Example connection activation callback
+nmos::connection_resource_auto_resolver make_node_implementation_auto_resolver(const nmos::settings& settings);
+
+// Example connection activation callback - captures node_resources by reference!
+nmos::connection_sender_transportfile_setter make_node_implementation_transportfile_setter(const nmos::resources& node_resources, const nmos::settings& settings);
 
 #endif

--- a/Development/nmos/connection_activation.cpp
+++ b/Development/nmos/connection_activation.cpp
@@ -100,7 +100,8 @@ namespace nmos
                     auto matching_resource = find_resource(model.node_resources, id_type);
                     if (model.node_resources.end() == matching_resource)
                     {
-                        throw std::logic_error("matching IS-04 resource not found");
+                        slog::log<slog::severities::error>(gate, SLOG_FLF) << "Implementation error for " << id_type << " during activation: " << "matching IS-04 resource not found";
+                        return;
                     }
 
                     nmos::set_connection_resource_active(connection_resource, [&](web::json::value& endpoint_active)

--- a/Development/nmos/connection_activation.cpp
+++ b/Development/nmos/connection_activation.cpp
@@ -113,7 +113,10 @@ namespace nmos
                         if (!connected_id_or_null.is_null()) connected_id = connected_id_or_null.as_string();
                     }, activation_time);
 
-                    set_transportfile(*matching_resource, connection_resource, connection_resource.data[nmos::fields::endpoint_transportfile]);
+                    if (nmos::types::sender == id_type.second)
+                    {
+                        set_transportfile(*matching_resource, connection_resource, connection_resource.data[nmos::fields::endpoint_transportfile]);
+                    }
                 });
 
                 // Update the IS-04 resource

--- a/Development/nmos/connection_activation.cpp
+++ b/Development/nmos/connection_activation.cpp
@@ -1,0 +1,143 @@
+#include "nmos/connection_activation.h"
+
+#include "detail/for_each_reversed.h"
+#include "nmos/activation_mode.h"
+#include "nmos/connection_api.h" // for nmos::set_connection_resource_active, etc.
+#include "nmos/model.h"
+#include "nmos/slog.h"
+#include "nmos/thread_utils.h"
+
+namespace nmos
+{
+    void connection_activation_thread(nmos::node_model& model, connection_resource_auto_resolver resolve_auto, connection_sender_transportfile_setter set_transportfile, slog::base_gate& gate)
+    {
+        auto lock = model.write_lock(); // in order to update the resources
+
+        auto most_recent_update = nmos::tai_min();
+        auto earliest_scheduled_activation = (nmos::tai_clock::time_point::max)();
+
+        for (;;)
+        {
+            // wait for the thread to be interrupted because there may be new scheduled activations, or immediate activations to process
+            // or because the server is being shut down
+            // or because it's time for the next scheduled activation
+            model.wait_until(lock, earliest_scheduled_activation, [&] { return model.shutdown || most_recent_update < nmos::most_recent_update(model.connection_resources); });
+            if (model.shutdown) break;
+
+            auto& by_updated = model.connection_resources.get<nmos::tags::updated>();
+
+            // go through all connection resources
+            // process any immediate activations
+            // process any scheduled activations whose requested_time has passed
+            // identify the next scheduled activation
+
+            const auto now = nmos::tai_clock::now();
+
+            earliest_scheduled_activation = (nmos::tai_clock::time_point::max)();
+
+            bool notify = false;
+
+            // since modify reorders the resource in this index, use for_each_reversed
+            detail::for_each_reversed(by_updated.begin(), by_updated.end(), [&](const nmos::resource& resource)
+            {
+                if (!resource.has_data()) return;
+
+                const std::pair<nmos::id, nmos::type> id_type{ resource.id, resource.type };
+
+                auto& staged = nmos::fields::endpoint_staged(resource.data);
+                auto& staged_activation = nmos::fields::activation(staged);
+                auto& staged_mode_or_null = nmos::fields::mode(staged_activation);
+
+                if (staged_mode_or_null.is_null()) return;
+
+                const nmos::activation_mode staged_mode{ staged_mode_or_null.as_string() };
+
+                if (nmos::activation_modes::activate_scheduled_absolute == staged_mode ||
+                    nmos::activation_modes::activate_scheduled_relative == staged_mode)
+                {
+                    auto& staged_activation_time = nmos::fields::activation_time(staged_activation);
+                    const auto scheduled_activation = nmos::time_point_from_tai(nmos::parse_version(staged_activation_time.as_string()));
+
+                    if (scheduled_activation < now)
+                    {
+                        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Processing scheduled activation for " << id_type;
+                    }
+                    else
+                    {
+                        if (scheduled_activation < earliest_scheduled_activation)
+                        {
+                            earliest_scheduled_activation = scheduled_activation;
+                        }
+
+                        return;
+                    }
+                }
+                else if (nmos::activation_modes::activate_immediate == staged_mode)
+                {
+                    // check for cancelled in-flight immediate activation
+                    if (nmos::fields::requested_time(staged_activation).is_null()) return;
+                    // check for processed in-flight immediate activation
+                    if (!nmos::fields::activation_time(staged_activation).is_null()) return;
+
+                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Processing immediate activation for " << id_type;
+                }
+                else
+                {
+                    slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Unexpected activation mode for " << id_type;
+                    return;
+                }
+
+                const auto activation_time = nmos::tai_now();
+
+                bool active = false;
+                nmos::id connected_id;
+
+                // Update the IS-05 connection resource
+
+                nmos::modify_resource(model.connection_resources, resource.id, [&](nmos::resource& connection_resource)
+                {
+                    const std::pair<nmos::id, nmos::type> id_type{ connection_resource.id, connection_resource.type };
+                    auto matching_resource = find_resource(model.node_resources, id_type);
+                    if (model.node_resources.end() == matching_resource)
+                    {
+                        throw std::logic_error("matching IS-04 resource not found");
+                    }
+
+                    nmos::set_connection_resource_active(connection_resource, [&](web::json::value& endpoint_active)
+                    {
+                        resolve_auto(*matching_resource, connection_resource, nmos::fields::transport_params(endpoint_active));
+                        active = nmos::fields::master_enable(endpoint_active);
+                        // Senders indicate the connected receiver_id, receivers indicate the connected sender_id
+                        auto& connected_id_or_null = nmos::types::sender == id_type.second ? nmos::fields::receiver_id(endpoint_active) : nmos::fields::sender_id(endpoint_active);
+                        if (!connected_id_or_null.is_null()) connected_id = connected_id_or_null.as_string();
+                    }, activation_time);
+
+                    set_transportfile(*matching_resource, connection_resource, connection_resource.data[nmos::fields::endpoint_transportfile]);
+                });
+
+                // Update the IS-04 resource
+
+                nmos::modify_resource(model.node_resources, resource.id, [&activation_time, &active, &connected_id](nmos::resource& resource)
+                {
+                    nmos::set_resource_subscription(resource, active, connected_id, activation_time);
+                });
+
+                notify = true;
+            });
+
+            if ((nmos::tai_clock::time_point::max)() != earliest_scheduled_activation)
+            {
+                slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Next scheduled activation is at " << nmos::make_version(nmos::tai_from_time_point(earliest_scheduled_activation))
+                    << " in about " << std::fixed << std::setprecision(3) << std::chrono::duration_cast<std::chrono::duration<double>>(earliest_scheduled_activation - now).count() << " seconds time";
+            }
+
+            if (notify)
+            {
+                slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Notifying node behaviour thread"; // and anyone else who cares...
+                model.notify();
+            }
+
+            most_recent_update = nmos::most_recent_update(model.connection_resources);
+        }
+    }
+}

--- a/Development/nmos/connection_activation.h
+++ b/Development/nmos/connection_activation.h
@@ -1,0 +1,33 @@
+#ifndef NMOS_CONNECTION_ACTIVATION_H
+#define NMOS_CONNECTION_ACTIVATION_H
+
+#include <functional>
+
+namespace web
+{
+    namespace json
+    {
+        class value;
+    }
+}
+
+namespace slog
+{
+    class base_gate;
+}
+
+namespace nmos
+{
+    struct node_model;
+    struct resource;
+
+    // a connection_resource_auto_resolver overwrites every instance of "auto" in the specified transport_params array for the specified (IS-04/IS-05) sender/connection_sender or receiver/connection_receiver
+    typedef std::function<void(const nmos::resource&, const nmos::resource&, web::json::value&)> connection_resource_auto_resolver;
+
+    // a connection_sender_transportfile_setter updates the specified /transportfile endpoint for the specified (IS-04/IS-05) sender/connection_sender
+    typedef std::function<void(const nmos::resource&, const nmos::resource&, web::json::value&)> connection_sender_transportfile_setter;
+
+    void connection_activation_thread(nmos::node_model& model, connection_resource_auto_resolver resolve_auto, connection_sender_transportfile_setter set_transportfile, slog::base_gate& gate);
+}
+
+#endif

--- a/Development/nmos/connection_activation.h
+++ b/Development/nmos/connection_activation.h
@@ -22,9 +22,11 @@ namespace nmos
     struct resource;
 
     // a connection_resource_auto_resolver overwrites every instance of "auto" in the specified transport_params array for the specified (IS-04/IS-05) sender/connection_sender or receiver/connection_receiver
+    // it may throw e.g. web::json::json_exception or std::runtime_error, which will prevent activation and for immediate activations cause a 500 Internal Error status code to be returned
     typedef std::function<void(const nmos::resource&, const nmos::resource&, web::json::value&)> connection_resource_auto_resolver;
 
     // a connection_sender_transportfile_setter updates the specified /transportfile endpoint for the specified (IS-04/IS-05) sender/connection_sender
+    // it may throw e.g. web::json::json_exception or std::runtime_error, which will prevent activation and for immediate activations cause a 500 Internal Error status code to be returned
     typedef std::function<void(const nmos::resource&, const nmos::resource&, web::json::value&)> connection_sender_transportfile_setter;
 
     void connection_activation_thread(nmos::node_model& model, connection_resource_auto_resolver resolve_auto, connection_sender_transportfile_setter set_transportfile, slog::base_gate& gate);

--- a/Development/nmos/connection_api.cpp
+++ b/Development/nmos/connection_api.cpp
@@ -560,7 +560,7 @@ namespace nmos
         // also be set back to null to unblock concurrent patch operations (nmos::set_connection_resource_not_pending does both).
         //
         // This obviously requires co-operation from other threads that are manipulating these connection resources.
-        // nmos-cpp-node/node_implementation.cpp currently serves as an example of how to handle sender/receiver activations.
+        // nmos::connection_activation_thread can usually be used to schedule sender/receiver activations.
         //
         // By the time we reacquire the model lock anything may have happened, but we can identify with the above whether to send
         // a success response or an error, and in the success case, release the 'per-resource lock' by updating the staged
@@ -731,7 +731,7 @@ namespace nmos
 
         void notify_connection_resource_patch(const nmos::node_model& model, slog::base_gate& gate)
         {
-            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Notifying connection thread";
+            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Notifying connection activation thread";
 
             model.notify();
         }

--- a/Development/nmos/connection_api.h
+++ b/Development/nmos/connection_api.h
@@ -37,6 +37,9 @@ namespace nmos
     // (This function should be called after nmos::set_connection_resource_active.)
     void set_resource_subscription(nmos::resource& node_resource, bool active, const nmos::id& connected_id, const nmos::tai& activation_time);
 
+    // Validate and parse the specified transport file for the specified receiver
+    web::json::value parse_rtp_transport_file(const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate);
+
     // "On activation all instances of "auto" should be resolved into the actual values that will be used"
     // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1-dev/APIs/ConnectionAPI.raml#L280-L281
     // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1-dev/APIs/schemas/sender_transport_params_rtp.json

--- a/Development/nmos/node_api_target_handler.cpp
+++ b/Development/nmos/node_api_target_handler.cpp
@@ -4,7 +4,6 @@
 #include "cpprest/http_client.h"
 #include "nmos/activation_mode.h"
 #include "nmos/client_utils.h"
-#include "nmos/connection_api.h"
 #include "nmos/is05_versions.h"
 #include "nmos/json_fields.h"
 #include "nmos/model.h"
@@ -12,10 +11,11 @@
 
 namespace nmos
 {
-    // implement the Node API /receivers/{receiverId}/target endpoint using the Connection API implementation
-    node_api_target_handler make_node_api_target_handler(nmos::node_model& model)
+    // implement the Node API /receivers/{receiverId}/target endpoint using the Connection API implementation with the specified transport file parser and the specified validator
+    // (the /target endpoint is only required to support RTP transport, other transport types use the Connection API)
+    node_api_target_handler make_node_api_target_handler(nmos::node_model& model, transport_file_parser parse_transport_file, details::connection_resource_patch_validator validate_merged)
     {
-        return [&model](const nmos::id& receiver_id, const web::json::value& sender_data, slog::base_gate& gate)
+        return [&model, parse_transport_file, validate_merged](const nmos::id& receiver_id, const web::json::value& sender_data, slog::base_gate& gate)
         {
             using web::json::value;
             using web::json::value_of;
@@ -52,7 +52,7 @@ namespace nmos
                     }
 
                     return res.extract_string(true);
-                }).then([&model, receiver_id, sender_id, &gate](const utility::string_t& sdp)
+                }).then([&model, receiver_id, sender_id, parse_transport_file, validate_merged, &gate](const utility::string_t& sdp)
                 {
                     // "The Connection Management API supersedes the now deprecated method of updating the 'target' resource on Node API Receivers in order to establish connections."
                     // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/3.1.%20Interoperability%20-%20NMOS%20IS-04.md#support-for-legacy-is-04-connection-management
@@ -71,14 +71,14 @@ namespace nmos
 
                     web::http::http_response res; // ignore the Connection API response
                     const auto version = nmos::is05_versions::v1_0; // hmm, could be based on supported API versions from settings?
-                    nmos::details::handle_connection_resource_patch(res, model, version, { receiver_id, nmos::types::receiver }, patch, gate);
+                    nmos::details::handle_connection_resource_patch(res, model, version, { receiver_id, nmos::types::receiver }, patch, parse_transport_file, validate_merged, gate);
                 });
             }
             else
             {
                 // no sender data means disconnect
 
-                return pplx::create_task([&model, receiver_id, &gate]
+                return pplx::create_task([&model, receiver_id, validate_merged, &gate]
                 {
                     const auto patch = value_of({
                         { nmos::fields::sender_id, value::null() },
@@ -90,9 +90,16 @@ namespace nmos
 
                     web::http::http_response res; // ignore the Connection API response
                     const auto version = nmos::is05_versions::v1_0; // hmm, could be based on supported API versions from settings?
-                    nmos::details::handle_connection_resource_patch(res, model, version, { receiver_id, nmos::types::receiver }, patch, gate);
+                    nmos::details::handle_connection_resource_patch(res, model, version, { receiver_id, nmos::types::receiver }, patch, {}, validate_merged, gate);
                 });
             }
         };
+    }
+
+    // implement the Node API /receivers/{receiverId}/target endpoint using the Connection API implementation with the default transport file parser
+    // (the /target endpoint is only required to support RTP transport, other transport types use the Connection API)
+    node_api_target_handler make_node_api_target_handler(nmos::node_model& model)
+    {
+        return make_node_api_target_handler(model, &nmos::parse_rtp_transport_file, {});
     }
 }

--- a/Development/nmos/node_api_target_handler.h
+++ b/Development/nmos/node_api_target_handler.h
@@ -1,9 +1,7 @@
 #ifndef NMOS_NODE_API_TARGET_HANDLER_H
 #define NMOS_NODE_API_TARGET_HANDLER_H
 
-#include <functional>
-#include "pplx/pplxtasks.h"
-#include "nmos/id.h"
+#include "nmos/connection_api.h"
 
 namespace web
 {
@@ -25,7 +23,19 @@ namespace nmos
     // handler for the Node API /receivers/{receiverId}/target endpoint
     typedef std::function<pplx::task<void>(const nmos::id&, const web::json::value&, slog::base_gate& gate)> node_api_target_handler;
 
-    // implement the Node API /receivers/{receiverId}/target endpoint using the Connection API implementation
+    // implement the Node API /receivers/{receiverId}/target endpoint using the Connection API implementation with the specified transport file parser and the specified validator
+    // (the /target endpoint is only required to support RTP transport, other transport types use the Connection API)
+    node_api_target_handler make_node_api_target_handler(nmos::node_model& model, transport_file_parser parse_transport_file, details::connection_resource_patch_validator validate_merged);
+
+    // implement the Node API /receivers/{receiverId}/target endpoint using the Connection API implementation with the specified transport file parser
+    // (the /target endpoint is only required to support RTP transport, other transport types use the Connection API)
+    inline node_api_target_handler make_node_api_target_handler(nmos::node_model& model, transport_file_parser parse_transport_file)
+    {
+        return make_node_api_target_handler(model, parse_transport_file, {});
+    }
+
+    // implement the Node API /receivers/{receiverId}/target endpoint using the Connection API implementation with the default transport file parser
+    // (the /target endpoint is only required to support RTP transport, other transport types use the Connection API)
     node_api_target_handler make_node_api_target_handler(nmos::node_model& model);
 }
 


### PR DESCRIPTION
Based on all the work @jwpwh did in his 'app hook' PRs (most recently, PR #77), this brings a large chunk of the `node_implementation_thread` back into the nmos module.

The new `nmos::connection_activation_thread` has two 'hooks':

* `void resolve_auto(const nmos::resource& resource, const nmos::resource& connection_resource, web::json::value& transport_params)`
  * [in] `resource` - the IS-04 sender or receiver
  * [in] `connection_resource` - the IS-05 sender or receiver
  * [in, out] `transport_params` - the transport parameters array to be updated

* `void set_transportfile(const nmos::resource& sender, const nmos::resource& connection_sender, web::json::value& endpoint_transportfile);`
  * [n] `sender` - the IS-04 sender
  * [in] `connection_sender` - the IS-05 sender
  * [in, out] `endpoint_transportfile` - the `/transportfile` endpoint object to be updated
