### PR TITLE
Preparatory work for supporting ST 2110-22 and JPEG XS

### DIFF
--- a/Development/nmos/media_type.h
+++ b/Development/nmos/media_type.h
@@ -16,7 +16,13 @@ namespace nmos
     {
         // Video media types
 
+        // Uncompressed Video
+        // See https://tools.ietf.org/html/rfc4175#section-6
         const media_type video_raw{ U("video/raw") };
+
+        // JPEG XS
+        // See https://tools.ietf.org/html/draft-ietf-payload-rtp-jpegxs-09#section-6
+        const media_type video_jxsv{ U("video/jxsv") };
 
         // Audio media types
 


### PR DESCRIPTION
As per #177, some of the SDP-related convenience/utility functions like `nmos::make_video_sdp_parameters` and `nmos::get_session_description_sdp_parameters` (and the `sdp_parameters` struct itself probably!) need improving to handle `video/jxsv`, if not other coded video formats. This doesn't try to do any of any that, but adds some of the constants that will be required.