### PR TITLE
Allow a preferred registration URL to be specified (node behaviour)

### DIFF
--- a/Development/nmos/node_behaviour.cpp
+++ b/Development/nmos/node_behaviour.cpp
@@ -231,11 +231,6 @@ namespace nmos
         {
             std::list<web::uri> registration_services;
 
-            if (!preferred_registration_service.is_empty())
-            {
-                registration_services.push_back(preferred_registration_service);
-            }
-
             if (nmos::service_priorities::no_priority != priorities.first)
             {
                 slog::log<slog::severities::info>(gate, SLOG_FLF) << "Attempting discovery of a Registration API in domain: " << browse_domain;
@@ -250,6 +245,11 @@ namespace nmos
                 {
                     slog::log<slog::severities::warning>(gate, SLOG_FLF) << "Did not discover a suitable Registration API via DNS-SD";
                 }
+            }
+
+            if (!preferred_registration_service.is_empty())
+            {
+                registration_services.push_front(preferred_registration_service);
             }
 
             if (registration_services.empty())

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -105,6 +105,15 @@ namespace nmos
         // registry_version [node]: used to construct request URLs for registry APIs (if not discovered via DNS-SD)
         const web::json::field_as_string_or registry_version{ U("registry_version"), U("v1.3") };
 
+        // preferred_registry_address [node]: used to construct request URLs for preferred registry API (tried before discovery phase)
+        const web::json::field_as_string preferred_registry_address{ U("preferred_registry_address") };
+
+        // preferred_registration_port [node]: used to construct request URLs for preferred registry API (tried before discovery phase)
+        const web::json::field_as_integer_or preferred_registration_port{ U("preferred_registration_port"), 3210 };
+
+        // preferred_registry_version [node]: used to construct request URLs for preferred registry API (tried before discovery phase)
+        const web::json::field_as_string_or preferred_registry_version{ U("preferred_registry_version"), U("v1.3") };
+
         // port numbers [registry, node]: ports to which clients should connect for each API
 
         // http_port [registry, node]: if specified, used in preference to the individual defaults for each HTTP API


### PR DESCRIPTION
Currently in the node behaviour it's only possible to provide a fallback registration URL to try in the event that mDNS discovery doesn't yield a registration endpoint to connect to. This change adds three new config keys for hostname (or IP address), port and API version (the latter two have sensible defaults) to request that the node attempt to connect to a preferred registration endpoint ahead of the list generated by the discovery process. This allows for a specific registration endpoint to be used that isn't advertised by DNS-SD or one regardless of the PRI value in the mDNS record. If the preferred URL is unavailable, it'll be popped off the list must like mDNS discovered entries. If the preferred hostname is not specified, behaviour will be as it is now.