### PR TITLE
Change to get a bigger buffer for GetAdapterAddresses when original is not big enough

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -158,7 +158,6 @@ jobs:
         echo "DOCKER_HOST=$DOCKER_HOST" >> $GITHUB_ENV
         echo "DOCKER_CERT_PATH=$DOCKER_CERT_PATH" >> $GITHUB_ENV
     
-    
     - name: ubuntu setup
       if: runner.os == 'Linux'
       run: |
@@ -168,6 +167,8 @@ jobs:
         ip address
         # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
         echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts
+        # re-synchronize the package index
+        sudo apt-get update -q
     
     - name: ubuntu mdns install
       if: runner.os == 'Linux' && matrix.install_mdns == true
@@ -519,7 +520,6 @@ jobs:
         echo "DOCKER_HOST=$DOCKER_HOST" >> $GITHUB_ENV
         echo "DOCKER_CERT_PATH=$DOCKER_CERT_PATH" >> $GITHUB_ENV
     
-    
     - name: ubuntu setup
       if: runner.os == 'Linux'
       run: |
@@ -529,6 +529,8 @@ jobs:
         ip address
         # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
         echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts
+        # re-synchronize the package index
+        sudo apt-get update -q
     
     - name: ubuntu mdns install
       if: runner.os == 'Linux' && matrix.install_mdns == true

--- a/.github/workflows/src/build-setup.yml
+++ b/.github/workflows/src/build-setup.yml
@@ -90,7 +90,6 @@
     echo "DOCKER_HOST=$DOCKER_HOST" >> $GITHUB_ENV
     echo "DOCKER_CERT_PATH=$DOCKER_CERT_PATH" >> $GITHUB_ENV
 
-
 - name: ubuntu setup
   if: runner.os == 'Linux'
   run: |
@@ -100,6 +99,8 @@
     ip address
     # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
     echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts
+    # re-synchronize the package index
+    sudo apt-get update -q
 
 - name: ubuntu mdns install
   if: runner.os == 'Linux' && matrix.install_mdns == true

--- a/Development/cmake/NmosCppLibraries.cmake
+++ b/Development/cmake/NmosCppLibraries.cmake
@@ -8,6 +8,7 @@ endif()
 # detail headers
 
 set(DETAIL_HEADERS
+    ${NMOS_CPP_DIR}/detail/default_init_allocator.h
     ${NMOS_CPP_DIR}/detail/for_each_reversed.h
     ${NMOS_CPP_DIR}/detail/pragma_warnings.h
     ${NMOS_CPP_DIR}/detail/private_access.h

--- a/Development/detail/default_init_allocator.h
+++ b/Development/detail/default_init_allocator.h
@@ -1,0 +1,34 @@
+#ifndef DETAIL_DEFAULT_INIT_ALLOCATOR_H
+#define DETAIL_DEFAULT_INIT_ALLOCATOR_H
+
+namespace detail
+{
+    // Allocator adaptor that interposes construct() calls to convert value initialization into default initialization.
+    // See https://stackoverflow.com/a/21028912
+    template <typename T, typename A = std::allocator<T>>
+    class default_init_allocator : public A
+    {
+        typedef std::allocator_traits<A> a_t;
+
+    public:
+        template <typename U> struct rebind
+        {
+            using other = default_init_allocator<U, typename a_t::template rebind_alloc<U>>;
+        };
+
+        using A::A;
+
+        template <typename U>
+        void construct(U* ptr) noexcept(std::is_nothrow_default_constructible<U>::value)
+        {
+            ::new(static_cast<void*>(ptr)) U;
+        }
+        template <typename U, typename ...Args>
+        void construct(U* ptr, Args&&... args)
+        {
+            a_t::construct(static_cast<A&>(*this), ptr, std::forward<Args>(args)...);
+        }
+    };
+}
+
+#endif

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -1,6 +1,5 @@
 #include "node_implementation.h"
 
-#include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/find_first_of.hpp>
@@ -178,13 +177,7 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate_)
 
     const auto clocks = web::json::value_of({ nmos::make_internal_clock(nmos::clock_names::clk0) });
     // filter network interfaces to those that correspond to the specified host_addresses
-    const auto host_interfaces = boost::copy_range<std::vector<web::hosts::experimental::host_interface>>(web::hosts::experimental::host_interfaces() | boost::adaptors::filtered([&](const web::hosts::experimental::host_interface& interface)
-    {
-        return interface.addresses.end() != boost::range::find_first_of(interface.addresses, nmos::fields::host_addresses(model.settings), [](const utility::string_t& interface_address, const web::json::value& host_address)
-        {
-            return interface_address == host_address.as_string();
-        });
-    }));
+    const auto host_interfaces = nmos::get_host_interfaces(model.settings);
     const auto interfaces = nmos::experimental::node_interfaces(host_interfaces);
 
     // example node

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -3,6 +3,17 @@
 
 #include "cpprest/json_utils.h"
 
+namespace web
+{
+    namespace hosts
+    {
+        namespace experimental
+        {
+            struct host_interface;
+        }
+    }
+}
+
 // Configuration settings and defaults
 namespace nmos
 {
@@ -25,6 +36,9 @@ namespace nmos
 
     // Get host name and/or addresses to be used to construct host and URL fields in the data model
     std::vector<utility::string_t> get_hosts(const settings& settings);
+
+    // Get interfaces corresponding to the host addresses in the settings
+    std::vector<web::hosts::experimental::host_interface> get_host_interfaces(const settings& settings);
 
     // Get a summary of the build configuration, including versions of dependencies
     utility::string_t get_build_settings_info();


### PR DESCRIPTION
The call to GetAdapterAddresses starts out with a buffer of 15000 bytes. If this buffer is not big enough, the call to GetAdapterAddresses returns with error code ERROR_BUFFER_OVERFLOW and returns the size of how big the buffer should be. This change looks for that error code, allocates a bigger buffer and calls GetAdapterAddresses again in order to avoid the error.
