### PR TITLE
Extend api_router lifetime to handle in-progress requests when server is closed

### DIFF
--- a/Development/cpprest/api_router.cpp
+++ b/Development/cpprest/api_router.cpp
@@ -77,6 +77,9 @@ namespace web
                                 res.set_status_code(status_codes::NotFound);
                             }
 
+                            // the task returned by reply() silently 'observes' any exception thrown from the underlying server
+                            // reply() itself can throw http_exception if a response has already been sent, but that would indicate a programming error
+                            // so don't handle exceptions with the specified exception handler here
                             req.reply(res);
                         }
                     });

--- a/Development/cpprest/test/api_router_test.cpp
+++ b/Development/cpprest/test/api_router_test.cpp
@@ -19,10 +19,10 @@ BST_TEST_CASE(testMakeListenerUri)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
-BST_TEST_CASE_PRIVATE(testGetRouteRelativePath)
+BST_TEST_CASE(testGetRouteRelativePath)
 {
     using utility::us2s;
-    using web::http::experimental::listener::api_router;
+    using web::http::experimental::listener::details::get_route_relative_path;
     using web::http::http_exception;
 
     web::http::http_request req;
@@ -30,47 +30,49 @@ BST_TEST_CASE_PRIVATE(testGetRouteRelativePath)
 
     // clear specification
 
-    BST_REQUIRE_STRING_EQUAL("/foo/bar/baz", us2s(api_router::get_route_relative_path(req, U(""))));
-    BST_REQUIRE_STRING_EQUAL("/bar/baz", us2s(api_router::get_route_relative_path(req, U("/foo"))));
-    BST_REQUIRE_STRING_EQUAL("", us2s(api_router::get_route_relative_path(req, U("/foo/bar/baz"))));
-    BST_REQUIRE_THROW(api_router::get_route_relative_path(req, U("/qux")), http_exception);
+    BST_REQUIRE_STRING_EQUAL("/foo/bar/baz", us2s(get_route_relative_path(req, U(""))));
+    BST_REQUIRE_STRING_EQUAL("/bar/baz", us2s(get_route_relative_path(req, U("/foo"))));
+    BST_REQUIRE_STRING_EQUAL("", us2s(get_route_relative_path(req, U("/foo/bar/baz"))));
+    BST_REQUIRE_THROW(get_route_relative_path(req, U("/qux")), http_exception);
 
     // less clear specification
 
     // compatible with http_request::relative_uri(), but should it be "foo/bar/baz"?
-    BST_CHECK_STRING_EQUAL("/foo/bar/baz", us2s(api_router::get_route_relative_path(req, U("/"))));
+    BST_CHECK_STRING_EQUAL("/foo/bar/baz", us2s(get_route_relative_path(req, U("/"))));
 
     // should it be "/bar/baz"?
-    BST_CHECK_STRING_EQUAL("bar/baz", us2s(api_router::get_route_relative_path(req, U("/foo/"))));
+    BST_CHECK_STRING_EQUAL("bar/baz", us2s(get_route_relative_path(req, U("/foo/"))));
 
     // should it throw, no match?
-    BST_CHECK_STRING_EQUAL("ar/baz", us2s(api_router::get_route_relative_path(req, U("/foo/b"))));
+    BST_CHECK_STRING_EQUAL("ar/baz", us2s(get_route_relative_path(req, U("/foo/b"))));
 
     // should it be ""?
-    BST_CHECK_THROW(api_router::get_route_relative_path(req, U("/foo/bar/baz/")), http_exception);
+    BST_CHECK_THROW(get_route_relative_path(req, U("/foo/bar/baz/")), http_exception);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
-BST_TEST_CASE_PRIVATE(testRouteRegexMatch)
+BST_TEST_CASE(testRouteRegexMatch)
 {
-    using web::http::experimental::listener::api_router;
+    using web::http::experimental::listener::details::match_entire;
+    using web::http::experimental::listener::details::match_prefix;
+    using web::http::experimental::listener::details::route_regex_match;
 
     utility::smatch_t route_match;
 
-    BST_REQUIRE(api_router::route_regex_match(U("/foo/bar/baz"), route_match, utility::regex_t(U("/f../b../b..")), api_router::match_entire));
-    BST_REQUIRE(api_router::route_regex_match(U("/foo/bar/baz"), route_match, utility::regex_t(U("/f../b../b..")), api_router::match_prefix));
+    BST_REQUIRE(route_regex_match(U("/foo/bar/baz"), route_match, utility::regex_t(U("/f../b../b..")), match_entire));
+    BST_REQUIRE(route_regex_match(U("/foo/bar/baz"), route_match, utility::regex_t(U("/f../b../b..")), match_prefix));
 
-    BST_REQUIRE(!api_router::route_regex_match(U("/foo/bar/baz/qux"), route_match, utility::regex_t(U("/f../b../b..")), api_router::match_entire));
-    BST_REQUIRE(api_router::route_regex_match(U("/foo/bar/baz/qux"), route_match, utility::regex_t(U("/f../b../b..")), api_router::match_prefix));
+    BST_REQUIRE(!route_regex_match(U("/foo/bar/baz/qux"), route_match, utility::regex_t(U("/f../b../b..")), match_entire));
+    BST_REQUIRE(route_regex_match(U("/foo/bar/baz/qux"), route_match, utility::regex_t(U("/f../b../b..")), match_prefix));
 
-    BST_REQUIRE(!api_router::route_regex_match(U("/foo/bar/qux"), route_match, utility::regex_t(U("/f../b../b..")), api_router::match_prefix));
-    BST_REQUIRE(!api_router::route_regex_match(U("/qux/foo/bar/baz"), route_match, utility::regex_t(U("/f../b../b..")), api_router::match_prefix));
+    BST_REQUIRE(!route_regex_match(U("/foo/bar/qux"), route_match, utility::regex_t(U("/f../b../b..")), match_prefix));
+    BST_REQUIRE(!route_regex_match(U("/qux/foo/bar/baz"), route_match, utility::regex_t(U("/f../b../b..")), match_prefix));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
-BST_TEST_CASE_PRIVATE(testGetParameters)
+BST_TEST_CASE(testGetParameters)
 {
-    using web::http::experimental::listener::api_router;
+    using web::http::experimental::listener::details::get_parameters;
     using web::http::experimental::listener::route_parameters;
 
     const utility::string_t path{ U("ABCD") };
@@ -86,5 +88,5 @@ BST_TEST_CASE_PRIVATE(testGetParameters)
 
     utility::smatch_t route_match;
     BST_REQUIRE(bst::regex_match(path, route_match, route_regex));
-    BST_REQUIRE(expected == api_router::get_parameters(parameter_sub_matches, route_match));
+    BST_REQUIRE(expected == get_parameters(parameter_sub_matches, route_match));
 }

--- a/Development/nmos/api_utils.cpp
+++ b/Development/nmos/api_utils.cpp
@@ -568,6 +568,8 @@ namespace nmos
 
                 slog::detail::logw<slog::log_statement, slog::base_gate>(gate, slog::severities::more_info, SLOG_FLF) << nmos::stash_categories({ nmos::categories::access }) << nmos::common_log_stash(req, res) << "Sending response after " << processing_dur << "ms";
 
+                // the task returned by reply() silently 'observes' any exception thrown from the underlying server
+                // reply() itself can throw http_exception if a response has already been sent, but that would indicate a programming error
                 req.reply(res);
                 return pplx::task_from_result(false); // don't continue matching routes
             };

--- a/Development/nmos/api_utils.h
+++ b/Development/nmos/api_utils.h
@@ -126,16 +126,16 @@ namespace nmos
     // add handler to set appropriate response headers, and error response body if indicated - call this only after adding all others!
     void add_api_finally_handler(web::http::experimental::listener::api_router& api, slog::base_gate& gate);
 
-    // modify the specified API to handle all requests (including CORS preflight requests via "OPTIONS") and attach it to the specified listener - captures api by reference!
-    void support_api(web::http::experimental::listener::http_listener& listener, web::http::experimental::listener::api_router& api, slog::base_gate& gate);
+    // modify the specified API to handle all requests (including CORS preflight requests via "OPTIONS") and attach it to the specified listener
+    void support_api(web::http::experimental::listener::http_listener& listener, web::http::experimental::listener::api_router api, slog::base_gate& gate);
 
     // construct an http_listener on the specified address and port, modifying the specified API to handle all requests
-    // (including CORS preflight requests via "OPTIONS") - captures api by reference!
-    web::http::experimental::listener::http_listener make_api_listener(bool secure, const utility::string_t& host_address, int port, web::http::experimental::listener::api_router& api, web::http::experimental::listener::http_listener_config config, slog::base_gate& gate);
+    // (including CORS preflight requests via "OPTIONS")
+    web::http::experimental::listener::http_listener make_api_listener(bool secure, const utility::string_t& host_address, int port, web::http::experimental::listener::api_router api, web::http::experimental::listener::http_listener_config config, slog::base_gate& gate);
 
     // construct an http_listener on the specified port, modifying the specified API to handle all requests
-    // (including CORS preflight requests via "OPTIONS") - captures api by reference!
-    inline web::http::experimental::listener::http_listener make_api_listener(int port, web::http::experimental::listener::api_router& api, web::http::experimental::listener::http_listener_config config, slog::base_gate& gate)
+    // (including CORS preflight requests via "OPTIONS")
+    inline web::http::experimental::listener::http_listener make_api_listener(int port, web::http::experimental::listener::api_router api, web::http::experimental::listener::http_listener_config config, slog::base_gate& gate)
     {
         return make_api_listener(false, web::http::experimental::listener::host_wildcard, port, api, config, gate);
     }


### PR DESCRIPTION
Intended to resolve #189 based on discussion following the alternative PR #190.

(fa71bcc) Give `api_router` a shared implementation, which means we can capture `api_router`s into the `http_listener`s by value rather than reference. (e0b3928) Extend its lifetime into the continuations that implement the asynchronous route matching.

Note that an asynchronous call of `req.reply(res)` intended to send a response, can still happen _after_ the `http_listener` is closed by the `nmos::server`, but this is handled by C++ REST SDK, which will have immediately sent a `500` (Internal Server Error) response, and silently ignores the attempt to send the asynchronous response, without generating an exception.

I think we may want to review the capture of the handlers by reference in `make_ws_api_listener`, but I believe it's less of an issue due to how `websocket_listener` is implemented.