### PR TITLE
Fix build with boost 1.73.0

### DIFF
--- a/Development/nmos/connection_api.cpp
+++ b/Development/nmos/connection_api.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/range/join.hpp>
 #include <boost/range/adaptor/filtered.hpp>
+#include <boost/bind/bind.hpp>
 #include "cpprest/http_utils.h"
 #include "cpprest/json_validator.h"
 #include "nmos/activation_mode.h"
@@ -100,8 +101,8 @@ namespace nmos
             {
                 nmos::experimental::load_json_schema,
                 boost::copy_range<std::vector<web::uri>>(boost::range::join(
-                    is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, _1, nmos::types::sender)),
-                    is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, _1, nmos::types::receiver))
+                    is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, boost::placeholders::_1, nmos::types::sender)),
+                    is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, boost::placeholders::_1, nmos::types::receiver))
                 ))
             };
             return validator;


### PR DESCRIPTION
Up to boost version 1.72.0, the boost placeholders (_1, _2, etc) were
defined in the global namespace. As of boost 1.73.0, these definitions
are no longer included in the global namespace, so the
boost::placeholders namespace must be explicitly specified.

boost/bind.hpp used to have a comment stating:
  For backward compatibility, this header includes
  <boost/bind/bind.hpp> and then imports the placeholders _1, _2,
  _3, ... into the global namespace. Definitions in the global
  namespace are not a good practice and this use is deprecated.
  Please switch to including <boost/bind/bind.hpp> directly,
  adding the using directive locally where appropriate.
  Alternatively, the existing behavior may be preserved by defining
  the macro BOOST_BIND_GLOBAL_PLACEHOLDERS.

As of version 1.73.0, these definitions are no longer in the global
namespace unless BOOST_BIND_GLOBAL_PLACEHOLDERS is defined.