### PR TITLE
Enable Conan compiler.cppstd to override nmos-cpp's preferred CMAKE_CXX_STANDARD

### DIFF
--- a/Development/cmake/NmosCppCommon.cmake
+++ b/Development/cmake/NmosCppCommon.cmake
@@ -19,12 +19,18 @@ endif()
 
 # enable C++11
 enable_language(CXX)
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "Default value for CXX_STANDARD property of targets")
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
 if(CMAKE_CXX_STANDARD STREQUAL "98")
     message(FATAL_ERROR "CMAKE_CXX_STANDARD must be 11 or higher; C++98 is not supported")
 endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+if(NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+if(NOT DEFINED CMAKE_CXX_EXTENSIONS)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
 
 if(NMOS_CPP_BUILD_TESTS AND CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     # note: to see the output of any failed tests, set CTEST_OUTPUT_ON_FAILURE=1 in the environment


### PR DESCRIPTION
Resolves #206. Follow up to #108.

The change made in commit edd896214a772b10bbcfae89824bfeb7b22743a4 enabled the user to override nmos-cpp's preferred `CMAKE_CXX_STANDARD` on the CMake command line by setting that variable into the cache.

More recently, we introduced a [Conan recipe](https://github.com/conan-io/conan-center-index/tree/master/recipes/nmos-cpp), with [packages published at Conan Center Index](https://conan.io/center/nmos-cpp). @pedro-alves-ferreira noticed that specifying `compiler.cppstd=17` (as in [How to manage C++ standard](https://docs.conan.io/en/latest/howtos/manage_cpp_standard.html)) was ignored on the first build.

This turns out to be because Conan sets `CMAKE_CXX_STANDARD` as a "normal" variable, and on first run, the current CMake behaviour is that setting it as a cache variable removes the normal variable. Using idiomatic existence checks on all the `CMAKE_CXX_` variables instead is the right way to solve this issue.

This could be artificially demonstrated in GitHub Actions, but I haven't gone that far with this PR.
Once it's merged, there will still need to be a new Conan package version published.
