### PR TITLE
Save parsed SDP tree in connection_resource.

### DIFF
--- a/Development/nmos/connection_api.h
+++ b/Development/nmos/connection_api.h
@@ -3,6 +3,7 @@
 
 #include "cpprest/api_router.h"
 #include "nmos/id.h"
+#include "nmos/sdp_utils.h"
 
 namespace slog
 {
@@ -24,7 +25,7 @@ namespace nmos
     // a transport_file_parser validates the specified transport file type/data for the specified (IS-04/IS-05) resource/connection_resource and returns a transport_params array to be merged
     // or may throw std::runtime_error, which will be mapped to a 500 Internal Error status code with NMOS error "debug" information including the exception message
     // (the default transport file parser, nmos::parse_rtp_transport_file, only supports RTP transport via the default SDP parser)
-    typedef std::function<web::json::value(const nmos::resource& resource, const nmos::resource& connection_resource, const utility::string_t& transportfile_type, const utility::string_t& transportfile_data, slog::base_gate& gate)> transport_file_parser;
+    typedef std::function<std::pair<sdp_parameters, web::json::value>(const nmos::resource& resource, const nmos::resource& connection_resource, const utility::string_t& transportfile_type, const utility::string_t& transportfile_data, slog::base_gate& gate)> transport_file_parser;
 
     namespace details
     {
@@ -69,7 +70,7 @@ namespace nmos
 
     // Validate and parse the specified transport file for the specified receiver
     // (this is the default transport file parser)
-    web::json::value parse_rtp_transport_file(const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate);
+    std::pair<sdp_parameters, web::json::value> parse_rtp_transport_file(const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate);
 
     // "On activation all instances of "auto" should be resolved into the actual values that will be used"
     // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1-dev/APIs/ConnectionAPI.raml#L280-L281

--- a/Development/nmos/resource.h
+++ b/Development/nmos/resource.h
@@ -10,6 +10,7 @@
 #include "nmos/settings.h"
 #include "nmos/tai.h"
 #include "nmos/type.h"
+#include "nmos/sdp_utils.h"
 
 namespace nmos
 {
@@ -48,6 +49,8 @@ namespace nmos
         // resource data is stored directly as json rather than e.g. being deserialized to a class hierarchy to allow quick
         // prototyping; json validation at the API boundary ensures the data met the schema for the specified version
         web::json::value data;
+        //Keeping track of latest patched sdp file params. Useful for having all sdp fields available when joining media-streams after IS-05 activation
+        struct nmos::sdp_parameters sdp_params;
         // when the resource data is null, the resource has been deleted or expired
         bool has_data() const { return !data.is_null(); }
 


### PR DESCRIPTION
It is really useful to have nicely parsed SDP tree during activation so that, for example, an audio receiver can get audio sampling rate and bit depth without looking up IS-04 sender resources.
It would be realy nice to have it upstream so I don't need to reimplement this hack every time:)