### PR TITLE
revert workaround for nmos-testing on mac

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,12 +71,6 @@ jobs:
       run: |
         pip install conan
     
-    # conan specifies an old version of crypography on macOS which causes nmos-testing to crash
-    - name: update python crypography
-      if: matrix.use_conan == true && runner.os == 'macOS'
-      run: |
-        pip install cryptography --upgrade
-    
     - name: install cmake
       uses: lukka/get-cmake@v3.18.3
     
@@ -437,12 +431,6 @@ jobs:
       if: matrix.use_conan == true
       run: |
         pip install conan
-    
-    # conan specifies an old version of crypography on macOS which causes nmos-testing to crash
-    - name: update python crypography
-      if: matrix.use_conan == true && runner.os == 'macOS'
-      run: |
-        pip install cryptography --upgrade
     
     - name: install cmake
       uses: lukka/get-cmake@v3.18.3

--- a/.github/workflows/src/build-setup.yml
+++ b/.github/workflows/src/build-setup.yml
@@ -3,12 +3,6 @@
   run: |
     pip install conan
 
-# conan specifies an old version of crypography on macOS which causes nmos-testing to crash
-- name: update python crypography
-  if: matrix.use_conan == true && runner.os == 'macOS'
-  run: |
-    pip install cryptography --upgrade
-
 - name: install cmake
   uses: lukka/get-cmake@v3.18.3
 


### PR DESCRIPTION
should no longer be necessary with conan 1.31.1