### PR TITLE
Fix nmos::details::wait_term_signal

### DIFF
--- a/Development/nmos/process_utils.cpp
+++ b/Development/nmos/process_utils.cpp
@@ -39,7 +39,7 @@ namespace nmos
 #endif
                 SIGTERM);
             signals.async_wait([](const boost::system::error_code&, int){});
-            service.run_one();
+            service.run();
         }
     }
 }


### PR DESCRIPTION
`boost::asio::signal_set::async_wait` is a "composed" operation so a single `boost::asio::io_service::run_one` is not sufficient to guarantee that the `async_wait` handler has actually been called.

I reproduced this bug in an application that also had another `signal_set` registered - on a different `io_service` - for different signals.

Changing `run_one` to `run` solves the problem.

We _could_ also put an explicit `service.stop()` in the handler, but since this is a local `io_service` with no other operations, it's not actually needed.

More background in this post: [\[Boost-users\] \[Asio\] run_one does not seem to run signal handler but run does](https://groups.google.com/g/boost-list/c/tC_T9UrF0IA?pli=1)