### PR TITLE
Fix build with boost 1.73.0

### DIFF
--- a/Development/bst/placeholders.h
+++ b/Development/bst/placeholders.h
@@ -1,0 +1,51 @@
+#ifndef BST_PLACEHOLDERS_H
+#define BST_PLACEHOLDERS_H
+
+// Provide bst::placeholders using the boost::placeholders namespace (to be compatible with Boost 1.73.0 and up),
+// or the global namespace (to be compatible with Boost versions less than 1.60.0). Boost versions between 1.60.0 and 1.73.0
+// have the boost::placeholders namespace defined, and import it into the global namespace by default. Versions less than
+// 1.60.0 don't have the boost::placeholders namespace defined at all, and simply define the placeholders in the global
+// namespace.
+// As of Boost version 1.73.0, the boost::placeholders namespace is no longer globally imported by default.
+
+// From boost/bind.hpp in Boost 1.73.0:
+//   For backward compatibility, this header includes
+//  <boost/bind/bind.hpp> and then imports the placeholders _1, _2,
+//  _3, ... into the global namespace. Definitions in the global
+//  namespace are not a good practice and this use is deprecated.
+//  Please switch to including <boost/bind/bind.hpp> directly,
+//  adding the using directive locally where appropriate.
+//  Alternatively, the existing behavior may be preserved by defining
+//  the macro BOOST_BIND_GLOBAL_PLACEHOLDERS.
+
+// Between 1.60.0 and 1.73.0, the boost::placeholders namespace will be included globally by boost/bind.hpp.
+// Including boost/bind/bind.hpp instead of boost/bind.hpp prevents this.
+#if BOOST_VERSION >= 106000
+#include <boost/bind/bind.hpp>
+#else
+#include <boost/bind.hpp>
+#endif
+
+namespace bst
+{
+    // bst::placeholders is aliased by slog/all_in_one.h to std::placeholders, which is not compatible with boost::bind
+#if BOOST_VERSION >= 106000
+    namespace boost_placeholders = boost::placeholders;
+#else
+    // Prior to Boost 1.60.0, the boost placeholders were defined exclusively in the global namespace
+    namespace boost_placeholders
+    {
+        using ::_1;
+        using ::_2;
+        using ::_3;
+        using ::_4;
+        using ::_5;
+        using ::_6;
+        using ::_7;
+        using ::_8;
+        using ::_9;
+    }
+#endif // BOOST_VERSION >= 106000
+}
+
+#endif // BST_PLACEHOLDERS_H

--- a/Development/nmos/connection_api.cpp
+++ b/Development/nmos/connection_api.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/range/join.hpp>
 #include <boost/range/adaptor/filtered.hpp>
+#include "bst/placeholders.h"
 #include "cpprest/http_utils.h"
 #include "cpprest/json_validator.h"
 #include "nmos/activation_mode.h"
@@ -100,8 +101,8 @@ namespace nmos
             {
                 nmos::experimental::load_json_schema,
                 boost::copy_range<std::vector<web::uri>>(boost::range::join(
-                    is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, _1, nmos::types::sender)),
-                    is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, _1, nmos::types::receiver))
+                    is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, bst::boost_placeholders::_1, nmos::types::sender)),
+                    is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, bst::boost_placeholders::_1, nmos::types::receiver))
                 ))
             };
             return validator;


### PR DESCRIPTION
### Issue:
Building with boost 1.73.0 causes the following compiler error:

> nmos-cpp/Development/nmos/connection_api.cpp: In function ‘const web::json::experimental::json_validator& nmos::details::staged_core_validator()’:
> nmos-cpp/Development/nmos/connection_api.cpp:103:149: error: ‘_1’ was not declared in this scope
>   103 |                     is05_versions::all | boost::adaptors::transformed(boost::bind(experimental::make_connectionapi_staged_patch_request_schema_uri, _1, nmos::types::sender)),
> 

This can be reproduced by specifying boost 1.73.0 in `conanfile.txt`

As of boost 1.73.0, the boost placeholders (_1, _2, etc) are no longer imported into the global namespace by default.

[boost/bind.hpp](https://www.boost.org/doc/libs/1_73_0/boost/bind.hpp) now has a comment stating:

>   For backward compatibility, this header includes
>   <boost/bind/bind.hpp> and then imports the placeholders _1, _2,
>   _3, ... into the global namespace. Definitions in the global
>   namespace are not a good practice and this use is deprecated.
>   Please switch to including <boost/bind/bind.hpp> directly,
>   adding the using directive locally where appropriate.
>   Alternatively, the existing behavior may be preserved by defining
>   the macro BOOST_BIND_GLOBAL_PLACEHOLDERS.
> 

### Solution:
To build with boost 1.73.0, the `boost/bind/bind.hpp` header should be included and the `boost::placeholders` namespace should be used.

There are three cases that need to be considered:
- **Boost version < 1.60.0:** placeholders defined directly in the global namespace
- **Boost version >= 1.73.0:** placeholders defined in `boost::placeholders`, unless `BOOST_BIND_GLOBAL_PLACEHOLDERS` is defined.
- **Boost version >= 1.60.0 and < 1.73.0:** placeholders defined in `boost::placeholders`, but imported into the global namespace

Because the `boost::placeholders` namespace is defined for versions 1.60.0 and up, this can be reduced to a single version check.

To maintain backwards compatibility with old Boost versions, a new namespace (`bst::boost_placeholders`) has been introduced which is aliased to `boost::placeholders` if the Boost version is >= 1.60.0, and aliased to the placeholders in the global namespace if the Boost version is < 1.60.0.

`bst::placeholders` would be a better name than `bst::boost_placeholders`, but `slog/all_in_one.h` already aliases it to `std::placeholders`, which isn't compatible with `boost::bind`.