### PR TITLE
Improve time-keeping

### DIFF
--- a/Development/nmos/registration_api.cpp
+++ b/Development/nmos/registration_api.cpp
@@ -247,7 +247,7 @@ namespace nmos
                 bool valid = true;
 
                 // a modification request must not change the existing type
-                const auto resource = nmos::find_resource(resources, id);
+                auto resource = nmos::find_resource(resources, id);
                 const bool creating = resources.end() == resource;
                 const bool valid_type = creating || resource->type == type;
                 valid = valid && valid_type;
@@ -403,7 +403,7 @@ namespace nmos
                         set_reply(res, status_codes::Created, data);
                         res.headers().add(web::http::header_names::location, make_registration_api_resource_location(created_resource));
 
-                        insert_resource(resources, std::move(created_resource), allow_invalid_resources);
+                        resource = insert_resource(resources, std::move(created_resource), allow_invalid_resources).first;
                     }
                     else
                     {
@@ -415,6 +415,9 @@ namespace nmos
                             resource.data = data;
                         });
                     }
+
+                    // experimental extension, for debugging
+                    res.headers().add(U("X-Paging-Timestamp"), make_version(resource->updated));
 
                     slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "At " << nmos::make_version(nmos::tai_now()) << ", the registry contains " << nmos::put_resources_statistics(resources);
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The implementation is incomplete in some areas. Development is ongoing, tracking
 
 Recent activity on the project (newest first):
 
+- Changed the implementation of `nmos::tai_clock` with the effect that it may no longer be monotonic
 - Added a minimum viable LLDP implementation (enabled by a CMake configuration option) to support sending and receiving the IS-04 v1.3 additional network data for Nodes required by IS-06
 - Update the IS-05 schemas to correct an unfortunate bug in the IS-05 v1.1 spec (see [AMWA-TV/nmos-device-connection-management#99](https://github.com/AMWA-TV/nmos-device-connection-management/pull/99))
 - Attempt to determine the DNS domain name automatically if not explicitly specified, for TR-1001-1


### PR DESCRIPTION
On some platforms the *rate* of the `steady_clock` can be significantly different than the (UTC) `system_clock`, causing obvious problems with 'scheduled absolute' IS-05 Connection API activations and with IS-04 Query API pagination with independently-produced `paging.since` and `paging.until` values. This should form part of the solution for #50 also.