### PR TITLE
Fix Ubuntu 20.04 test runner installation of SDPoker

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -358,11 +358,7 @@ jobs:
           pip install -r requirements.txt
     
           # Install SDPoker
-          if [[ "${{ matrix.os }}" == "windows-latest" || "$EUID" == "0" ]]; then
-            npm install -g AMWA-TV/sdpoker
-          else
-            sudo npm install -g AMWA-TV/sdpoker
-          fi
+          npm install -g git+https://git@github.com/AMWA-TV/sdpoker.git
           run_python="python"
         fi
         pip install -r utilities/run-test-suites/gsheetsImport/requirements.txt
@@ -763,11 +759,7 @@ jobs:
           pip install -r requirements.txt
     
           # Install SDPoker
-          if [[ "${{ matrix.os }}" == "windows-latest" || "$EUID" == "0" ]]; then
-            npm install -g AMWA-TV/sdpoker
-          else
-            sudo npm install -g AMWA-TV/sdpoker
-          fi
+          npm install -g git+https://git@github.com/AMWA-TV/sdpoker.git
           run_python="python"
         fi
         pip install -r utilities/run-test-suites/gsheetsImport/requirements.txt

--- a/.github/workflows/src/amwa-test.yml
+++ b/.github/workflows/src/amwa-test.yml
@@ -48,11 +48,7 @@
       pip install -r requirements.txt
 
       # Install SDPoker
-      if [[ "${{ matrix.os }}" == "windows-latest" || "$EUID" == "0" ]]; then
-        npm install -g AMWA-TV/sdpoker
-      else
-        sudo npm install -g AMWA-TV/sdpoker
-      fi
+      npm install -g git+https://git@github.com/AMWA-TV/sdpoker.git
       run_python="python"
     fi
     pip install -r utilities/run-test-suites/gsheetsImport/requirements.txt


### PR DESCRIPTION
Explicitly specify `git+https://git@github.com/{user}/{repo}.git` to workaround npm "feature" of rewriting GitHub package specs (https://github.com/npm/cli/issues/2610), which applies on GitHub Actions after the Ubuntu 20.04 image 20211129.1 update (https://github.com/actions/virtual-environments/pull/4625) upgraded to Node v16.13.0 (npm v8.1.0)

Finally, stop using sudo in order to avoid permissions issue on the npm cache (https://github.com/npm/cli/issues/624)