### PR TITLE
Terminate runing request before closing the server to fix issue #189

### DIFF
--- a/Development/cpprest/api_router.h
+++ b/Development/cpprest/api_router.h
@@ -52,6 +52,9 @@ namespace web
                     // provide an exception handler for this route and sub-routes (using std::current_exception, etc.)
                     void set_exception_handler(route_handler handler);
 
+                    // flag to indicate whether the router has been canceled, this flag is used to terminate the routers iteraton loop
+                    void set_canceled(bool canceled);
+
                 private:
                     enum match_flag_type { match_entire = 0, match_prefix = 1 };
                     typedef std::pair<utility::regex_t, utility::named_sub_matches_t> regex_named_sub_matches_type;
@@ -73,6 +76,8 @@ namespace web
 
                     route_handlers routes;
                     route_handler exception_handler;
+
+                    bool canceled;
                 };
 
                 // convenient using declarations to make defining routers less verbose

--- a/Development/nmos/server.cpp
+++ b/Development/nmos/server.cpp
@@ -58,6 +58,12 @@ namespace nmos
         {
             // Open the API ports
 
+            // reset API routers termination flag
+            for (auto& router : api_routers)
+            {
+                router.second.set_canceled(false);
+            }
+
             std::vector<pplx::task<void>> tasks;
 
             for (auto& http_listener : http_listeners)
@@ -83,6 +89,12 @@ namespace nmos
         return pplx::create_task([&]
         {
             // Close the API ports
+
+            // terminate API routers
+            for (auto& router : api_routers)
+            {
+                router.second.set_canceled(true);
+            }
 
             std::vector<pplx::task<void>> tasks;
 


### PR DESCRIPTION
Ensure the api router is completed/terminated before returning to the http_listener request handler.  This will prevent the API routers to be deleted before the http_listeners while deleting the server instance.