### PR TITLE
Add missing dependency on Boost

### DIFF
--- a/Development/cmake/NmosCppDependencies.cmake
+++ b/Development/cmake/NmosCppDependencies.cmake
@@ -227,6 +227,10 @@ else()
                 json_schema_validator PRIVATE
                 JSON_SCHEMA_BOOST_REGEX
                 )
+            target_link_libraries(
+                json_schema_validator PRIVATE
+                Boost::regex
+                )
         endif()
     endif()
 


### PR DESCRIPTION
This didn't affect the Ubuntu 14.04 build in GitHub Actions only because Boost headers are found in the system include dir _/usr/include/_, but for other systems with GCC 4.8, and Boost installed in non-standard location, it is necessary.