### PR TITLE
Add argument to set PTP domain in SDP parameters

### DIFF
--- a/Development/bst/optional.h
+++ b/Development/bst/optional.h
@@ -47,6 +47,7 @@ namespace bst
 {
     using std::nullopt_t;
     using std::nullopt;
+    using std::bad_optional_access;
 }
 
 #elif defined(BST_OPTIONAL_BOOST)
@@ -58,6 +59,12 @@ namespace bst
 {
     typedef boost::none_t nullopt_t;
     const boost::none_t nullopt = boost::none;
+#if BOOST_VERSION >= 105600
+    using boost::bad_optional_access;
+#else
+    // Prior to Boost 1.56.0, boost::optional provided an interface that differed in a number of ways from that ultimately defined for C++17 std::optional
+    // e.g. no member function value
+#endif
 }
 
 #endif
@@ -66,7 +73,6 @@ namespace bst
 {
     using bst_optional::optional;
     using bst_optional::make_optional;
-    using bst_optional::bad_optional_access;
 }
 
 #endif

--- a/Development/bst/optional.h
+++ b/Development/bst/optional.h
@@ -1,0 +1,72 @@
+#ifndef BST_OPTIONAL_H
+#define BST_OPTIONAL_H
+
+// Provide bst::optional, etc. using either std:: or boost:: symbols
+// C++17 feature test macro: __has_include(<optional>), __cpp_lib_optional
+
+#if !defined(BST_OPTIONAL_STD) && !defined(BST_OPTIONAL_BOOST)
+
+#if defined(__GNUC__)
+// std::optional is available from GCC 7.1, with -std=c++17
+//#if __GNUC__  > 7 || (__GNUC__ == 7 && __GNUC_MINOR__ >= 1)
+#if __cplusplus >= 201703L
+#define BST_OPTIONAL_STD
+#else
+#define BST_OPTIONAL_BOOST
+#endif
+
+#elif defined(_MSC_VER)
+
+#if _MSC_VER >= 1910
+// From VS2017, /std:c++17 switch is introduced, but this is only indicated in __cplusplus if /Zc:__cplusplus is also specified
+#if __cplusplus >= 201703L
+#define BST_OPTIONAL_STD
+#else
+#define BST_OPTIONAL_BOOST
+#endif
+#else
+// Earlier
+#define BST_OPTIONAL_BOOST
+#endif
+
+#else
+
+// Default to C++17
+#define BST_OPTIONAL_STD
+
+#endif
+
+#endif
+
+#if defined(BST_OPTIONAL_STD)
+
+#include <optional>
+namespace bst_optional = std;
+
+namespace bst
+{
+    using std::nullopt_t;
+    using std::nullopt;
+}
+
+#elif defined(BST_OPTIONAL_BOOST)
+
+#include <boost/optional.hpp>
+namespace bst_optional = boost;
+
+namespace bst
+{
+    typedef boost::none_t nullopt_t;
+    const boost::none_t nullopt = boost::none;
+}
+
+#endif
+
+namespace bst
+{
+    using bst_optional::optional;
+    using bst_optional::make_optional;
+    using bst_optional::bad_optional_access;
+}
+
+#endif

--- a/Development/nmos/json_fields.h
+++ b/Development/nmos/json_fields.h
@@ -53,6 +53,8 @@ namespace nmos
         const web::json::field_as_string ref_type{ U("ref_type") };
         const web::json::field_as_string ptp_version{ U("version") };
         const web::json::field_as_string gmid{ U("gmid") };
+        const web::json::field_as_bool traceable{ U("traceable") };
+        const web::json::field_as_bool locked{ U("locked") };
         // device
         const web::json::field_as_string node_id{ U("node_id") };
         const web::json::field_as_array senders{ U("senders") }; // deprecated

--- a/Development/nmos/media_type.h
+++ b/Development/nmos/media_type.h
@@ -35,7 +35,7 @@ namespace nmos
 
         // Mux media types
 
-        // See http://www.videoservicesforum.org/download/technical_recommendations/VSF_TR-04_2015-11-12.pdf
+        // See SMPTE ST 2022-8:2019
         const media_type video_SMPTE2022_6{ U("video/SMPTE2022-6") };
     }
 }

--- a/Development/nmos/node_resource.cpp
+++ b/Development/nmos/node_resource.cpp
@@ -85,9 +85,9 @@ namespace nmos
             { nmos::fields::name, clk.name },
             { nmos::fields::ref_type, nmos::clock_ref_types::ptp.name },
             { nmos::fields::ptp_version, U("IEEE1588-2008") }, // cf. sdp::ptp_versions::IEEE1588_2008
-            { U("traceable"), traceable },
+            { nmos::fields::traceable, traceable },
             { nmos::fields::gmid, gmid },
-            { U("locked"), locked }
+            { nmos::fields::locked, locked }
         });
     }
 }

--- a/Development/nmos/node_resources.cpp
+++ b/Development/nmos/node_resources.cpp
@@ -197,6 +197,16 @@ namespace nmos
         return make_audio_source(id, device_id, {}, grain_rate, channels, settings);
     }
 
+    nmos::resource make_mux_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings)
+    {
+        return make_generic_source(id, device_id, clk, grain_rate, nmos::formats::mux, settings);
+    }
+
+    nmos::resource make_mux_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings)
+    {
+        return make_mux_source(id, device_id, {}, grain_rate, settings);
+    }
+
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_core.json
     nmos::resource make_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings)
     {
@@ -554,7 +564,7 @@ namespace nmos
         auto resource = make_receiver(id, device_id, transport, interfaces, settings);
         auto& data = resource.data;
 
-        data[U("format")] = value::string(nmos::formats::data.name);
+        data[U("format")] = value::string(nmos::formats::mux.name);
         data[U("caps")][U("media_types")][0] = value::string(media_type.name);
 
         return resource;

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -33,7 +33,7 @@ namespace nmos
             return{ ip_address.is_v4() ? sdp::address_types::IP4 : sdp::address_types::IP6, ip_address.is_multicast() };
         }
 
-        std::vector<sdp_parameters::ts_refclk_t> make_ts_refclk(const web::json::value& node, const web::json::value& source, const web::json::value& sender)
+        std::vector<sdp_parameters::ts_refclk_t> make_ts_refclk(const web::json::value& node, const web::json::value& source, const web::json::value& sender, boost::optional<int> ptp_domain)
         {
             const auto& clock_name = nmos::fields::clock_name(source);
             if (clock_name.is_null()) throw sdp_creation_error("no source clock");
@@ -53,8 +53,16 @@ namespace nmos
             {
                 const sdp::ptp_version version{ nmos::fields::ptp_version(*clock) };
 
-                // since 'gmid' is required, always indicate it rather than 'traceable'
-                return{ interface_bindings.size(), sdp_parameters::ts_refclk_t::ptp(version, boost::algorithm::to_upper_copy(nmos::fields::gmid(*clock))) };
+                // since 'gmid' is required, always indicate it (and the domain) rather than 'traceable'
+                auto server = boost::algorithm::to_upper_copy(nmos::fields::gmid(*clock));
+                if (ptp_domain)
+                {
+                    if (*ptp_domain < 0 || *ptp_domain > 127) throw sdp_creation_error("PTP domain out of range");
+
+                    server += U(":") + utility::conversions::details::to_string_t(*ptp_domain);
+                }
+
+                return{ interface_bindings.size(), sdp_parameters::ts_refclk_t::ptp(version, server) };
             }
             else if (nmos::clock_ref_types::internal == ref_type)
             {
@@ -119,7 +127,7 @@ namespace nmos
         }
     }
 
-    static sdp_parameters make_video_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids)
+    static sdp_parameters make_video_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain)
     {
         sdp_parameters::video_t params;
         params.tp = sdp::type_parameters::type_N;
@@ -147,10 +155,10 @@ namespace nmos
         const auto& grain_rate = nmos::fields::grain_rate(flow.has_field(nmos::fields::grain_rate) ? flow : source);
         params.exactframerate = nmos::rational(nmos::fields::numerator(grain_rate), nmos::fields::denominator(grain_rate));
 
-        return{ sender.at(nmos::fields::label).as_string(), params, 96, media_stream_ids, details::make_ts_refclk(node, source, sender) };
+        return{ sender.at(nmos::fields::label).as_string(), params, 96, media_stream_ids, details::make_ts_refclk(node, source, sender, ptp_domain) };
     }
 
-    static sdp_parameters make_audio_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids)
+    static sdp_parameters make_audio_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain)
     {
         sdp_parameters::audio_t params;
 
@@ -172,10 +180,10 @@ namespace nmos
         // ptime
         params.packet_time = 1;
 
-        return{ sender.at(nmos::fields::label).as_string(), params, 97, media_stream_ids, details::make_ts_refclk(node, source, sender) };
+        return{ sender.at(nmos::fields::label).as_string(), params, 97, media_stream_ids, details::make_ts_refclk(node, source, sender, ptp_domain) };
     }
 
-    static sdp_parameters make_data_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids)
+    static sdp_parameters make_data_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain)
     {
         sdp_parameters::data_t params;
 
@@ -189,10 +197,10 @@ namespace nmos
 
         // hm, no vpid_code in the flow
 
-        return{ sender.at(nmos::fields::label).as_string(), params, 100, media_stream_ids, details::make_ts_refclk(node, source, sender) };
+        return{ sender.at(nmos::fields::label).as_string(), params, 100, media_stream_ids, details::make_ts_refclk(node, source, sender, ptp_domain) };
     }
 
-    static sdp_parameters make_mux_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids)
+    static sdp_parameters make_mux_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain)
     {
         sdp_parameters::mux_t params;
         // "Senders shall comply with either the Narrow Linear Senders (Type NL) requirements, or the Wide Senders (Type W) requirements."
@@ -202,22 +210,27 @@ namespace nmos
         // Payload type 98 is "High bit rate media transport / 27-MHz Clock"
         // Payload type 99 is "High bit rate media transport FEC / 27-MHz Clock"
         // See SMPTE ST 2022-6:2012 Section 6.3 RTP/UDP/IP Header
-        return{ sender.at(nmos::fields::label).as_string(), params, 98, media_stream_ids, details::make_ts_refclk(node, source, sender) };
+        return{ sender.at(nmos::fields::label).as_string(), params, 98, media_stream_ids, details::make_ts_refclk(node, source, sender, ptp_domain) };
+    }
+
+    sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain)
+    {
+        const auto& format = nmos::fields::format(flow);
+        if (nmos::formats::video.name == format)
+            return make_video_sdp_parameters(node, source, flow, sender, media_stream_ids, ptp_domain);
+        else if (nmos::formats::audio.name == format)
+            return make_audio_sdp_parameters(node, source, flow, sender, media_stream_ids, ptp_domain);
+        else if (nmos::formats::data.name == format)
+            return make_data_sdp_parameters(node, source, flow, sender, media_stream_ids, ptp_domain);
+        else if (nmos::formats::mux.name == format)
+            return make_mux_sdp_parameters(node, source, flow, sender, media_stream_ids, ptp_domain);
+        else
+            throw details::sdp_creation_error("unsuported media format");
     }
 
     sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids)
     {
-        const auto& format = nmos::fields::format(flow);
-        if (nmos::formats::video.name == format)
-            return make_video_sdp_parameters(node, source, flow, sender, media_stream_ids);
-        else if (nmos::formats::audio.name == format)
-            return make_audio_sdp_parameters(node, source, flow, sender, media_stream_ids);
-        else if (nmos::formats::data.name == format)
-            return make_data_sdp_parameters(node, source, flow, sender, media_stream_ids);
-        else if (nmos::formats::mux.name == format)
-            return make_mux_sdp_parameters(node, source, flow, sender, media_stream_ids);
-        else
-            throw details::sdp_creation_error("unsuported media format");
+        return make_sdp_parameters(node, source, flow, sender, media_stream_ids, boost::none);
     }
 
     static web::json::value make_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params, const web::json::value& ptime, const web::json::value& rtpmap, const web::json::value& fmtp)

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -33,7 +33,7 @@ namespace nmos
             return{ ip_address.is_v4() ? sdp::address_types::IP4 : sdp::address_types::IP6, ip_address.is_multicast() };
         }
 
-        std::vector<sdp_parameters::ts_refclk_t> make_ts_refclk(const web::json::value& node, const web::json::value& source, const web::json::value& sender, boost::optional<int> ptp_domain)
+        std::vector<sdp_parameters::ts_refclk_t> make_ts_refclk(const web::json::value& node, const web::json::value& source, const web::json::value& sender, bst::optional<int> ptp_domain)
         {
             const auto& clock_name = nmos::fields::clock_name(source);
             if (clock_name.is_null()) throw sdp_creation_error("no source clock");
@@ -127,7 +127,7 @@ namespace nmos
         }
     }
 
-    static sdp_parameters make_video_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain)
+    static sdp_parameters make_video_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, bst::optional<int> ptp_domain)
     {
         sdp_parameters::video_t params;
         params.tp = sdp::type_parameters::type_N;
@@ -158,7 +158,7 @@ namespace nmos
         return{ sender.at(nmos::fields::label).as_string(), params, 96, media_stream_ids, details::make_ts_refclk(node, source, sender, ptp_domain) };
     }
 
-    static sdp_parameters make_audio_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain)
+    static sdp_parameters make_audio_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, bst::optional<int> ptp_domain)
     {
         sdp_parameters::audio_t params;
 
@@ -183,7 +183,7 @@ namespace nmos
         return{ sender.at(nmos::fields::label).as_string(), params, 97, media_stream_ids, details::make_ts_refclk(node, source, sender, ptp_domain) };
     }
 
-    static sdp_parameters make_data_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain)
+    static sdp_parameters make_data_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, bst::optional<int> ptp_domain)
     {
         sdp_parameters::data_t params;
 
@@ -200,7 +200,7 @@ namespace nmos
         return{ sender.at(nmos::fields::label).as_string(), params, 100, media_stream_ids, details::make_ts_refclk(node, source, sender, ptp_domain) };
     }
 
-    static sdp_parameters make_mux_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain)
+    static sdp_parameters make_mux_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, bst::optional<int> ptp_domain)
     {
         sdp_parameters::mux_t params;
         // "Senders shall comply with either the Narrow Linear Senders (Type NL) requirements, or the Wide Senders (Type W) requirements."
@@ -213,7 +213,7 @@ namespace nmos
         return{ sender.at(nmos::fields::label).as_string(), params, 98, media_stream_ids, details::make_ts_refclk(node, source, sender, ptp_domain) };
     }
 
-    sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain)
+    sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, bst::optional<int> ptp_domain)
     {
         const auto& format = nmos::fields::format(flow);
         if (nmos::formats::video.name == format)
@@ -228,9 +228,10 @@ namespace nmos
             throw details::sdp_creation_error("unsuported media format");
     }
 
+    // deprecated, provided for backwards compatibility, because it may be necessary to also specify the PTP domain to generate an RFC 7273 'ts-refclk' attribute that meets the additional constraints of ST 2110-10
     sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids)
     {
-        return make_sdp_parameters(node, source, flow, sender, media_stream_ids, boost::none);
+        return make_sdp_parameters(node, source, flow, sender, media_stream_ids, bst::nullopt);
     }
 
     static web::json::value make_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params, const web::json::value& ptime, const web::json::value& rtpmap, const web::json::value& fmtp)

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -85,7 +85,7 @@ namespace nmos
         struct rtpmap_t
         {
             uint64_t payload_type;
-            // encoding-name is "raw" for video, "L24" or "L16" for audio, "smpte291" for data
+            // encoding-name is "raw" for video, "L24" or "L16" for audio, "smpte291" for data, "SMPTE2022-6" for mux
             utility::string_t encoding_name;
             uint64_t clock_rate;
 
@@ -170,6 +170,18 @@ namespace nmos
             {}
         } data;
 
+        // additional "video/SMPTE2022-6" parameters (mux only)
+        // see SMPTE ST 2022-8:2019
+        struct mux_t
+        {
+            sdp::type_parameter tp;
+
+            mux_t() {}
+            mux_t(const sdp::type_parameter& tp)
+                : tp(tp)
+            {}
+        } mux;
+
         struct ts_refclk_t
         {
             sdp::ts_refclk_source clock_source;
@@ -236,6 +248,7 @@ namespace nmos
             , video(video)
             , audio()
             , data()
+            , mux()
             , ts_refclk(ts_refclk)
             , mediaclk(sdp::mediaclk_sources::direct, U("0"))
         {}
@@ -253,6 +266,7 @@ namespace nmos
             , video()
             , audio(audio)
             , data()
+            , mux()
             , ts_refclk(ts_refclk)
             , mediaclk(sdp::mediaclk_sources::direct, U("0"))
         {}
@@ -270,6 +284,25 @@ namespace nmos
             , video()
             , audio()
             , data(data)
+            , mux()
+            , ts_refclk(ts_refclk)
+            , mediaclk(sdp::mediaclk_sources::direct, U("0"))
+        {}
+
+        // construct "video/SMPTE2022-6" SDP parameters with sensible defaults for unspecified fields
+        sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {})
+            : origin(U("-"), sdp::ntp_now() >> 32)
+            , session_name(session_name)
+            , connection_data(32)
+            , timing()
+            , group(!media_stream_ids.empty() ? group_t{ sdp::group_semantics::duplication, media_stream_ids } : group_t{})
+            , media_type(sdp::media_types::video)
+            , protocol(sdp::protocols::RTP_AVP)
+            , rtpmap(payload_type, U("SMPTE2022-6"), 27000000)
+            , video()
+            , audio()
+            , data()
+            , mux(mux)
             , ts_refclk(ts_refclk)
             , mediaclk(sdp::mediaclk_sources::direct, U("0"))
         {}

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -1,7 +1,7 @@
 #ifndef NMOS_SDP_UTILS_H
 #define NMOS_SDP_UTILS_H
 
-#include <boost/optional.hpp>
+#include "bst/optional.h"
 #include "cpprest/basic_utils.h"
 #include "sdp/json.h"
 #include "sdp/ntp.h"
@@ -15,8 +15,9 @@ namespace nmos
 
     // Sender helper functions
 
-    sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain);
+    sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, bst::optional<int> ptp_domain);
 
+    // deprecated, provided for backwards compatibility, because it may be necessary to also specify the PTP domain to generate an RFC 7273 'ts-refclk' attribute that meets the additional constraints of ST 2110-10
     sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids);
 
     web::json::value make_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params);

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -1,6 +1,7 @@
 #ifndef NMOS_SDP_UTILS_H
 #define NMOS_SDP_UTILS_H
 
+#include <boost/optional.hpp>
 #include "cpprest/basic_utils.h"
 #include "sdp/json.h"
 #include "sdp/ntp.h"
@@ -13,6 +14,8 @@ namespace nmos
     struct sdp_parameters;
 
     // Sender helper functions
+
+    sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, boost::optional<int> ptp_domain);
 
     sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids);
 


### PR DESCRIPTION
Tried out an implementation with `boost::optional` for the optional PTP domain argument. Let me know what you think.

I'm also wondering what you think about, when the PTP domain is not specified but the PTP clock's `traceable` field is set, using the `ptp=<ptp_server>:traceable` format of `ts-refclk` instead? And then only falling back to just putting the GMID with no domain if no domain is given and the clock is not traceable?
