### PR TITLE
Remove cpprestsdk force build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -103,8 +103,8 @@ jobs:
     - name: windows setup
       if: runner.os == 'Windows'
       run: |
-        # force build cpprestsdk, set compiler to cl.exe to avoid building with gcc.
-        echo "::set-env name=CMAKE_EXTRA_ARGS::${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_CONAN_BUILD_LIBS=cpprestsdk;missing -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe"
+        # set compiler to cl.exe to avoid building with gcc.
+        echo "::set-env name=CMAKE_EXTRA_ARGS::${{ env.CMAKE_EXTRA_ARGS }} -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe"
         # disable unused network interface
         netsh interface set interface name="vEthernet (nat)" admin=DISABLED
         # get host IP address
@@ -133,7 +133,6 @@ jobs:
     - name: mac setup
       if: runner.os == 'macOS'
       run: |
-        echo "::set-env name=CMAKE_EXTRA_ARGS::${{ env.CMAKE_EXTRA_ARGS }} '-DNMOS_CPP_CONAN_BUILD_LIBS=cpprestsdk;missing'"
         hostip=$(ipconfig getifaddr en0)
         echo "::set-env name=HOST_IP_ADDRESS::$hostip"
         ifconfig
@@ -435,8 +434,8 @@ jobs:
     - name: windows setup
       if: runner.os == 'Windows'
       run: |
-        # force build cpprestsdk, set compiler to cl.exe to avoid building with gcc.
-        echo "::set-env name=CMAKE_EXTRA_ARGS::${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_CONAN_BUILD_LIBS=cpprestsdk;missing -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe"
+        # set compiler to cl.exe to avoid building with gcc.
+        echo "::set-env name=CMAKE_EXTRA_ARGS::${{ env.CMAKE_EXTRA_ARGS }} -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe"
         # disable unused network interface
         netsh interface set interface name="vEthernet (nat)" admin=DISABLED
         # get host IP address
@@ -465,7 +464,6 @@ jobs:
     - name: mac setup
       if: runner.os == 'macOS'
       run: |
-        echo "::set-env name=CMAKE_EXTRA_ARGS::${{ env.CMAKE_EXTRA_ARGS }} '-DNMOS_CPP_CONAN_BUILD_LIBS=cpprestsdk;missing'"
         hostip=$(ipconfig getifaddr en0)
         echo "::set-env name=HOST_IP_ADDRESS::$hostip"
         ifconfig

--- a/.github/workflows/src/build-setup.yml
+++ b/.github/workflows/src/build-setup.yml
@@ -9,8 +9,8 @@
 - name: windows setup
   if: runner.os == 'Windows'
   run: |
-    # force build cpprestsdk, set compiler to cl.exe to avoid building with gcc.
-    echo "::set-env name=CMAKE_EXTRA_ARGS::${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_CONAN_BUILD_LIBS=cpprestsdk;missing -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe"
+    # set compiler to cl.exe to avoid building with gcc.
+    echo "::set-env name=CMAKE_EXTRA_ARGS::${{ env.CMAKE_EXTRA_ARGS }} -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe"
     # disable unused network interface
     netsh interface set interface name="vEthernet (nat)" admin=DISABLED
     # get host IP address
@@ -39,7 +39,6 @@
 - name: mac setup
   if: runner.os == 'macOS'
   run: |
-    echo "::set-env name=CMAKE_EXTRA_ARGS::${{ env.CMAKE_EXTRA_ARGS }} '-DNMOS_CPP_CONAN_BUILD_LIBS=cpprestsdk;missing'"
     hostip=$(ipconfig getifaddr en0)
     echo "::set-env name=HOST_IP_ADDRESS::$hostip"
     ifconfig

--- a/Documents/Dependencies.md
+++ b/Documents/Dependencies.md
@@ -58,8 +58,6 @@ By default nmos-cpp uses [Conan](https://conan.io) to download most of its depen
 
 Now follow the [Getting Started](Getting-Started.md) instructions directly. Conan is used to download the rest of the dependencies.
 
-Note: Due to [an issue](https://github.com/bincrafters/community/issues/998) with the C++ REST SDK recipe you may need to force Conan to install from source rather than using a pre-built package. In [cmake/NmosCppConan.cmake](cmake/NmosCppConan.cmake) change `BUILD missing` in `conan_cmake_run` to `BUILD missing cpprestsdk`, run CMake once then revert this change. You may need to repeat this step when switching to a new build configuration.
-
 If you prefer not to use Conan, you must install Boost, WebSocket++, OpenSSL and C++ REST SDK as detailed below then call CMake with `-DUSE_CONAN:BOOL="0"` when building nmos-cpp.
 
 ### Boost C++ Libraries


### PR DESCRIPTION
The bug in the bincrafters recipe with pre-built packages doesn't seem to be present in the conan center version, remove the documentation and update github builds