### PR TITLE
Fix SEGFAULT while running testWebSocketListenerCloseOpen on macOS

### DIFF
--- a/Development/cpprest/ws_listener_impl.cpp
+++ b/Development/cpprest/ws_listener_impl.cpp
@@ -289,6 +289,7 @@ namespace web
                     public:
                         explicit websocket_listener_wspp(web::uri address, websocket_listener_config config)
                             : websocket_listener_impl(std::move(address), std::move(config))
+                            , init(false)
                         {
                             // since we cannot set the callback function before the server constructor we can't get log message from that
                             server.get_alog().set_log_handler(configuration().get_log_callback());
@@ -309,9 +310,10 @@ namespace web
                             try
                             {
                                 // either initialise or restart the io_service
-                                if (0 == &server.get_io_service())
+                                if (!init)
                                 {
                                     server.init_asio();
+                                    init = true;
                                 }
                                 else
                                 {
@@ -635,6 +637,7 @@ namespace web
                         server_t server;
                         connections_t connections;
                         std::mutex mutex;
+                        bool init; // flag to identify whether to initialise or restart the io_service
                     };
 
                     std::unique_ptr<websocket_listener_impl> make_websocket_listener_impl(web::uri&& address, websocket_listener_config&& config)


### PR DESCRIPTION
This could be due to `Reference cannot be bound to dereferenced null pointer` while executing `&server.get_io_service()` for determining whether to initialise or restart the io_service. This can be done, using a `boolean flag` to identify the status of the io_service instead of calling `&server.get_io_service()`