### PR TITLE
ST2022-6 SDP creation/parsing

### DIFF
--- a/Development/nmos/media_type.h
+++ b/Development/nmos/media_type.h
@@ -35,7 +35,7 @@ namespace nmos
 
         // Mux media types
 
-        // See http://www.videoservicesforum.org/download/technical_recommendations/VSF_TR-04_2015-11-12.pdf
+        // See SMPTE ST 2022-8:2019
         const media_type video_SMPTE2022_6{ U("video/SMPTE2022-6") };
     }
 }

--- a/Development/nmos/node_resources.cpp
+++ b/Development/nmos/node_resources.cpp
@@ -197,6 +197,16 @@ namespace nmos
         return make_audio_source(id, device_id, {}, grain_rate, channels, settings);
     }
 
+    nmos::resource make_mux_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings)
+    {
+        return make_generic_source(id, device_id, clk, grain_rate, nmos::formats::mux, settings);
+    }
+
+    nmos::resource make_mux_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings)
+    {
+        return make_mux_source(id, device_id, {}, grain_rate, settings);
+    }
+
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_core.json
     nmos::resource make_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings)
     {
@@ -554,7 +564,7 @@ namespace nmos
         auto resource = make_receiver(id, device_id, transport, interfaces, settings);
         auto& data = resource.data;
 
-        data[U("format")] = value::string(nmos::formats::data.name);
+        data[U("format")] = value::string(nmos::formats::mux.name);
         data[U("caps")][U("media_types")][0] = value::string(media_type.name);
 
         return resource;

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -197,6 +197,9 @@ namespace nmos
         sdp_parameters::mux_t params;
         params.tp = sdp::type_parameters::type_NL;
 
+        // Payload type 98 is "High bit rate media transport / 27-MHz Clock"
+        // Payload type 99 is "High bit rate media transport FEC / 27-MHz Clock"
+        // See SMPTE ST 2022-6:2012 Section 6.3 RTP/UDP/IP Header
         return{ sender.at(nmos::fields::label).as_string(), params, 98, media_stream_ids, details::make_ts_refclk(node, source, sender) };
     }
 

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -195,6 +195,8 @@ namespace nmos
     static sdp_parameters make_mux_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids)
     {
         sdp_parameters::mux_t params;
+        // "Senders shall comply with either the Narrow Linear Senders (Type NL) requirements, or the Wide Senders (Type W) requirements."
+        // See SMPTE 2022-8:2019 Section 6 Network Compatibility and Transmission Traffic Shape Models
         params.tp = sdp::type_parameters::type_NL;
 
         // Payload type 98 is "High bit rate media transport / 27-MHz Clock"
@@ -1127,9 +1129,13 @@ namespace nmos
             // See SMPTE ST 2110-21:2017 Section 8.1 Required Parameters
             // and Section 8.2 Optional Parameters
 
+            // "TP" (type parameter) is required, but allow it to be omitted for now...
             const auto tp = sdp::find_name(format_specific_parameters, sdp::fields::type_parameter);
-            if (format_specific_parameters.end() == tp) throw details::sdp_processing_error("missing format parameter: TP");
-            sdp_params.video.tp = sdp::type_parameter{ sdp::fields::value(*tp).as_string() };
+            if (format_specific_parameters.end() != tp)
+            {
+                sdp_params.video.tp = sdp::type_parameter{ sdp::fields::value(*tp).as_string() };
+            }
+            // else sdp_params.video.tp = {};
 
             // don't examine optional parameter "TROFF"
         }

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -85,7 +85,7 @@ namespace nmos
         struct rtpmap_t
         {
             uint64_t payload_type;
-            // encoding-name is "raw" for video, "L24" or "L16" for audio, "smpte291" for data
+            // encoding-name is "raw" for video, "L24" or "L16" for audio, "smpte291" for data, "SMPTE2022-6" for mux
             utility::string_t encoding_name;
             uint64_t clock_rate;
 
@@ -170,6 +170,18 @@ namespace nmos
             {}
         } data;
 
+        // additional "video/SMPTE2022-6" parameters (mux only)
+        // see SMPTE ST 2022-8:2019
+        struct mux_t
+        {
+            sdp::type_parameter tp;
+
+            mux_t() {}
+            mux_t(const sdp::type_parameter& tp)
+                : tp(tp)
+            {}
+        } mux;
+
         struct ts_refclk_t
         {
             sdp::ts_refclk_source clock_source;
@@ -236,6 +248,7 @@ namespace nmos
             , video(video)
             , audio()
             , data()
+            , mux()
             , ts_refclk(ts_refclk)
             , mediaclk(sdp::mediaclk_sources::direct, U("0"))
         {}
@@ -253,6 +266,7 @@ namespace nmos
             , video()
             , audio(audio)
             , data()
+            , mux()
             , ts_refclk(ts_refclk)
             , mediaclk(sdp::mediaclk_sources::direct, U("0"))
         {}
@@ -270,6 +284,25 @@ namespace nmos
             , video()
             , audio()
             , data(data)
+            , mux()
+            , ts_refclk(ts_refclk)
+            , mediaclk(sdp::mediaclk_sources::direct, U("0"))
+        {}
+
+        // construct "video/SMPTE2022-6" SDP parameters with sensible defaults for unspecified fields
+        sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {})
+            : origin(U("-"), sdp::ntp_now() >> 32)
+            , session_name(session_name)
+            , connection_data(32)
+            , timing()
+            , group(!media_stream_ids.empty() ? group_t{ sdp::group_semantics::duplication, media_stream_ids } : group_t{})
+            , media_type(sdp::media_types::video)
+            , protocol(sdp::protocols::RTP_AVP)
+            , rtpmap(payload_type, U("SMPTE2022-6"), 27000000)
+            , video()
+            , audio()
+            , data()
+            , mux(mux)
             , ts_refclk(ts_refclk)
             , mediaclk(sdp::mediaclk_sources::direct, U("0"))
         {}


### PR DESCRIPTION
Should largely resolve #74 most significant missing component is generating the proper group attributes and media descriptions of ST2022-5 FEC streams. I'm not sure what all of the valid or expected combinations of ST2022-5 and ST2022-7 are yet or how they should properly be handled in the SDP so I've left that out for now.

I've included all of the required content in the SDP that I could determine from ST2022-8 although it's not super clear so it's possible that I've missed something.