### PR TITLE
SDP fixes

### DIFF
--- a/Development/bst/filesystem.h
+++ b/Development/bst/filesystem.h
@@ -82,6 +82,7 @@ namespace bst
         using bst_filesystem::file_size;
         using bst_filesystem::create_directory;
         using bst_filesystem::remove_all;
+        using bst_filesystem::temp_directory_path;
     }
 }
 

--- a/Development/cmake/NmosCppTest.cmake
+++ b/Development/cmake/NmosCppTest.cmake
@@ -46,6 +46,7 @@ set(NMOS_CPP_TEST_NMOS_TEST_SOURCES
     nmos/test/json_validator_test.cpp
     nmos/test/paging_utils_test.cpp
     nmos/test/query_api_test.cpp
+    nmos/test/sdp_utils_test.cpp
     nmos/test/system_resources_test.cpp
     )
 set(NMOS_CPP_TEST_NMOS_TEST_HEADERS

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -25,16 +25,20 @@ namespace nmos
     // deprecated, provided for backwards compatibility, because it may be necessary to also specify the PTP domain to generate an RFC 7273 'ts-refclk' attribute that meets the additional constraints of ST 2110-10
     sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids);
 
-    web::json::value make_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params);
+    // Sender/Receiver helper functions
+
+    // Make a json representation of an SDP file, e.g. for sdp::make_session_description, from the specified parameters; explicitly specify whether 'source-filter' attributes are included to override the default behaviour
+    web::json::value make_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params, bst::optional<bool> source_filters = bst::nullopt);
 
     // Receiver helper functions
 
-    // Get transport parameters from the parsed SDP file
+    // Get IS-05 transport parameters from the json representation of an SDP file, e.g. from sdp::parse_session_description
     web::json::value get_session_description_transport_params(const web::json::value& session_description);
 
-    // Get other SDP parameters from the parsed SDP file
+    // Get other SDP parameters from the json representation of an SDP file, e.g. from sdp::parse_session_description
     sdp_parameters get_session_description_sdp_parameters(const web::json::value& session_description);
 
+    // Get SDP parameters from the json representation of an SDP file, e.g. from sdp::parse_session_description
     std::pair<sdp_parameters, web::json::value> parse_session_description(const web::json::value& session_description);
 
     void validate_sdp_parameters(const web::json::value& receiver, const sdp_parameters& sdp_params);
@@ -235,7 +239,7 @@ namespace nmos
             utility::string_t clock_parameters;
 
             mediaclk_t() {}
-            mediaclk_t(const sdp::mediaclk_source& clock_source, const utility::string_t& clock_parameters)
+            mediaclk_t(const sdp::mediaclk_source& clock_source, const utility::string_t& clock_parameters = {})
                 : clock_source(clock_source)
                 , clock_parameters(clock_parameters)
             {}

--- a/Development/nmos/test/sdp_utils_test.cpp
+++ b/Development/nmos/test/sdp_utils_test.cpp
@@ -1,0 +1,255 @@
+// The first "test" is of course whether the header compiles standalone
+#include "nmos/sdp_utils.h"
+
+#include "bst/test/test.h"
+#include "nmos/json_fields.h"
+#include "sdp/sdp.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testInterpretationOfSdpFilesUnicast)
+{
+    using web::json::value;
+    using web::json::value_of;
+
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#unicast
+
+    const std::string test_sdp = R"(v=0
+o=- 2890844526 2890842807 IN IP4 10.47.16.5
+s=SDP Example
+c=IN IP4 10.46.16.34/127
+t=2873397496 2873404696
+a=recvonly
+m=video 51372 RTP/AVP 99
+a=rtpmap:99 h263-1998/90000
+)";
+
+    const auto test_params = value_of({
+        value_of({
+            { nmos::fields::source_ip, value::null() },
+            { nmos::fields::multicast_ip, value::null() },
+            { nmos::fields::interface_ip, U("10.46.16.34") },
+            { nmos::fields::destination_port, 51372 },
+            { nmos::fields::rtp_enabled, true },
+        })
+    });
+
+    auto session_description = sdp::parse_session_description(test_sdp);
+    auto transport_params = nmos::get_session_description_transport_params(session_description);
+
+    BST_REQUIRE(test_params == transport_params);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testInterpretationOfSdpFilesSourceSpecificMulticast)
+{
+    using web::json::value;
+    using web::json::value_of;
+
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#source-specific-multicast
+
+    const std::string test_sdp = R"(v=0
+o=- 1497010742 1497010742 IN IP4 172.29.26.24
+s=SDP Example
+t=2873397496 2873404696
+m=video 5000 RTP/AVP 103
+c=IN IP4 232.21.21.133/32
+a=source-filter:incl IN IP4 232.21.21.133 172.29.226.24
+a=rtpmap:103 raw/90000
+)";
+
+    const auto test_params = value_of({
+        value_of({
+            { nmos::fields::source_ip, U("172.29.226.24") },
+            { nmos::fields::multicast_ip, U("232.21.21.133") },
+            { nmos::fields::interface_ip, U("auto") },
+            { nmos::fields::destination_port, 5000 },
+            { nmos::fields::rtp_enabled, true },
+        })
+    });
+
+    auto session_description = sdp::parse_session_description(test_sdp);
+    auto transport_params = nmos::get_session_description_transport_params(session_description);
+
+    BST_REQUIRE(test_params == transport_params);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testInterpretationOfSdpFilesSeparateSourceAddresses)
+{
+    using web::json::value;
+    using web::json::value_of;
+
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#separate-source-addresses
+
+    const std::string test_sdp = R"(v=0
+o=ali 1122334455 1122334466 IN IP4 dup.example.com
+s=DUP Grouping Semantics
+t=0 0
+m=video 30000 RTP/AVP 100
+c=IN IP4 233.252.0.1/127
+a=source-filter:incl IN IP4 233.252.0.1 198.51.100.1 198.51.100.2
+a=rtpmap:100 MP2T/90000
+a=ssrc:1000 cname:ch1@example.com
+a=ssrc:1010 cname:ch1@example.com
+a=ssrc-group:DUP 1000 1010
+a=mid:Ch1
+)";
+
+    const auto test_params = value_of({
+        value_of({
+            { nmos::fields::source_ip, U("198.51.100.1") },
+            { nmos::fields::multicast_ip, U("233.252.0.1") },
+            { nmos::fields::interface_ip, U("auto") },
+            { nmos::fields::destination_port, 30000 },
+            { nmos::fields::rtp_enabled, true },
+        }),
+        value_of({
+            { nmos::fields::source_ip, U("198.51.100.2") },
+            { nmos::fields::multicast_ip, U("233.252.0.1") },
+            { nmos::fields::interface_ip, U("auto") },
+            { nmos::fields::destination_port, 30000 },
+            { nmos::fields::rtp_enabled, true },
+        })
+    });
+
+    auto session_description = sdp::parse_session_description(test_sdp);
+    auto transport_params = nmos::get_session_description_transport_params(session_description);
+
+    BST_REQUIRE(test_params == transport_params);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testInterpretationOfSdpFilesSeparateDestinationAddresses)
+{
+    using web::json::value;
+    using web::json::value_of;
+
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#separate-destination-addresses
+
+    const std::string test_sdp = R"(v=0
+o=ali 1122334455 1122334466 IN IP4 dup.example.com
+s=DUP Grouping Semantics
+t=0 0
+a=group:DUP S1a S1b
+m=video 30000 RTP/AVP 100
+c=IN IP4 233.252.0.1/127
+a=source-filter:incl IN IP4 233.252.0.1 198.51.100.1
+a=rtpmap:100 MP2T/90000
+a=mid:S1a
+m=video 30000 RTP/AVP 101
+c=IN IP4 233.252.0.2/127
+a=source-filter:incl IN IP4 233.252.0.2 198.51.100.1
+a=rtpmap:101 MP2T/90000
+a=mid:S1b
+)";
+
+    const auto test_params = value_of({
+        value_of({
+            { nmos::fields::source_ip, U("198.51.100.1") },
+            { nmos::fields::multicast_ip, U("233.252.0.1") },
+            { nmos::fields::interface_ip, U("auto") },
+            { nmos::fields::destination_port, 30000 },
+            { nmos::fields::rtp_enabled, true },
+        }),
+        value_of({
+            { nmos::fields::source_ip, U("198.51.100.1") },
+            { nmos::fields::multicast_ip, U("233.252.0.2") },
+            { nmos::fields::interface_ip, U("auto") },
+            { nmos::fields::destination_port, 30000 },
+            { nmos::fields::rtp_enabled, true },
+        })
+    });
+
+    auto session_description = sdp::parse_session_description(test_sdp);
+    auto transport_params = nmos::get_session_description_transport_params(session_description);
+
+    BST_REQUIRE(test_params == transport_params);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testSdpTransportParamsUnicast)
+{
+    using web::json::value;
+    using web::json::value_of;
+
+    const auto test_params = nmos::sdp_parameters(U("SDP Example"), nmos::sdp_parameters::video_t{}, 99);
+
+    const auto test_sender_params = value_of({
+        value_of({
+            { nmos::fields::source_ip, U("10.46.116.34") },
+            { nmos::fields::destination_ip, U("10.46.16.34") },
+            { nmos::fields::source_port, 5004 },
+            { nmos::fields::destination_port, 51372 },
+            { nmos::fields::rtp_enabled, true }
+        })
+    });
+
+    for (int i = 0; i < 2; ++i)
+    {
+        const bool source_filters = i == 0;
+
+        const auto test_receiver_params = value_of({
+            value_of({
+                { nmos::fields::source_ip, source_filters ? value::string(U("10.46.116.34")) : value::null() },
+                { nmos::fields::multicast_ip, value::null() },
+                { nmos::fields::interface_ip, U("10.46.16.34") },
+                { nmos::fields::destination_port, 51372 },
+                { nmos::fields::rtp_enabled, true },
+            })
+        });
+
+        const auto sender_sdp = nmos::make_session_description(test_params, test_sender_params, source_filters);
+        auto receiver_params = nmos::get_session_description_transport_params(sender_sdp);
+        BST_REQUIRE(test_receiver_params == receiver_params);
+
+        const auto receiver_sdp = nmos::make_session_description(test_params, receiver_params);
+        receiver_params = nmos::get_session_description_transport_params(receiver_sdp);
+        BST_REQUIRE(test_receiver_params == receiver_params);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testSdpTransportParamsMulticast)
+{
+    using web::json::value;
+    using web::json::value_of;
+
+    const auto test_params = nmos::sdp_parameters(U("SDP Example"), nmos::sdp_parameters::video_t{}, 103);
+
+    const auto test_sender_params = value_of({
+        value_of({
+            { nmos::fields::source_ip, U("172.29.226.24") },
+            { nmos::fields::destination_ip, U("232.21.21.133") },
+            { nmos::fields::source_port, 5004 },
+            { nmos::fields::destination_port, 5000 },
+            { nmos::fields::rtp_enabled, true }
+        })
+    });
+
+    for (int i = 0; i < 2; ++i)
+    {
+        // i.e. source-specific multicast then any-source multicast
+        const bool source_filters = i == 0;
+
+        const auto test_receiver_params = value_of({
+            value_of({
+                { nmos::fields::source_ip, source_filters ? value::string(U("172.29.226.24")) : value::null() },
+                { nmos::fields::multicast_ip, U("232.21.21.133") },
+                { nmos::fields::interface_ip, U("auto") },
+                { nmos::fields::destination_port, 5000 },
+                { nmos::fields::rtp_enabled, true },
+            })
+        });
+
+        const auto sender_sdp = nmos::make_session_description(test_params, test_sender_params, source_filters);
+        auto receiver_params = nmos::get_session_description_transport_params(sender_sdp);
+        BST_REQUIRE(test_receiver_params == receiver_params);
+
+        // replace "auto"
+        receiver_params[0][nmos::fields::interface_ip] = value::string(U("172.29.126.24"));
+
+        const auto receiver_sdp = nmos::make_session_description(test_params, receiver_params);
+        receiver_params = nmos::get_session_description_transport_params(receiver_sdp);
+        BST_REQUIRE(test_receiver_params == receiver_params);
+    }
+}

--- a/Development/sdp/json.h
+++ b/Development/sdp/json.h
@@ -219,6 +219,13 @@ namespace sdp
             return sdp::fields::name(nv) == name;
         });
     }
+    inline web::json::array::iterator find_name(web::json::array& name_value_array, const utility::string_t& name)
+    {
+        return std::find_if(name_value_array.begin(), name_value_array.end(), [&](const web::json::value& nv)
+        {
+            return sdp::fields::name(nv) == name;
+        });
+    }
 
     // Time Units
     // See https://tools.ietf.org/html/rfc4566#section-5.10


### PR DESCRIPTION
1. Fix correct setting of `source_ip` in a Receiver's `transport_params` when parsing an SDP file which doesn't contain a `source-filter`. Previously it set it from the origin `<unicast-address>` but that's wrong - as shown by the example in the IS-05 spec for [Behaviour - RTP Transport Type - Unicast](https://specs.amwa.tv/is-05/releases/v1.1.1/docs/4.1._Behaviour_-_RTP_Transport_Type.html#unicast).

2. Following on from that, generate `source-filter`s from unicast Senders' `transport_params` by default.

3. To enable creation of the effective SDP files at a Receiver when `rtp_enabled` is explicitly overridden, support creation of SDP files from Receivers' `transport_params`. Previously only worked from Senders' `transport_params`, which have a slightly different set of parameters, e.g. `destination_ip` vs. `multicast_ip`/`interface_ip`.

4. New test cases are added for most of the above improvements.

5. Also support "session-level" `ts-refclk` and `mediaclk` which will resolve #125. The `source-filter` attribute is still not handled at  "session-level", but I've added more comments to explain some of the ways the `source-filter` handling could be improved (e.g. checking `<dest-address>` actually matches the connection address being considered).

6. Fix generation of `a=mediaclk:sender` (which would previously have been rendered with a trailing `=`).
