### PR TITLE
Updates from the Parameter Registers

### DIFF
--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -5,7 +5,7 @@
     // Custom settings for the example node implementation
 
     // how_many: provides for very basic testing of a node with many sub-resources of each type
-    //"how_many" : 7,
+    //"how_many": 4,
 
     // activate_senders: controls whether to activate senders on start up (true, default) or not (false)
     //"activate_senders": false,
@@ -22,6 +22,18 @@
     // interlace_mode: controls the interlace_mode of video flows, see nmos::interlace_mode
     // when omitted, a default is used based on the frame_rate, etc.
     //"interlace_mode": "progressive",
+
+    // colorspace: controls the colorspace of video flows, see nmos::colorspace
+    //"colorspace": "BT709",
+
+    // transfer_chacteristic: controls the transfer characteristic system of video flows, see nmos::transfer_characteristic
+    //"transfer_chacteristic": "SDR",
+
+    // color_sampling: controls the color (sub-)sampling mode of video flows, see sdp::sampling
+    //"color_sampling": "YCbCr-4:2:2",
+
+    // component_depth: controls the bits per component sample of video flows
+    //"component_depth": 10,
 
     // channel_count: controls the number of channels in audio sources
     //"channel_count": 8,

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -76,6 +76,18 @@ namespace impl
         // when omitted, a default is used based on the frame_rate, etc.
         const web::json::field_as_string interlace_mode{ U("interlace_mode") };
 
+        // colorspace: controls the colorspace of video flows, see nmos::colorspace
+        const web::json::field_as_string_or colorspace{ U("colorspace"), U("BT709") };
+
+        // transfer_chacteristic: controls the transfer characteristic system of video flows, see nmos::transfer_characteristic
+        const web::json::field_as_string_or transfer_chacteristic{ U("transfer_chacteristic"), U("SDR") };
+
+        // color_sampling: controls the color (sub-)sampling mode of video flows, see sdp::sampling
+        const web::json::field_as_string_or color_sampling{ U("color_sampling"), U("YCbCr-4:2:2") };
+
+        // component_depth: controls the bits per component sample of video flows
+        const web::json::field_as_integer_or component_depth{ U("component_depth"), 10 };
+
         // channel_count: controls the number of channels in audio sources
         const web::json::field_as_integer_or channel_count{ U("channel_count"), 4 };
 
@@ -169,6 +181,10 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate_)
     const auto frame_width = impl::fields::frame_width(model.settings);
     const auto frame_height = impl::fields::frame_height(model.settings);
     const auto interlace_mode = impl::get_interlace_mode(model.settings);
+    const auto colorspace = nmos::colorspace{ impl::fields::colorspace(model.settings) };
+    const auto transfer_characteristic = nmos::transfer_characteristic{ impl::fields::transfer_chacteristic(model.settings) };
+    const auto sampling = sdp::sampling{ impl::fields::color_sampling(model.settings) };
+    const auto bit_depth = impl::fields::component_depth(model.settings);
     const auto channel_count = impl::fields::channel_count(model.settings);
     const auto smpte2022_7 = impl::fields::smpte2022_7(model.settings);
 
@@ -292,7 +308,7 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate_)
                     flow_id, source_id, device_id,
                     frame_rate,
                     frame_width, frame_height, interlace_mode,
-                    nmos::colorspaces::BT709, nmos::transfer_characteristics::SDR, nmos::chroma_subsampling::YCbCr422, 10,
+                    colorspace, transfer_characteristic, sampling, bit_depth,
                     model.settings
                 );
             }
@@ -372,7 +388,7 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate_)
                         { nmos::caps::format::frame_width, nmos::make_caps_integer_constraint({ frame_width }) },
                         { nmos::caps::format::frame_height, nmos::make_caps_integer_constraint({ frame_height }) },
                         { nmos::caps::format::interlace_mode, nmos::make_caps_string_constraint(interlace_modes) },
-                        { nmos::caps::format::color_sampling, nmos::make_caps_string_constraint({ sdp::samplings::YCbCr_4_2_2.name }) }
+                        { nmos::caps::format::color_sampling, nmos::make_caps_string_constraint({ sampling.name }) }
                     })
                 });
                 receiver.data[nmos::fields::version] = receiver.data[nmos::fields::caps][nmos::fields::version] = value(nmos::make_version());

--- a/Development/nmos/colorspace.h
+++ b/Development/nmos/colorspace.h
@@ -7,13 +7,27 @@ namespace nmos
 {
     // Colorspace (used in video flows)
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video.json
+    // and https://github.com/AMWA-TV/nmos-parameter-registers/tree/main/flow-attributes#colorspace
     DEFINE_STRING_ENUM(colorspace)
     namespace colorspaces
     {
+        // Recommendation ITU-R BT.601-7
         const colorspace BT601{ U("BT601") };
+        // Recommendation ITU-R BT.709-6
         const colorspace BT709{ U("BT709") };
+        // Recommendation ITU-R BT.2020-2
         const colorspace BT2020{ U("BT2020") };
+        // Recommendation ITU-R BT.2100 Table 2 titled "System colorimetry"
         const colorspace BT2100{ U("BT2100") };
+
+        // Since IS-04 v1.3, colorspace values may be defined in the Flow Attributes register of the NMOS Parameter Registers
+
+        // SMPTE ST 2065-1 Academy Color Encoding Specification (ACES)
+        const colorspace ST2065_1{ U("ST2065-1") };
+        // SMPTE ST 2065-3 Academy Density Exchange Encoding (ADX)
+        const colorspace ST2065_3{ U("ST2065-3") };
+        // ISO 11664-1 CIE 1931 standard colorimetric system
+        const colorspace XYZ{ U("XYZ") };
     }
 }
 

--- a/Development/nmos/components.cpp
+++ b/Development/nmos/components.cpp
@@ -14,6 +14,7 @@ namespace nmos
         });
     }
 
+    // deprecated, see overload with sdp::sampling in nmos/sdp_utils.h
     web::json::value make_components(chroma_subsampling chroma_subsampling, unsigned int frame_width, unsigned int frame_height, unsigned int bit_depth)
     {
         using web::json::value;

--- a/Development/nmos/components.h
+++ b/Development/nmos/components.h
@@ -23,7 +23,9 @@ namespace nmos
         const component_name G{ U("G") };
         const component_name B{ U("B") };
         const component_name DepthMap{ U("DepthMap") };
+
         // Experimental extension, to support CLYCbCr, XYZ, and KEY signal formats
+
         const component_name Yc{ U("Yc") };
         const component_name Cbc{ U("Cbc") };
         const component_name Crc{ U("Crc") };
@@ -35,6 +37,7 @@ namespace nmos
     web::json::value make_component(const nmos::component_name& name, unsigned int width, unsigned int height, unsigned int bit_depth);
 
     enum chroma_subsampling : int { YCbCr422, RGB444 };
+    // deprecated, see overload with sdp::sampling in nmos/sdp_utils.h
     web::json::value make_components(chroma_subsampling chroma_subsampling = YCbCr422, unsigned int frame_width = 1920, unsigned int frame_height = 1080, unsigned int bit_depth = 10);
 }
 

--- a/Development/nmos/components.h
+++ b/Development/nmos/components.h
@@ -8,6 +8,7 @@ namespace nmos
 {
     // Components (used in raw video flows)
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video_raw.json
+    // and https://github.com/AMWA-TV/nmos-parameter-registers/tree/main/flow-attributes#components
     DEFINE_STRING_ENUM(component_name)
     namespace component_names
     {

--- a/Development/nmos/components.h
+++ b/Development/nmos/components.h
@@ -22,6 +22,13 @@ namespace nmos
         const component_name G{ U("G") };
         const component_name B{ U("B") };
         const component_name DepthMap{ U("DepthMap") };
+        // Experimental extension, to support CLYCbCr, XYZ, and KEY signal formats
+        const component_name Yc{ U("Yc") };
+        const component_name Cbc{ U("Cbc") };
+        const component_name Crc{ U("Crc") };
+        const component_name X{ U("X") };
+        const component_name Z{ U("Z") };
+        const component_name Key{ U("Key") };
     }
 
     web::json::value make_component(const nmos::component_name& name, unsigned int width, unsigned int height, unsigned int bit_depth);

--- a/Development/nmos/components.h
+++ b/Development/nmos/components.h
@@ -6,7 +6,7 @@
 
 namespace nmos
 {
-    // Components (used in raw video flows)
+    // Components (for raw video flows since IS-04 v1.1, extended to coded video Flows since v1.3 by the entry in the Flow Attributes register)
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video_raw.json
     // and https://github.com/AMWA-TV/nmos-parameter-registers/tree/main/flow-attributes#components
     DEFINE_STRING_ENUM(component_name)
@@ -24,7 +24,8 @@ namespace nmos
         const component_name B{ U("B") };
         const component_name DepthMap{ U("DepthMap") };
 
-        // Experimental extension, to support CLYCbCr, XYZ, and KEY signal formats
+        // Since IS-04 v1.3, component names may be defined in the Flow Attributes register of the NMOS Parameter Registers
+        // The following values support CLYCbCr, XYZ, and KEY signal formats, see sdp::samplings
 
         const component_name Yc{ U("Yc") };
         const component_name Cbc{ U("Cbc") };

--- a/Development/nmos/node_resources.cpp
+++ b/Development/nmos/node_resources.cpp
@@ -18,6 +18,7 @@
 #include "nmos/is08_versions.h"
 #include "nmos/media_type.h"
 #include "nmos/resource.h"
+#include "nmos/sdp_utils.h" // for nmos::make_components
 #include "nmos/transfer_characteristic.h"
 #include "nmos/transport.h"
 #include "nmos/version.h"
@@ -271,6 +272,21 @@ namespace nmos
     }
 
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video_raw.json
+    nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const sdp::sampling& color_sampling, unsigned int bit_depth, const nmos::settings& settings)
+    {
+        using web::json::value;
+
+        auto resource = make_video_flow(id, source_id, device_id, grain_rate, frame_width, frame_height, interlace_mode, colorspace, transfer_characteristic, settings);
+        auto& data = resource.data;
+
+        data[U("media_type")] = value::string(nmos::media_types::video_raw.name);
+
+        data[U("components")] = make_components(color_sampling, frame_width, frame_height, bit_depth);
+
+        return resource;
+    }
+
+    // deprecated, see overload with sdp::sampling
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, chroma_subsampling chroma_subsampling, unsigned int bit_depth, const nmos::settings& settings)
     {
         using web::json::value;
@@ -285,6 +301,7 @@ namespace nmos
         return resource;
     }
 
+    // deprecated, constructs a 1920 x 1080, interlaced, BT709, SDR, YCbCr-4:2:2, 10 bit raw video Flow
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings)
     {
         return make_raw_video_flow(id, source_id, device_id, {}, 1920, 1080, nmos::interlace_modes::interlaced_bff, nmos::colorspaces::BT709, nmos::transfer_characteristics::SDR, YCbCr422, 10, settings);

--- a/Development/nmos/node_resources.h
+++ b/Development/nmos/node_resources.h
@@ -10,6 +10,11 @@ namespace web
     class uri;
 }
 
+namespace sdp
+{
+    struct sampling;
+}
+
 namespace nmos
 {
     // IS-04 Node API resources
@@ -62,7 +67,10 @@ namespace nmos
     nmos::resource make_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const nmos::settings& settings);
 
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video_raw.json
+    nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const sdp::sampling& color_sampling, unsigned int bit_depth, const nmos::settings& settings);
+    // deprecated, see overload with sdp::sampling
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, chroma_subsampling chroma_subsampling, unsigned int bit_depth, const nmos::settings& settings);
+    // deprecated, constructs a 1920 x 1080, interlaced, BT709, SDR, YCbCr-4:2:2, 10 bit raw video Flow
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video_coded.json

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -6,6 +6,7 @@
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/irange.hpp>
+#include <boost/range/numeric.hpp>
 #include "cpprest/basic_utils.h"
 #include "nmos/capabilities.h"
 #include "nmos/clock_ref_type.h"
@@ -92,152 +93,84 @@ namespace nmos
             else throw sdp_creation_error("unexpected clock ref_type");
         }
 
-        sdp::sampling make_sampling(const web::json::array& components)
+        // See sdp::samplings
+        typedef std::pair<uint32_t, uint32_t> width_height_t;
+        static const std::map<sdp::sampling, std::vector<std::pair<component_name, width_height_t>>> samplers
         {
-            using name = component_name;
-            namespace names = component_names;
-
-            // https://tools.ietf.org/html/rfc4175#section-6.1
-
-            // convert json to component name vs dimension lookup for easy access,
-            // as components can be in any order inside the json
-            struct dimension { int width; int height; };
-            const auto dimensions = boost::copy_range<std::map<name, dimension>>(components | boost::adaptors::transformed([](const web::json::value& component)
-            {
-                return std::map<name, dimension>::value_type{ name{ nmos::fields::name(component) }, dimension{ nmos::fields::width(component), nmos::fields::height(component) } };
-            }));
-            const auto de = dimensions.end();
-
-            // See sdp::samplings
-            if (4 == dimensions.size() && de != dimensions.find(names::R) && de != dimensions.find(names::G) && de != dimensions.find(names::B) && de != dimensions.find(names::A))
-            {
-                // Red-Green-Blue-Alpha
-                return sdp::samplings::RGBA;
-            }
-            else if (3 == dimensions.size() && de != dimensions.find(names::R) && de != dimensions.find(names::G) && de != dimensions.find(names::B))
-            {
-                // Red-Green-Blue
-                return sdp::samplings::RGB;
-            }
-            else if (3 == dimensions.size() && de != dimensions.find(names::Y) && de != dimensions.find(names::Cb) && de != dimensions.find(names::Cr))
-            {
-                // Non-constant luminance YCbCr
-                const auto& Y = dimensions.at(names::Y);
-                const auto& Cb = dimensions.at(names::Cb);
-                const auto& Cr = dimensions.at(names::Cr);
-                if (Cb.width != Cr.width || Cb.height != Cr.height) throw sdp_creation_error("unsupported YCbCr dimensions");
-                const auto& C = Cb;
-                if (Y.height == C.height)
-                {
-                    if (Y.width == C.width) return sdp::samplings::YCbCr_4_4_4;
-                    else if (Y.width / 2 == C.width) return sdp::samplings::YCbCr_4_2_2;
-                    else if (Y.width / 4 == C.width) return sdp::samplings::YCbCr_4_1_1;
-                    else throw sdp_creation_error("unsupported YCbCr dimensions");
-                }
-                else if (Y.height / 2 == C.height)
-                {
-                    if (Y.width / 2 == C.width) return sdp::samplings::YCbCr_4_2_0;
-                    else throw sdp_creation_error("unsupported YCbCr dimensions");
-                }
-                else throw sdp_creation_error("unsupported YCbCr dimensions");
-            }
-            else if (3 == dimensions.size() && de != dimensions.find(names::Yc) && de != dimensions.find(names::Cbc) && de != dimensions.find(names::Crc))
-            {
-                // Constant luminance YCbCr
-                const auto& Y = dimensions.at(names::Yc);
-                const auto& Cb = dimensions.at(names::Cbc);
-                const auto& Cr = dimensions.at(names::Crc);
-                if (Cb.width != Cr.width || Cb.height != Cr.height) throw sdp_creation_error("unsupported CLYCbCr dimensions");
-                const auto& C = Cb;
-                if (Y.height == C.height)
-                {
-                    if (Y.width == C.width) return sdp::samplings::CLYCbCr_4_4_4;
-                    else if (Y.width / 2 == C.width) return sdp::samplings::CLYCbCr_4_2_2;
-                    else throw sdp_creation_error("unsupported CLYCbCr dimensions");
-                }
-                else if (Y.height / 2 == C.height)
-                {
-                    if (Y.width / 2 == C.width) return sdp::samplings::CLYCbCr_4_2_0;
-                    else throw sdp_creation_error("unsupported CLYCbCr dimensions");
-                }
-                else throw sdp_creation_error("unsupported CLYCbCr dimensions");
-            }
-            else if (3 == dimensions.size() && de != dimensions.find(names::I) && de != dimensions.find(names::Ct) && de != dimensions.find(names::Cp))
-            {
-                // Constant intensity ICtCp
-                const auto& I = dimensions.at(names::I);
-                const auto& Ct = dimensions.at(names::Ct);
-                const auto& Cp = dimensions.at(names::Cp);
-                if (Ct.width != Cp.width || Ct.height != Cp.height) throw sdp_creation_error("unsupported ICtCp dimensions");
-                const auto& C = Ct;
-                if (I.height == C.height)
-                {
-                    if (I.width == C.width) return sdp::samplings::ICtCp_4_4_4;
-                    else if (I.width / 2 == C.width) return sdp::samplings::ICtCp_4_2_2;
-                    else throw sdp_creation_error("unsupported ICtCp dimensions");
-                }
-                else if (I.height / 2 == C.height)
-                {
-                    if (I.width / 2 == C.width) return sdp::samplings::ICtCp_4_2_0;
-                    else throw sdp_creation_error("unsupported ICtCp dimensions");
-                }
-                else throw sdp_creation_error("unsupported ICtCp dimensions");
-            }
-            else if (3 == dimensions.size() && de != dimensions.find(names::X) && de != dimensions.find(names::Y) && de != dimensions.find(names::Z))
-            {
-                // XYZ
-                return sdp::samplings::XYZ;
-            }
-            else if (1 == dimensions.size() && de != dimensions.find(names::Key))
-            {
-                // Key signal represented as a single component
-                return sdp::samplings::KEY;
-            }
-            else throw sdp_creation_error("unsupported components");
-        }
+            // Red-Green-Blue-Alpha
+            { sdp::samplings::RGBA, { { component_names::R, { 1, 1 } }, { component_names::G, { 1, 1 } }, { component_names::B, { 1, 1 } }, { component_names::A, { 1, 1 } } } },
+            // Red-Green-Blue
+            { sdp::samplings::RGB, { { component_names::R, { 1, 1 } }, { component_names::G, { 1, 1 } }, { component_names::B, { 1, 1 } } } },
+            // Non-constant luminance YCbCr
+            { sdp::samplings::YCbCr_4_4_4, { { component_names::Y, { 1, 1 } }, { component_names::Cb, { 1, 1 } }, { component_names::Cr, { 1, 1 } } } },
+            { sdp::samplings::YCbCr_4_2_2, { { component_names::Y, { 1, 1 } }, { component_names::Cb, { 2, 1 } }, { component_names::Cr, { 2, 1 } } } },
+            { sdp::samplings::YCbCr_4_2_0, { { component_names::Y, { 1, 1 } }, { component_names::Cb, { 2, 2 } }, { component_names::Cr, { 2, 2 } } } },
+            { sdp::samplings::YCbCr_4_1_1, { { component_names::Y, { 1, 1 } }, { component_names::Cb, { 4, 1 } }, { component_names::Cr, { 4, 1 } } } },
+            // Constant luminance YCbCr
+            { sdp::samplings::CLYCbCr_4_4_4, { { component_names::Yc, { 1, 1 } }, { component_names::Cbc, { 1, 1 } }, { component_names::Crc, { 1, 1 } } } },
+            { sdp::samplings::CLYCbCr_4_2_2, { { component_names::Yc, { 1, 1 } }, { component_names::Cbc, { 2, 1 } }, { component_names::Crc, { 2, 1 } } } },
+            { sdp::samplings::CLYCbCr_4_2_0, { { component_names::Yc, { 1, 1 } }, { component_names::Cbc, { 2, 2 } }, { component_names::Crc, { 2, 2 } } } },
+            // Constant intensity ICtCp
+            { sdp::samplings::ICtCp_4_4_4, { { component_names::I, { 1, 1 } }, { component_names::Ct, { 1, 1 } }, { component_names::Cp, { 1, 1 } } } },
+            { sdp::samplings::ICtCp_4_2_2, { { component_names::I, { 1, 1 } }, { component_names::Ct, { 2, 1 } }, { component_names::Cp, { 2, 1 } } } },
+            { sdp::samplings::ICtCp_4_2_0, { { component_names::I, { 1, 1 } }, { component_names::Ct, { 2, 2 } }, { component_names::Cp, { 2, 2 } } } },
+            // XYZ
+            { sdp::samplings::XYZ, { { component_names::X, { 1, 1 } }, { component_names::Y, { 1, 1 } }, { component_names::Z, { 1, 1 } } } },
+            // Key signal represented as a single component
+            { sdp::samplings::KEY, { { component_names::Key, { 1, 1 } } } },
+            // Sampling signaled by the payload
+            { sdp::samplings::UNSPECIFIED, {} }
+        };
 
         web::json::value make_components(const sdp::sampling& sampling, uint32_t width, uint32_t height, uint32_t depth)
         {
             using web::json::value;
             using web::json::value_from_elements;
-            using name = component_name;
-            namespace names = component_names;
-            struct component_sampler { name c; uint32_t dw; uint32_t dh; };
-            // See sdp::samplings
-            static const std::map<sdp::sampling, std::vector<component_sampler>> samplers
-            {
-                // Red-Green-Blue-Alpha
-                { sdp::samplings::RGBA, { { names::R, 1, 1 }, { names::G, 1, 1 }, { names::B, 1, 1 }, { names::A, 1, 1 } } },
-                // Red-Green-Blue
-                { sdp::samplings::RGB, { { names::R, 1, 1 }, { names::G, 1, 1 }, { names::B, 1, 1 } } },
-                // Non-constant luminance YCbCr
-                { sdp::samplings::YCbCr_4_4_4, { { names::Y, 1, 1 }, { names::Cb, 1, 1 }, { names::Cr, 1, 1 } } },
-                { sdp::samplings::YCbCr_4_2_2, { { names::Y, 1, 1 }, { names::Cb, 2, 1 }, { names::Cr, 2, 1 } } },
-                { sdp::samplings::YCbCr_4_2_0, { { names::Y, 1, 1 }, { names::Cb, 2, 2 }, { names::Cr, 2, 2 } } },
-                { sdp::samplings::YCbCr_4_1_1, { { names::Y, 1, 1 }, { names::Cb, 4, 1 }, { names::Cr, 4, 1 } } },
-                // Constant luminance YCbCr
-                { sdp::samplings::CLYCbCr_4_4_4, { { names::Yc, 1, 1 }, { names::Cbc, 1, 1 }, { names::Crc, 1, 1 } } },
-                { sdp::samplings::CLYCbCr_4_2_2, { { names::Yc, 1, 1 }, { names::Cbc, 2, 1 }, { names::Crc, 2, 1 } } },
-                { sdp::samplings::CLYCbCr_4_2_0, { { names::Yc, 1, 1 }, { names::Cbc, 2, 2 }, { names::Crc, 2, 2 } } },
-                // Constant intensity ICtCp
-                { sdp::samplings::ICtCp_4_4_4, { { names::I, 1, 1 }, { names::Ct, 1, 1 }, { names::Cp, 1, 1 } } },
-                { sdp::samplings::ICtCp_4_2_2, { { names::I, 1, 1 }, { names::Ct, 2, 1 }, { names::Cp, 2, 1 } } },
-                { sdp::samplings::ICtCp_4_2_0, { { names::I, 1, 1 }, { names::Ct, 2, 2 }, { names::Cp, 2, 2 } } },
-                // XYZ
-                { sdp::samplings::XYZ, { { names::X, 1, 1 }, { names::Y, 1, 1 }, { names::Z, 1, 1 } } },
-                // Key signal represented as a single component
-                { sdp::samplings::KEY, { { names::Key, 1, 1 } } },
-                // Sampling signaled by the payload
-                { sdp::samplings::UNSPECIFIED, {} },
-            };
 
             const auto sampler = samplers.find(sampling);
             if (samplers.end() == sampler) return value::null();
 
-            return value_from_elements(sampler->second | boost::adaptors::transformed([&](const component_sampler& sampler)
+            return value_from_elements(sampler->second | boost::adaptors::transformed([&](const std::pair<component_name, width_height_t>& component)
             {
-                return make_component(sampler.c, width / sampler.dw, height / sampler.dh, depth);
+                return make_component(component.first, width / component.second.first, height / component.second.second, depth);
             }));
+        }
+
+        sdp::sampling make_sampling(const web::json::array& components)
+        {
+            // https://tools.ietf.org/html/rfc4175#section-6.1
+
+            // each entry of the array indicates the number of samples in horizontal and vertical direction for the specified component
+            // which depends on the frame width and height, whereas the sampling values only indicate the relative (sub-)sampling frequency
+            // so to account for this and handle any order of the components in the array, convert into a map from component name to
+            // relative sampling period, i.e. Y@1920x1080, Cb@960x540, Cr@960x540 becomes Y@1:1, Cb@2:2, Cr@2:2 which is YCbCr_4_2_0
+
+            typedef std::map<component_name, width_height_t> components_t;
+            typedef std::map<components_t, sdp::sampling> samplers_t;
+
+            static const auto samplers = boost::copy_range<samplers_t>(nmos::details::samplers | boost::adaptors::transformed([](const std::pair<sdp::sampling, std::vector<std::pair<component_name, width_height_t>>>& sampler)
+            {
+                return samplers_t::value_type{ boost::copy_range<components_t>(sampler.second), sampler.first };
+            }));
+
+            const auto max_samples = boost::accumulate(components | boost::adaptors::transformed([](const web::json::value& component)
+            {
+                return width_height_t{ nmos::fields::width(component), nmos::fields::height(component) };
+            }), width_height_t{}, [](const width_height_t& lhs, const width_height_t& rhs)
+            {
+                return width_height_t{ (std::max)(lhs.first, rhs.first), (std::max)(lhs.second, rhs.second) };
+            });
+            const auto components_sampler = boost::copy_range<components_t>(components | boost::adaptors::transformed([&max_samples](const web::json::value& component)
+            {
+                const width_height_t samples{ nmos::fields::width(component), nmos::fields::height(component) };
+                if (0 != max_samples.first % samples.first || 0 != max_samples.second % samples.second) throw sdp_creation_error("unsupported components");
+                return components_t::value_type{ component_name{ nmos::fields::name(component) }, { max_samples.first / samples.first, max_samples.second / samples.second } };
+            }));
+
+            const auto sampler = samplers.find(components_sampler);
+            if (samplers.end() == sampler) throw sdp_creation_error("unsupported components");
+
+            return sampler->second;
         }
 
         // Payload identifiers 96-127 are used for payloads defined dynamically during a session

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -146,7 +146,8 @@ namespace nmos
             // each entry of the array indicates the number of samples in horizontal and vertical direction for the specified component
             // which depends on the frame width and height, whereas the sampling values only indicate the relative (sub-)sampling frequency
             // so to account for this and handle any order of the components in the array, convert into a map from component name to
-            // relative sampling period, i.e. Y@1920x1080, Cb@960x540, Cr@960x540 becomes Y@1:1, Cb@2:2, Cr@2:2 which is YCbCr_4_2_0
+            // relative sampling period, i.e. components array of Y@1920x1080, Cb@960x540, Cr@960x540 is converted into the relative
+            // component sampler Y@1x1, Cb@2x2, Cr@2x2, which is YCbCr-4:2:0
 
             typedef std::map<component_name, width_height_t> components_t;
             typedef std::map<components_t, sdp::sampling> samplers_t;

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -121,21 +121,24 @@ namespace nmos
             // Sampling signaled by the payload
             { sdp::samplings::UNSPECIFIED, {} }
         };
+    }
 
-        web::json::value make_components(const sdp::sampling& sampling, uint32_t width, uint32_t height, uint32_t depth)
+    web::json::value make_components(const sdp::sampling& sampling, uint32_t width, uint32_t height, uint32_t depth)
+    {
+        using web::json::value;
+        using web::json::value_from_elements;
+
+        const auto sampler = nmos::details::samplers.find(sampling);
+        if (nmos::details::samplers.end() == sampler) return value::null();
+
+        return value_from_elements(sampler->second | boost::adaptors::transformed([&](const std::pair<component_name, nmos::details::width_height_t>& component)
         {
-            using web::json::value;
-            using web::json::value_from_elements;
+            return make_component(component.first, width / component.second.first, height / component.second.second, depth);
+        }));
+    }
 
-            const auto sampler = samplers.find(sampling);
-            if (samplers.end() == sampler) return value::null();
-
-            return value_from_elements(sampler->second | boost::adaptors::transformed([&](const std::pair<component_name, width_height_t>& component)
-            {
-                return make_component(component.first, width / component.second.first, height / component.second.second, depth);
-            }));
-        }
-
+    namespace details
+    {
         sdp::sampling make_sampling(const web::json::array& components)
         {
             // https://tools.ietf.org/html/rfc4175#section-6.1

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -13,12 +13,13 @@ namespace nmos
 {
     struct sdp_parameters;
 
-    // Sender helper functions
-
     namespace details
     {
         sdp::sampling make_sampling(const web::json::array& components);
+        web::json::value make_components(const sdp::sampling& sampling, uint32_t width, uint32_t height, uint32_t depth);
     }
+
+    // Sender helper functions
 
     // Construct SDP parameters from the IS-04 resources, using default values for unspecified items
     sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, bst::optional<int> ptp_domain);

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -13,13 +13,14 @@ namespace nmos
 {
     struct sdp_parameters;
 
+    // Sender helper functions
+
+    web::json::value make_components(const sdp::sampling& sampling, uint32_t width, uint32_t height, uint32_t depth);
+
     namespace details
     {
         sdp::sampling make_sampling(const web::json::array& components);
-        web::json::value make_components(const sdp::sampling& sampling, uint32_t width, uint32_t height, uint32_t depth);
     }
-
-    // Sender helper functions
 
     // Construct SDP parameters from the IS-04 resources, using default values for unspecified items
     sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, bst::optional<int> ptp_domain);

--- a/Development/nmos/string_enum.h
+++ b/Development/nmos/string_enum.h
@@ -27,6 +27,9 @@ namespace nmos
     };
 }
 
+#define DECLARE_STRING_ENUM(Type) \
+    struct Type;
+
 #define DEFINE_STRING_ENUM(Type) \
     struct Type : public nmos::string_enum<Type> \
     { \

--- a/Development/nmos/test/sdp_utils_test.cpp
+++ b/Development/nmos/test/sdp_utils_test.cpp
@@ -2,8 +2,17 @@
 #include "nmos/sdp_utils.h"
 
 #include "bst/test/test.h"
+#include "nmos/components.h"
 #include "nmos/json_fields.h"
 #include "sdp/sdp.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testMakeComponents)
+{
+    // use the older function to test the newer function
+    BST_REQUIRE(nmos::make_components(nmos::YCbCr422, 1920, 1080, 10) == nmos::details::make_components(sdp::samplings::YCbCr_4_2_2, 1920, 1080, 10));
+    BST_REQUIRE(nmos::make_components(nmos::RGB444, 3840, 2160, 12) == nmos::details::make_components(sdp::samplings::RGB, 3840, 2160, 12));
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 BST_TEST_CASE(testInterpretationOfSdpFilesUnicast)

--- a/Development/nmos/test/sdp_utils_test.cpp
+++ b/Development/nmos/test/sdp_utils_test.cpp
@@ -13,8 +13,8 @@ BST_TEST_CASE(testMakeComponentsMakeSampling)
     using web::json::value_of;
 
     // use the older function to test the newer function
-    BST_REQUIRE(nmos::make_components(nmos::YCbCr422, 1920, 1080, 8) == nmos::details::make_components(sdp::samplings::YCbCr_4_2_2, 1920, 1080, 8));
-    BST_REQUIRE(nmos::make_components(nmos::RGB444, 3840, 2160, 12) == nmos::details::make_components(sdp::samplings::RGB, 3840, 2160, 12));
+    BST_REQUIRE(nmos::make_components(nmos::YCbCr422, 1920, 1080, 8) == nmos::make_components(sdp::samplings::YCbCr_4_2_2, 1920, 1080, 8));
+    BST_REQUIRE(nmos::make_components(nmos::RGB444, 3840, 2160, 12) == nmos::make_components(sdp::samplings::RGB, 3840, 2160, 12));
 
     const std::vector<sdp::sampling> samplings{
         // Red-Green-Blue-Alpha
@@ -55,7 +55,7 @@ BST_TEST_CASE(testMakeComponentsMakeSampling)
     {
         for (const auto& dim : dims)
         {
-            auto components = nmos::details::make_components(sampling, dim.first, dim.second, 10);
+            auto components = nmos::make_components(sampling, dim.first, dim.second, 10);
             BST_REQUIRE(sampling == nmos::details::make_sampling(components.as_array()));
             std::shuffle(components.as_array().begin(), components.as_array().end(), gen);
             BST_REQUIRE(sampling == nmos::details::make_sampling(components.as_array()));

--- a/Development/nmos/transfer_characteristic.h
+++ b/Development/nmos/transfer_characteristic.h
@@ -7,14 +7,33 @@ namespace nmos
 {
     // Transfer characteristic (used in video flows)
     // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video.json
+    // and https://github.com/AMWA-TV/nmos-parameter-registers/tree/main/flow-attributes#transfer-characteristic
     DEFINE_STRING_ENUM(transfer_characteristic)
     namespace transfer_characteristics
     {
         const transfer_characteristic none{};
 
+        // Standard Dynamic Range
         const transfer_characteristic SDR{ U("SDR") };
-        const transfer_characteristic HLG{ U("HLG") };
+        // Perceptual Quantization
         const transfer_characteristic PQ{ U("PQ") };
+        // Hybrid Log Gamma
+        const transfer_characteristic HLG{ U("HLG") };
+
+        // Since IS-04 v1.3, transfer_characteristic values may be defined in the Flow Attributes register of the NMOS Parameter Registers
+
+        // Video streams of linear encoded floating-point samples (depth=16f), such that all values fall within the range [0..1.0]
+        const transfer_characteristic LINEAR{ U("LINEAR") };
+        // Video Stream of linear encoded floating-point samples (depth=16f) normalized from PQ as specified in ITU-R BT.2100-0
+        const transfer_characteristic BT2100LINPQ{ U("BT2100LINPQ") };
+        // Video Stream of linear encoded floating-point samples (depth=16f) normalized from HLG as specified in ITU-R BT.2100-0
+        const transfer_characteristic BT2100LINHLG{ U("BT2100LINHLG") };
+        // Video stream of linear encoded floating-point samples (depth=16f) as specified in SMPTE ST 2065-1
+        const transfer_characteristic ST2065_1{ U("ST2065-1") };
+        // Video stream utilizing the transfer characteristic specified in SMPTE ST 428-1 Section 4.3
+        const transfer_characteristic ST428_1{ U("ST428-1") };
+        // Video streams of density encoded samples, such as those defined in SMPTE ST 2065-3
+        const transfer_characteristic DENSITY{ U("DENSITY") };
     }
 }
 

--- a/Development/sdp/json.h
+++ b/Development/sdp/json.h
@@ -468,7 +468,9 @@ namespace sdp
     DEFINE_STRING_ENUM(sampling)
     namespace samplings
     {
+        // Red-Green-Blue-Alpha
         const sampling RGBA{ U("RGBA") };
+        // Red-Green-Blue
         const sampling RGB{ U("RGB") };
         // Non-constant luminance YCbCr
         const sampling YCbCr_4_4_4{ U("YCbCr-4:4:4") };

--- a/Development/sdp/json.h
+++ b/Development/sdp/json.h
@@ -478,16 +478,20 @@ namespace sdp
         const sampling YCbCr_4_2_0{ U("YCbCr-4:2:0") };
         const sampling YCbCr_4_1_1{ U("YCbCr-4:1:1") };
         // Constant luminance YCbCr
+        // e.g. as specified in Recommendation ITU-R BT.2020-2
         const sampling CLYCbCr_4_4_4{ U("CLYCbCr-4:4:4") };
         const sampling CLYCbCr_4_2_2{ U("CLYCbCr-4:2:2") };
         const sampling CLYCbCr_4_2_0{ U("CLYCbCr-4:2:0") };
         // Constant intensity ICtCp
+        // e.g. as specified in Recommendation ITU-R BT.2100
         const sampling ICtCp_4_4_4{ U("ICtCp-4:4:4") };
         const sampling ICtCp_4_2_2{ U("ICtCp-4:2:2") };
         const sampling ICtCp_4_2_0{ U("ICtCp-4:2:0") };
         // XYZ
+        // e.g. as specified in SMPTE ST 428-1
         const sampling XYZ{ U("XYZ") };
         // Key signal represented as a single component
+        // e.g. as specified in SMPTE RP 157
         const sampling KEY{ U("KEY") };
         // Hmm, only the JPEG XS payload mapping includes this value, for "sampling signaled by the payload"
         // See https://tools.ietf.org/html/draft-ietf-payload-rtp-jpegxs-09#section-6


### PR DESCRIPTION
Adds the extended values for `colorspace` and `transfer_characteristic` from the Parameter Registers, and new `nmos::make_components` and `nmos::make_raw_video_flow` overloads that enable the additional component names introduced to support ST 2110-20 raw and ST 2110-22 JPEG XS signal formats like CLYCbCr, ICtCp, XYZ and KEY.

Plus updated example code in **nmos-cpp-node**.

Plus updated unit tests in **nmos-cpp-test**.

----

@jonathan-r-thorpe, this one probably _does_ deserve squash-merging if approved, the separate commits just make the thought process more transparent for review. 😅