### PR TITLE
Add application/sdp+json as the precise media type for the experimental SDP-as-JSON response

### DIFF
--- a/Development/nmos/api_utils.cpp
+++ b/Development/nmos/api_utils.cpp
@@ -8,6 +8,7 @@
 #include "cpprest/uri_schemes.h"
 #include "cpprest/ws_utils.h"
 #include "nmos/api_version.h"
+#include "nmos/media_type.h"
 #include "nmos/slog.h"
 #include "nmos/type.h"
 #include "nmos/version.h"
@@ -190,7 +191,7 @@ namespace nmos
                 const auto accept = req.headers().find(web::http::header_names::accept);
                 return req.headers().end() != accept
                     && !boost::algorithm::contains(accept->second, mime_type)
-                    && boost::algorithm::contains(accept->second, U("text/html"));
+                    && boost::algorithm::contains(accept->second, nmos::media_types::text_html.name);
             }
 
             web::json::value make_html_response_a_tag(const web::uri& href, const web::json::value& value)
@@ -563,7 +564,7 @@ namespace nmos
                 if (web::http::details::is_mime_type_json(mime_type) && experimental::details::is_html_response_preferred(req, mime_type))
                 {
                     res.set_body(nmos::experimental::make_html_response_body(res, gate));
-                    res.headers().set_content_type(U("text/html; charset=utf-8"));
+                    res.headers().set_content_type(nmos::media_types::text_html.name + U("; charset=utf-8"));
                 }
 
                 slog::detail::logw<slog::log_statement, slog::base_gate>(gate, slog::severities::more_info, SLOG_FLF) << nmos::stash_categories({ nmos::categories::access }) << nmos::common_log_stash(req, res) << "Sending response after " << processing_dur << "ms";

--- a/Development/nmos/connection_resources.cpp
+++ b/Development/nmos/connection_resources.cpp
@@ -6,6 +6,7 @@
 #include "nmos/api_utils.h" // for nmos::http_scheme
 #include "nmos/is05_versions.h"
 #include "nmos/is07_versions.h"
+#include "nmos/media_type.h" // for nmos::media_types::application_sdp
 #include "nmos/resource.h"
 
 namespace nmos
@@ -171,7 +172,7 @@ namespace nmos
 
         return value_of({
             { nmos::fields::transportfile_data, transportfile },
-            { nmos::fields::transportfile_type, U("application/sdp") }
+            { nmos::fields::transportfile_type, nmos::media_types::application_sdp.name }
         });
     }
 

--- a/Development/nmos/media_type.h
+++ b/Development/nmos/media_type.h
@@ -43,6 +43,17 @@ namespace nmos
 
         // See SMPTE ST 2022-8:2019
         const media_type video_SMPTE2022_6{ U("video/SMPTE2022-6") };
+
+        // Additional media types for NMOS responses
+
+        const media_type application_sdp{ U("application/sdp") };
+
+        // experimental extension, to support HTML rendering of NMOS responses
+        const media_type text_html{ U("text/html") };
+
+        // experimental extension, to support JSON rendering in NMOS responses
+        const media_type application_schema_json{ U("application/schema+json") };
+        const media_type application_sdp_json{ U("application/sdp+json") };
     }
 }
 

--- a/Development/nmos/node_api_target_handler.cpp
+++ b/Development/nmos/node_api_target_handler.cpp
@@ -6,6 +6,7 @@
 #include "nmos/client_utils.h"
 #include "nmos/is05_versions.h"
 #include "nmos/json_fields.h"
+#include "nmos/media_type.h" // for nmos::media_types::application_sdp
 #include "nmos/model.h"
 #include "nmos/slog.h"
 
@@ -47,9 +48,9 @@ namespace nmos
                     {
                         slog::log<slog::severities::warning>(gate, SLOG_FLF) << "Missing Content-Type: should be application/sdp";
                     }
-                    else if (U("application/sdp") != content_type)
+                    else if (nmos::media_types::application_sdp.name != content_type)
                     {
-                        throw web::http::http_exception(U("Incorrect Content-Type: ") + content_type + U(", should be application/sdp"));
+                        throw web::http::http_exception(U("Incorrect Content-Type: ") + content_type + U(", should be ") + nmos::media_types::application_sdp.name);
                     }
 
                     return res.extract_string(true);
@@ -66,7 +67,7 @@ namespace nmos
                         })},
                         { nmos::fields::transport_file, value_of({
                             { nmos::fields::data, sdp },
-                            { nmos::fields::type, U("application/sdp") }
+                            { nmos::fields::type, nmos::media_types::application_sdp.name }
                         })}
                     });
 

--- a/Development/nmos/schemas_api.cpp
+++ b/Development/nmos/schemas_api.cpp
@@ -6,6 +6,7 @@
 #include "nmos/api_utils.h"
 #include "nmos/json_schema.h"
 #include "nmos/log_manip.h"
+#include "nmos/media_type.h" // for nmos::media_types::application_schema_json
 
 namespace nmos
 {
@@ -185,10 +186,10 @@ namespace nmos
 
                 if (schemas.end() != found)
                 {
-                    res.headers().set_content_type(U("application/schema+json"));
+                    res.headers().set_content_type(nmos::media_types::application_schema_json.name);
 
                     // experimental extension, to support human-readable HTML rendering of NMOS responses
-                    if (experimental::details::is_html_response_preferred(req, U("application/schema+json")))
+                    if (experimental::details::is_html_response_preferred(req, nmos::media_types::application_schema_json.name))
                     {
                         const auto base_uri = web::uri_builder().set_path(U("/schemas/") + repository + U("/") + tag + U("/")).to_uri();
                         set_reply(res, status_codes::OK, details::make_json_schema_html_response_body(base_uri, found->second));


### PR DESCRIPTION
As suggested by @rjb1000 in https://github.com/garethsb/nmos-cpp-examples/discussions/1#discussioncomment-1682324.