### PR TITLE
Conan default package id mode considered harmful

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -79,6 +79,8 @@ jobs:
       if: matrix.use_conan == true
       run: |
         pip install conan
+        # override default 'semver_direct_mode' due to boost
+        conan config set general.default_package_id_mode=minor_mode
         conan config set general.revisions_enabled=1
     
     - name: install cmake
@@ -482,6 +484,8 @@ jobs:
       if: matrix.use_conan == true
       run: |
         pip install conan
+        # override default 'semver_direct_mode' due to boost
+        conan config set general.default_package_id_mode=minor_mode
         conan config set general.revisions_enabled=1
     
     - name: install cmake

--- a/.github/workflows/src/build-setup.yml
+++ b/.github/workflows/src/build-setup.yml
@@ -2,6 +2,8 @@
   if: matrix.use_conan == true
   run: |
     pip install conan
+    # override default 'semver_direct_mode' due to boost
+    conan config set default_package_id_mode=minor_mode
     conan config set general.revisions_enabled=1
 
 - name: install cmake

--- a/Development/cmake/NmosCppDependencies.cmake
+++ b/Development/cmake/NmosCppDependencies.cmake
@@ -1,7 +1,7 @@
 # Boost
 
 set(BOOST_VERSION_MIN "1.54.0")
-set(BOOST_VERSION_CUR "1.76.0")
+set(BOOST_VERSION_CUR "1.77.0")
 # note: 1.57.0 doesn't work due to https://svn.boost.org/trac10/ticket/10754
 # note: some components are only required for one platform or other
 # so find_package(Boost) is called after adding those components

--- a/Documents/Dependencies.md
+++ b/Documents/Dependencies.md
@@ -54,10 +54,18 @@ By default nmos-cpp uses [Conan](https://conan.io) to download most of its depen
 
 1. Install Python 3 if necessary  
    Note: The Python scripts directory needs to be added to the `PATH`, so the Conan executable can be found
-2. Run `pip install conan`, on some platforms with Python 2 and Python 3 installed this may need to be `pip3 install conan`  
+2. Install Conan using `pip install conan`  
    Notes:
-   - Currently, Conan 1.33 or higher is required; version 1.39 (latest release at the time) has been tested
+   - On some platforms with Python 2 and Python 3 both installed this may need to be `pip3 install conan`  
+   - Currently, Conan 1.33 or higher is required; version 1.42.1 (latest release at the time) has been tested
    - Conan evolves fairly quickly, so it's worth running `pip install --upgrade conan` regularly
+   - By default [Conan assumes semver compatibility](https://docs.conan.io/en/1.42/creating_packages/define_abi_compatibility.html#versioning-schema).
+     Boost and other C++ libraries do not meet this expectation and break ABI compatibility between e.g. minor versions.
+     Unfortunately, the recipes in Conan Center Index do not generally customize their `package_id` method to take this into account.
+     Therefore it is strongly recommended to change Conan's default package id mode to `minor_mode` or a stricter mode such as `recipe_revision_mode`.
+     ```sh
+     conan config set general.default_package_id_mode=minor_mode
+     ```
 3. Install a [DNS Service Discovery](#dns-service-discovery) implementation, since this isn't currently handled by Conan
 
 Now follow the [Getting Started](Getting-Started.md) instructions directly. Conan is used to download the rest of the dependencies.


### PR DESCRIPTION
The [build-test #297](https://github.com/sony/nmos-cpp/actions/runs/1367671562) logs show that bumping Boost from 1.76.0 to 1.77.0 caused nmos-cpp-node to terminate with a segmentation fault on Ubuntu 18.04 and 20.04.

This is because by default [Conan assumes semver compatibility](https://docs.conan.io/en/1.42/creating_packages/define_abi_compatibility.html#versioning-schema). Boost and other C++ libraries do not meet this expectation and break ABI compatibility between e.g. minor versions. The recipes in Conan Center Index do not generally customize their `package_id` method to take this into account.

Conan outputs this message in the log, but it's **highly** misleading!

```
WARN: cpprestsdk/2.10.18: requirement boost/1.76.0 overridden by your conanfile to boost/1.77.0
```

The cpprestsdk binary package used is still one built against Boost 1.76.0. When nmos-cpp(-node) is then built against Boost 1.77.0, this results in a seg fault.

A workaround is to change Conan's default package id mode to `minor_mode` or a stricter mode such as `recipe_revision_mode`.

```sh
conan config set general.default_package_id_mode=minor_mode
```

I wish there were something better we could do than put this in CI and documentation, but I haven't come up with anything.
