### PR TITLE
Add source map extension to the admin UI HTTP server

### DIFF
--- a/Development/nmos/admin_ui.cpp
+++ b/Development/nmos/admin_ui.cpp
@@ -42,6 +42,7 @@ namespace nmos
                 { U("ico"), U("image/x-icon") },
                 { U("html"), U("text/html") },
                 { U("js"), U("application/javascript") },
+                { U("map"), U("application/json") },
                 { U("json"), U("application/json") },
                 { U("css"), U("text/css") },
                 { U("png"), U("image/png") }


### PR DESCRIPTION
When using sony/nmos-js this allows viewing the Javascript source maps in the web inspector.

Mime-type application/json seems like a good choice, but doesn't actually matter:
https://stackoverflow.com/a/19912684/466698