### PR TITLE
Little unit test tweak

### DIFF
--- a/Development/nmos/test/json_validator_test.cpp
+++ b/Development/nmos/test/json_validator_test.cpp
@@ -36,10 +36,11 @@ BST_TEST_CASE(testInvalidTypeSchema)
                         { U("type"), U("string") },
                         { U("pattern"), U("^auto$") }
                     }, keep_order),
-                    U("bad") })
-                }})
+                    U("bad")
+                })
             }})
-        }});
+        }})
+    }});
 
    // invalid JSON-type for schema
    BST_REQUIRE_THROW(make_validator(schema, id), std::invalid_argument);
@@ -65,12 +66,12 @@ BST_TEST_CASE(testEnumSchema)
                     value_of({
                         { U("enum"), value_of({
                             { U("good") }
-                            })
-                        }})
-                    })
-                }})
+                        })
+                    }})
+                })
             }})
-        }});
+        }})
+    }});
 
     auto validator = make_validator(schema, id);
 

--- a/Development/nmos/test/query_api_test.cpp
+++ b/Development/nmos/test/query_api_test.cpp
@@ -20,7 +20,8 @@ BST_TEST_CASE(testQueryAPISubscriptionsExtensionSchema)
         boost::copy_range<std::vector<web::uri>>(nmos::is04_versions::all | boost::adaptors::transformed(nmos::experimental::make_queryapi_subscriptions_post_request_schema_uri))
     };
 
-    // valid subscriptions data
+    // valid subscriptions post request data
+    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.x/examples/queryapi-subscriptions-post-request.json
     auto data = value_of({
         { U("max_update_rate_ms"), 100 },
         { U("resource_path"), U("/nodes") },
@@ -28,19 +29,14 @@ BST_TEST_CASE(testQueryAPISubscriptionsExtensionSchema)
             { U("label"), U("host1") }
         }) },
         { U("persist"), false },
-        { U("secure"), false },
-        { U("authorization"), false },
-        { U("ws_href"), U("ws://172.29.80.52:8870/ws/?uid=7c903667-7113-4a8f-8865-1c63f9070a9e") },
-        { U("id"), U("7c903667-7113-4a8f-8865-1c63f9070a9e") }
+        { U("secure"), false }
     });
 
-    // valid subscriptions
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.x/examples/queryapi-subscriptions-post-200.json
+    // validate successfully, i.e. no exception
+    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.x/APIs/schemas/queryapi-subscriptions-post-request.json
     validator.validate(data, nmos::experimental::make_queryapi_subscriptions_post_request_schema_uri(nmos::is04_versions::v1_3));
-    BST_REQUIRE(true);
 
     // empty path, for experimental extension
     data[U("resource_path")] = value::string(U(""));
     validator.validate(data, nmos::experimental::make_queryapi_subscriptions_post_request_schema_uri(nmos::is04_versions::v1_3));
-    BST_REQUIRE(true);
 }


### PR DESCRIPTION
Little change so that the test doesn't use post _response_ example data to test the post _request_ schema.

The _response_ data does in fact validate against the _request_ schema but the `id` and `ws_href` are supposed to be allocated by the Query API, not by the client. The test could also check the `POST` response or `GET` data against the other schema, but the important thing is whether a new `POST` request validates.