### PR TITLE
Minor changes related to callback functions

### DIFF
--- a/Development/nmos-cpp-node/main.cpp
+++ b/Development/nmos-cpp-node/main.cpp
@@ -7,7 +7,11 @@
 #include "nmos/server.h"
 #include "node_implementation.h"
 
+#if (NMOS_IS_MAIN == 1)
 int main(int argc, char* argv[])
+#else
+int nmos_main(int argc, char* argv[])
+#endif
 {
     // Construct our data models including mutexes to protect them
 
@@ -92,7 +96,13 @@ int main(int argc, char* argv[])
 
         // Set up the node server
 
-        auto node_server = nmos::experimental::make_node_server(node_model, make_node_implementation_auto_resolver(node_model.settings), make_node_implementation_transportfile_setter(node_model.node_resources, node_model.settings), {}, log_model, gate);
+        auto node_server = nmos::experimental::make_node_server(node_model,
+            make_node_implementation_transport_file_parser (),
+            make_node_implementation_patch_validator(),
+            make_node_implementation_auto_resolver(node_model.settings),
+            make_node_implementation_transportfile_setter(node_model.node_resources, node_model.settings),
+            make_node_implementation_connection_activated(),
+            log_model, gate);
 
         // Add the underlying implementation, which will set up the node resources, etc.
 

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -184,6 +184,17 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate)
     temperature_events.wait();
 }
 
+nmos::transport_file_parser make_node_implementation_transport_file_parser()
+{
+    // This example does not override this callback
+    return &nmos::parse_rtp_transport_file;
+}
+
+nmos::details::connection_resource_patch_validator make_node_implementation_patch_validator()
+{
+    // This example does not make use of this callback
+    return {};
+}
 nmos::connection_resource_auto_resolver make_node_implementation_auto_resolver(const nmos::settings& settings)
 {
     using web::json::value;
@@ -253,4 +264,10 @@ nmos::connection_sender_transportfile_setter make_node_implementation_transportf
             endpoint_transportfile = nmos::make_connection_rtp_sender_transportfile(sdp);
         }
     };
+}
+
+nmos::connection_activation_handler make_node_implementation_connection_activated()
+{
+    // This example does not make use of this callback
+    return {};
 }

--- a/Development/nmos-cpp-node/node_implementation.h
+++ b/Development/nmos-cpp-node/node_implementation.h
@@ -4,6 +4,7 @@
 #include "nmos/connection_activation.h"
 #include "nmos/resources.h" // just a forward declaration of nmos::resources
 #include "nmos/settings.h" // just a forward declaration of nmos::settings
+#include "nmos/connection_api.h"
 
 namespace slog
 {
@@ -15,15 +16,47 @@ namespace nmos
     struct node_model;
 }
 
+// When NMOS_IS_MAIN is defined as 1, then main.cpp will define the "main" function
+// as main. This is good for the example.
+// When integrating into an application which has its own main() and is able to 
+// use all the initialization in the nmos "main" function as is, then define
+// NMOS_IS_MAIN=0 to change the function name to "nmos_main" instead.
+#if !defined(NMOS_IS_MAIN)
+#define NMOS_IS_MAIN 1
+#endif
+#if (NMOS_IS_MAIN==0)
+int nmos_main(int argc, char* argv[]);
+#endif
+
 // This is an example of how to integrate the nmos-cpp library with a device-specific underlying implementation.
 // It constructs and inserts a node resource and some sub-resources into the model, based on the model settings,
 // starts background tasks to emit regular events from the temperature event source and then waits for shutdown.
 void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate);
 
-// Example connection activation callback
+// Example transport file parser
+// The parse_transport_file hook allows the sender/receiver to reject PATCH /staged requests 
+// with either 400 Bad Request or 500 Internal Error and a "debug" message in the response body 
+// from the exception.
+//
+// This must always return a callable function. {} is not allowed. The default function is
+// nmos::parse_rtp_transport_file.
+nmos::transport_file_parser make_node_implementation_transport_file_parser();
+
+// Example patch validator
+// the validate_merged hook allows the sender/receiver to reject PATCH /staged requests 
+// with either 400 Bad Request or 500 Internal Error and a "debug" message in the response body
+// from the exception.
+nmos::details::connection_resource_patch_validator make_node_implementation_patch_validator();
+
+// Example connection activation auto_resolver callback
 nmos::connection_resource_auto_resolver make_node_implementation_auto_resolver(const nmos::settings& settings);
 
-// Example connection activation callback - captures node_resources by reference!
+// Example connection activation transportfile_setter callback - captures node_resources by reference!
 nmos::connection_sender_transportfile_setter make_node_implementation_transportfile_setter(const nmos::resources& node_resources, const nmos::settings& settings);
+
+// Example connection activation handler callback
+// This callback lets the application perform application specific actions to complete an
+// activated connection.
+nmos::connection_activation_handler make_node_implementation_connection_activated();
 
 #endif

--- a/Development/nmos/connection_activation.h
+++ b/Development/nmos/connection_activation.h
@@ -23,15 +23,15 @@ namespace nmos
 
     // a connection_resource_auto_resolver overwrites every instance of "auto" in the specified transport_params array for the specified (IS-04/IS-05) sender/connection_sender or receiver/connection_receiver
     // it may throw e.g. web::json::json_exception or std::runtime_error, which will prevent activation and for immediate activations cause a 500 Internal Error status code to be returned
-    typedef std::function<void(const nmos::resource&, const nmos::resource&, web::json::value&)> connection_resource_auto_resolver;
+    typedef std::function<void(const nmos::resource& node_resource, const nmos::resource& connection_resource, web::json::value& transport_params)> connection_resource_auto_resolver;
 
     // a connection_sender_transportfile_setter updates the specified /transportfile endpoint for the specified (IS-04/IS-05) sender/connection_sender
     // it may throw e.g. web::json::json_exception or std::runtime_error, which will prevent activation and for immediate activations cause a 500 Internal Error status code to be returned
-    typedef std::function<void(const nmos::resource&, const nmos::resource&, web::json::value&)> connection_sender_transportfile_setter;
+    typedef std::function<void(const nmos::resource& node_sender, const nmos::resource& connection_sender, web::json::value& endpoint_transportfile)> connection_sender_transportfile_setter;
 
     // a connection_activation_handler is a notification that the active parameters for the specified (IS-04/IS-05) sender/connection_sender or receiver/connection_receiver have changed
     // for now, this callback must not throw exceptions
-    typedef std::function<void(const nmos::resource&, const nmos::resource&)> connection_activation_handler;
+    typedef std::function<void(const nmos::resource& node_resource, const nmos::resource& connection_resource)> connection_activation_handler;
 
     // callbacks from this function are called with the model locked, and may read but should not write directly to the model
     void connection_activation_thread(nmos::node_model& model, connection_resource_auto_resolver resolve_auto, connection_sender_transportfile_setter set_transportfile, connection_activation_handler connection_activated, slog::base_gate& gate);

--- a/Development/nmos/connection_api.h
+++ b/Development/nmos/connection_api.h
@@ -24,14 +24,16 @@ namespace nmos
     // a transport_file_parser validates the specified transport file type/data for the specified (IS-04/IS-05) resource/connection_resource and returns a transport_params array to be merged
     // or may throw std::runtime_error, which will be mapped to a 500 Internal Error status code with NMOS error "debug" information including the exception message
     // (the default transport file parser only supports RTP transport via the default SDP parser)
-    typedef std::function<web::json::value(const nmos::resource&, const nmos::resource&, const utility::string_t&, const utility::string_t&, slog::base_gate&)> transport_file_parser;
+    //
+    // The default transport file parser is nmos::parse_rtp_transport_file
+    typedef std::function<web::json::value(const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate)> transport_file_parser;
 
     namespace details
     {
         // a connection_resource_patch_validator can be used to perform any final validation of the specified merged /staged value for the specified (IS-04/IS-05) resource/connection_resource
         // that cannot be expressed by the schemas or /constraints endpoint
         // it may throw web::json::json_exception, which will be mapped to a 400 Bad Request status code with NMOS error "debug" information including the exception message
-        typedef std::function<void(const nmos::resource&, const nmos::resource&, const web::json::value&, slog::base_gate&)> connection_resource_patch_validator;
+        typedef std::function<void(const nmos::resource& node_resource, const nmos::resource& connection_resource, const web::json::value& connection_merged_staged, slog::base_gate& gate)> connection_resource_patch_validator;
     }
 
     // Connection API factory functions


### PR DESCRIPTION
These are some minor changes to the callback functions to make it more clear what all the available callbacks are and what their arguments are. The example implementation makes all the callbacks instead of just the functions that are not {}. I think the placeholders would help indicate which callbacks are available.

There are also some preprocessor macros for allowing the main() function to be renamed to nmos_main() in case the application can use the body of main() as is. e.g. nmos_main() would be called from the application and the main() in the application would not collide with the sample implementation.