### PR TITLE
Fix many spec URLs, mainly those that were returning 404 Not Found due to the retagging of v1.x as v1.x.0

### DIFF
--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -120,7 +120,7 @@
 
     // registration_heartbeat_interval [registry, node]:
     // "Nodes are expected to peform a heartbeat every 5 seconds by default."
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#heartbeating
     //"registration_heartbeat_interval": 5,
 
     // registration_request_max [node]: timeout for interactions with the Registration API /resource endpoint
@@ -136,13 +136,13 @@
 
     // events_heartbeat_interval [node, client]:
     // "Upon connection, the client is required to report its health every 5 seconds in order to maintain its session and subscription."
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#41-heartbeats
     //"events_heartbeat_interval": 5,
 
     // events_expiry_interval [node]:
     // "The server is expected to check health commands and after a 12 seconds timeout (2 consecutive missed health commands plus 2 seconds to allow for latencies)
     // it should clear the subscriptions for that particular client and close the websocket connection."
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#41-heartbeats
     //"events_expiry_interval": 12,
 
     // system_address [node]: IP address or host name used to construct request URLs for the System API (if not discovered via DNS-SD)

--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -120,7 +120,7 @@
 
     // registration_heartbeat_interval [registry, node]:
     // "Nodes are expected to peform a heartbeat every 5 seconds by default."
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
     //"registration_heartbeat_interval": 5,
 
     // registration_request_max [node]: timeout for interactions with the Registration API /resource endpoint
@@ -136,13 +136,13 @@
 
     // events_heartbeat_interval [node, client]:
     // "Upon connection, the client is required to report its health every 5 seconds in order to maintain its session and subscription."
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
     //"events_heartbeat_interval": 5,
 
     // events_expiry_interval [node]:
     // "The server is expected to check health commands and after a 12 seconds timeout (2 consecutive missed health commands plus 2 seconds to allow for latencies)
     // it should clear the subscriptions for that particular client and close the websocket connection."
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
     //"events_expiry_interval": 12,
 
     // system_address [node]: IP address or host name used to construct request URLs for the System API (if not discovered via DNS-SD)

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -510,9 +510,9 @@ void node_implementation_init(nmos::node_model& model, slog::base_gate& gate)
             {
                 event_type = impl::temperature_Celsius;
 
-                // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/3.0.%20Event%20types.md#231-measurements
-                // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/examples/eventsapi-type-number-measurement-get-200.json
-                // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/examples/eventsapi-state-number-measurement-get-200.json
+                // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#231-measurements
+                // and https://specs.amwa.tv/is-07/releases/v1.0.1/examples/eventsapi-type-number-measurement-get-200.html
+                // and https://specs.amwa.tv/is-07/releases/v1.0.1/examples/eventsapi-state-number-measurement-get-200.html
                 events_type = nmos::make_events_number_type({ -200, 10 }, { 1000, 10 }, { 1, 10 }, U("C"));
                 events_state = nmos::make_events_number_state({ source_id, flow_id }, { 201, 10 }, event_type);
             }
@@ -520,7 +520,7 @@ void node_implementation_init(nmos::node_model& model, slog::base_gate& gate)
             {
                 event_type = nmos::event_types::boolean;
 
-                // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/3.0.%20Event%20types.md#21-boolean
+                // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#21-boolean
                 events_type = nmos::make_events_boolean_type();
                 events_state = nmos::make_events_boolean_state({ source_id, flow_id }, false);
             }
@@ -528,7 +528,7 @@ void node_implementation_init(nmos::node_model& model, slog::base_gate& gate)
             {
                 event_type = nmos::event_types::string;
 
-                // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/3.0.%20Event%20types.md#22-string
+                // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#22-string
                 // and of course, https://en.wikipedia.org/wiki/Metasyntactic_variable
                 events_type = nmos::make_events_string_type(0, 0, U("^foo|bar|baz|qu+x$"));
                 events_state = nmos::make_events_string_state({ source_id, flow_id }, U("foo"));
@@ -537,7 +537,7 @@ void node_implementation_init(nmos::node_model& model, slog::base_gate& gate)
             {
                 event_type = impl::catcall;
 
-                // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/3.0.%20Event%20types.md#3-enum
+                // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#3-enum
                 events_type = nmos::make_events_number_enum_type({
                     { 1, { U("meow"), U("chatty") } },
                     { 2, { U("purr"), U("happy") } },
@@ -938,7 +938,7 @@ nmos::connection_resource_auto_resolver make_node_implementation_auto_resolver(c
         const auto& constraints = nmos::fields::endpoint_constraints(connection_resource.data);
 
         // "In some cases the behaviour is more complex, and may be determined by the vendor."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
+        // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/2.2._APIs_-_Server_Side_Implementation.html#use-of-auto
         if (rtp_sender_ids.end() != boost::range::find(rtp_sender_ids, id_type.first))
         {
             const bool smpte2022_7 = 1 < transport_params.size();

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -938,7 +938,7 @@ nmos::connection_resource_auto_resolver make_node_implementation_auto_resolver(c
         const auto& constraints = nmos::fields::endpoint_constraints(connection_resource.data);
 
         // "In some cases the behaviour is more complex, and may be determined by the vendor."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
         if (rtp_sender_ids.end() != boost::range::find(rtp_sender_ids, id_type.first))
         {
             const bool smpte2022_7 = 1 < transport_params.size();

--- a/Development/nmos-cpp-registry/config.json
+++ b/Development/nmos-cpp-registry/config.json
@@ -55,12 +55,12 @@
     // [registry]: used in System API resource is04 object's heartbeat_interval field
     // "Constants related to the AMWA IS-04 Discovery and Registration Specification are contained in the is04 object.
     // heartbeat_interval defines how often Nodes should perform a heartbeat to maintain their resources in the Registration API."
-    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#amwa-is-04-nmos-discovery-and-registration-parameters
+    // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#amwa-is-04-nmos-discovery-and-registration-parameters
     //"registration_heartbeat_interval": 5,
 
     // registration_expiry_interval [registry]:
     // "Registration APIs should use a garbage collection interval of 12 seconds by default (triggered just after two failed heartbeats at the default 5 second interval)."
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#heartbeating
     //"registration_expiry_interval": 12,
 
     // query_paging_default/query_paging_limit [registry]: default/maximum number of results per "page" when using the Query API (a client may request a lower limit)
@@ -183,11 +183,11 @@
     //     "tag_1": [ "tag_1_value_1", "tag_1_value_2" ],
     //     "tag_2": [ "tag_2_value_1" ]
     // }
-    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#tags
+    // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/2.1._APIs_-_Common_Keys.html#tags
     //"system_tags": {},
 
     // "syslog contains hostname and port for the system's syslog "version 1" server using the UDP transport (IETF RFC 5246)"
-    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#syslog-parameters
+    // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#syslog-parameters
 
     // system_syslog_hostname [registry]: the fully-qualified host name or the IP address of the system's syslog "version 1" server
     //"system_syslog_hostname": "",
@@ -196,7 +196,7 @@
     //"system_syslog_port": 514,
 
     // "syslogv2 contains hostname and port for the system's syslog "version 2" server using the TLS transport (IETF RFC 5245)"
-    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#syslog-parameters
+    // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#syslog-parameters
 
     // system_syslogv2_hostname [registry]: the fully-qualified host name or the IP address of the system's syslog "version 2" server
     //"system_syslogv2_hostname": "",

--- a/Development/nmos-cpp-registry/config.json
+++ b/Development/nmos-cpp-registry/config.json
@@ -55,12 +55,12 @@
     // [registry]: used in System API resource is04 object's heartbeat_interval field
     // "Constants related to the AMWA IS-04 Discovery and Registration Specification are contained in the is04 object.
     // heartbeat_interval defines how often Nodes should perform a heartbeat to maintain their resources in the Registration API."
-    // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#amwa-is-04-nmos-discovery-and-registration-parameters
+    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#amwa-is-04-nmos-discovery-and-registration-parameters
     //"registration_heartbeat_interval": 5,
 
     // registration_expiry_interval [registry]:
     // "Registration APIs should use a garbage collection interval of 12 seconds by default (triggered just after two failed heartbeats at the default 5 second interval)."
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
     //"registration_expiry_interval": 12,
 
     // query_paging_default/query_paging_limit [registry]: default/maximum number of results per "page" when using the Query API (a client may request a lower limit)
@@ -183,11 +183,11 @@
     //     "tag_1": [ "tag_1_value_1", "tag_1_value_2" ],
     //     "tag_2": [ "tag_2_value_1" ]
     // }
-    // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/2.1._APIs_-_Common_Keys.html#tags
+    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#tags
     //"system_tags": {},
 
     // "syslog contains hostname and port for the system's syslog "version 1" server using the UDP transport (IETF RFC 5246)"
-    // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#syslog-parameters
+    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#syslog-parameters
 
     // system_syslog_hostname [registry]: the fully-qualified host name or the IP address of the system's syslog "version 1" server
     //"system_syslog_hostname": "",
@@ -196,7 +196,7 @@
     //"system_syslog_port": 514,
 
     // "syslogv2 contains hostname and port for the system's syslog "version 2" server using the TLS transport (IETF RFC 5245)"
-    // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#syslog-parameters
+    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#syslog-parameters
 
     // system_syslogv2_hostname [registry]: the fully-qualified host name or the IP address of the system's syslog "version 2" server
     //"system_syslogv2_hostname": "",

--- a/Development/nmos/activation_mode.h
+++ b/Development/nmos/activation_mode.h
@@ -6,7 +6,7 @@
 namespace nmos
 {
     // Connection API activation mode
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/schemas/v1.0-activation-schema.json
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/schemas/v1.0-activation-schema.json
     DEFINE_STRING_ENUM(activation_mode)
     namespace activation_modes
     {

--- a/Development/nmos/activation_mode.h
+++ b/Development/nmos/activation_mode.h
@@ -6,7 +6,7 @@
 namespace nmos
 {
     // Connection API activation mode
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/schemas/v1.0-activation-schema.json
+    // See https://specs.amwa.tv/is-05/releases/v1.0.0/APIs/schemas/with-refs/v1.0-activation-schema.html
     DEFINE_STRING_ENUM(activation_mode)
     namespace activation_modes
     {

--- a/Development/nmos/activation_utils.cpp
+++ b/Development/nmos/activation_utils.cpp
@@ -83,7 +83,7 @@ namespace nmos
                 activation[nmos::fields::requested_time] = value::null();
 
                 // "If no activation was requested in the PATCH `activation_time` will be set `null`."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml
+                // See https://specs.amwa.tv/is-05/releases/v1.0.0/APIs/ConnectionAPI.html
                 activation[nmos::fields::activation_time] = value::null();
 
                 break;
@@ -93,8 +93,8 @@ namespace nmos
                 activation[nmos::fields::mode] = value::null();
 
                 // Each of these fields "returns to null [...] when the resource is unlocked by setting the activation mode to null."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/schemas/v1.0-activation-response-schema.json
-                // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/activation-response-schema.json
+                // See https://specs.amwa.tv/is-05/releases/v1.0.0/APIs/schemas/with-refs/v1.0-activation-response-schema.html
+                // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/activation-response-schema.html
                 activation[nmos::fields::requested_time] = value::null();
                 activation[nmos::fields::activation_time] = value::null();
 
@@ -104,7 +104,7 @@ namespace nmos
 
                 // "For immediate activations, in the response to the PATCH request this field
                 // will be set to 'activate_immediate'"
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/schemas/v1.0-activation-response-schema.json
+                // See https://specs.amwa.tv/is-05/releases/v1.0.0/APIs/schemas/with-refs/v1.0-activation-response-schema.html
                 activation[nmos::fields::mode] = value::string(nmos::activation_modes::activate_immediate.name);
 
                 // "For an immediate activation this field will always be null on the staged endpoint,
@@ -125,7 +125,7 @@ namespace nmos
                 activation[nmos::fields::requested_time] = request_activation.at(nmos::fields::requested_time);
 
                 // "For scheduled activations `activation_time` should be the absolute TAI time the parameters will actually transition."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml
+                // See https://specs.amwa.tv/is-05/releases/v1.0.0/APIs/ConnectionAPI.html
                 auto absolute_requested_time = get_absolute_requested_time(activation, request_time);
                 activation[nmos::fields::activation_time] = value::string(nmos::make_version(absolute_requested_time));
 

--- a/Development/nmos/activation_utils.cpp
+++ b/Development/nmos/activation_utils.cpp
@@ -83,7 +83,7 @@ namespace nmos
                 activation[nmos::fields::requested_time] = value::null();
 
                 // "If no activation was requested in the PATCH `activation_time` will be set `null`."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/ConnectionAPI.raml
+                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml
                 activation[nmos::fields::activation_time] = value::null();
 
                 break;
@@ -93,8 +93,8 @@ namespace nmos
                 activation[nmos::fields::mode] = value::null();
 
                 // Each of these fields "returns to null [...] when the resource is unlocked by setting the activation mode to null."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/schemas/v1.0-activation-response-schema.json
-                // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/activation-response-schema.json
+                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/schemas/v1.0-activation-response-schema.json
+                // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/activation-response-schema.json
                 activation[nmos::fields::requested_time] = value::null();
                 activation[nmos::fields::activation_time] = value::null();
 
@@ -104,7 +104,7 @@ namespace nmos
 
                 // "For immediate activations, in the response to the PATCH request this field
                 // will be set to 'activate_immediate'"
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/schemas/v1.0-activation-response-schema.json
+                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/schemas/v1.0-activation-response-schema.json
                 activation[nmos::fields::mode] = value::string(nmos::activation_modes::activate_immediate.name);
 
                 // "For an immediate activation this field will always be null on the staged endpoint,
@@ -125,7 +125,7 @@ namespace nmos
                 activation[nmos::fields::requested_time] = request_activation.at(nmos::fields::requested_time);
 
                 // "For scheduled activations `activation_time` should be the absolute TAI time the parameters will actually transition."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/ConnectionAPI.raml
+                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml
                 auto absolute_requested_time = get_absolute_requested_time(activation, request_time);
                 activation[nmos::fields::activation_time] = value::string(nmos::make_version(absolute_requested_time));
 

--- a/Development/nmos/api_downgrade.cpp
+++ b/Development/nmos/api_downgrade.cpp
@@ -6,7 +6,7 @@
 
 namespace nmos
 {
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#downgrade-queries
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.5._APIs_-_Query_Parameters.html#downgrade-queries
 
     bool is_permitted_downgrade(const nmos::resource& resource, const nmos::api_version& version)
     {

--- a/Development/nmos/api_downgrade.cpp
+++ b/Development/nmos/api_downgrade.cpp
@@ -6,7 +6,7 @@
 
 namespace nmos
 {
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.5.%20APIs%20-%20Query%20Parameters.md#downgrade-queries
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#downgrade-queries
 
     bool is_permitted_downgrade(const nmos::resource& resource, const nmos::api_version& version)
     {

--- a/Development/nmos/api_downgrade.h
+++ b/Development/nmos/api_downgrade.h
@@ -5,7 +5,7 @@
 
 // "Downgrade queries permit old-versioned responses to be provided to clients which are confident
 // that they can handle any missing attributes between the specified API versions."
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#downgrade-queries
+// See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.5._APIs_-_Query_Parameters.html#downgrade-queries
 namespace nmos
 {
     struct api_version;

--- a/Development/nmos/api_downgrade.h
+++ b/Development/nmos/api_downgrade.h
@@ -5,7 +5,7 @@
 
 // "Downgrade queries permit old-versioned responses to be provided to clients which are confident
 // that they can handle any missing attributes between the specified API versions."
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.5.%20APIs%20-%20Query%20Parameters.md#downgrade-queries
+// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#downgrade-queries
 namespace nmos
 {
     struct api_version;

--- a/Development/nmos/api_utils.cpp
+++ b/Development/nmos/api_utils.cpp
@@ -213,7 +213,7 @@ namespace nmos
 
     // construct a standard NMOS "child resources" response, from the specified sub-routes
     // merging with ones from an existing response
-    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.0.%20APIs.md#api-paths
+    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.0.%20APIs.md#api-paths
     web::json::value make_sub_routes_body(std::set<utility::string_t> sub_routes, const web::http::http_request& req, web::http::http_response res)
     {
         using namespace web::http::experimental::listener::api_router_using_declarations;

--- a/Development/nmos/api_utils.cpp
+++ b/Development/nmos/api_utils.cpp
@@ -213,7 +213,7 @@ namespace nmos
 
     // construct a standard NMOS "child resources" response, from the specified sub-routes
     // merging with ones from an existing response
-    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.0.%20APIs.md#api-paths
+    // see https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.0._APIs.html#api-paths
     web::json::value make_sub_routes_body(std::set<utility::string_t> sub_routes, const web::http::http_request& req, web::http::http_response res)
     {
         using namespace web::http::experimental::listener::api_router_using_declarations;

--- a/Development/nmos/api_utils.h
+++ b/Development/nmos/api_utils.h
@@ -108,7 +108,7 @@ namespace nmos
 
     // construct a standard NMOS "child resources" response, from the specified sub-routes
     // merging with ones from an existing response
-    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.0.%20APIs.md#api-paths
+    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.0.%20APIs.md#api-paths
     web::json::value make_sub_routes_body(std::set<utility::string_t> sub_routes, const web::http::http_request& req, web::http::http_response res);
 
     // construct sub-routes for the specified API versions

--- a/Development/nmos/api_utils.h
+++ b/Development/nmos/api_utils.h
@@ -108,7 +108,7 @@ namespace nmos
 
     // construct a standard NMOS "child resources" response, from the specified sub-routes
     // merging with ones from an existing response
-    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.0.%20APIs.md#api-paths
+    // see https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.0._APIs.html#api-paths
     web::json::value make_sub_routes_body(std::set<utility::string_t> sub_routes, const web::http::http_request& req, web::http::http_response res);
 
     // construct sub-routes for the specified API versions

--- a/Development/nmos/capabilities.h
+++ b/Development/nmos/capabilities.h
@@ -7,7 +7,7 @@
 namespace nmos
 {
     // BCP-004-01 Receiver Capabilities
-    // See https://github.com/AMWA-TV/nmos-receiver-capabilities/blob/v1.0.0/docs/1.0.%20Receiver%20Capabilities.md
+    // See https://specs.amwa.tv/bcp-004-01/releases/v1.0.0/docs/1.0._Receiver_Capabilities.html
     namespace fields
     {
         const web::json::field_as_value_or constraint_sets{ U("constraint_sets"), {} };
@@ -19,19 +19,19 @@ namespace nmos
     template <> nmos::rational inline no_minimum() { return (std::numeric_limits<int64_t>::max)(); }
     template <> nmos::rational inline no_maximum() { return 0; }
 
-    // See https://github.com/AMWA-TV/nmos-receiver-capabilities/blob/v1.0.0/docs/1.0.%20Receiver%20Capabilities.md#string-constraint-keywords
+    // See https://specs.amwa.tv/bcp-004-01/releases/v1.0.0/docs/1.0._Receiver_Capabilities.html#string-constraint-keywords
     web::json::value make_caps_string_constraint(const std::vector<utility::string_t>& enum_values = {});
 
-    // See https://github.com/AMWA-TV/nmos-receiver-capabilities/blob/v1.0.0/docs/1.0.%20Receiver%20Capabilities.md#integer-and-number-constraint-keywords
+    // See https://specs.amwa.tv/bcp-004-01/releases/v1.0.0/docs/1.0._Receiver_Capabilities.html#integer-and-number-constraint-keywords
     web::json::value make_caps_integer_constraint(const std::vector<int64_t>& enum_values = {}, int64_t minimum = no_minimum<int64_t>(), int64_t maximum = no_maximum<int64_t>());
 
-    // See https://github.com/AMWA-TV/nmos-receiver-capabilities/blob/v1.0.0/docs/1.0.%20Receiver%20Capabilities.md#integer-and-number-constraint-keywords
+    // See https://specs.amwa.tv/bcp-004-01/releases/v1.0.0/docs/1.0._Receiver_Capabilities.html#integer-and-number-constraint-keywords
     web::json::value make_caps_number_constraint(const std::vector<double>& enum_values = {}, double minimum = no_minimum<double>(), double maximum = no_maximum<double>());
 
-    // See https://github.com/AMWA-TV/nmos-receiver-capabilities/blob/v1.0.0/docs/1.0.%20Receiver%20Capabilities.md#boolean-constraint-keywords
+    // See https://specs.amwa.tv/bcp-004-01/releases/v1.0.0/docs/1.0._Receiver_Capabilities.html#boolean-constraint-keywords
     web::json::value make_caps_boolean_constraint(const std::vector<bool>& enum_values = {});
 
-    // See https://github.com/AMWA-TV/nmos-receiver-capabilities/blob/v1.0.0/docs/1.0.%20Receiver%20Capabilities.md#rational-constraint-keywords
+    // See https://specs.amwa.tv/bcp-004-01/releases/v1.0.0/docs/1.0._Receiver_Capabilities.html#rational-constraint-keywords
     web::json::value make_caps_rational_constraint(const std::vector<nmos::rational>& enum_values = {}, const nmos::rational& minimum = no_minimum<nmos::rational>(), const nmos::rational& maximum = no_maximum<nmos::rational>());
 
     bool match_string_constraint(const utility::string_t& value, const web::json::value& constraint);
@@ -41,7 +41,7 @@ namespace nmos
     bool match_rational_constraint(const nmos::rational& value, const web::json::value& constraint);
 
     // NMOS Parameter Registers - Capabilities register
-    // See https://github.com/AMWA-TV/nmos-parameter-registers/blob/main/capabilities/README.md
+    // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/
     namespace caps
     {
         namespace meta

--- a/Development/nmos/channelmapping_activation.cpp
+++ b/Development/nmos/channelmapping_activation.cpp
@@ -178,7 +178,7 @@ namespace nmos
                 // At the moment, it doesn't seem necessary to enable support multiple API instances via the API selector mechanism
                 // so therefore just a single Channel Mapping API instance is mounted directly at /x-nmos/channelmapping/{version}/
                 // If it becomes necessary, each device could associated with a specific API selector
-                // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/2.0.%20APIs.md#api-paths
+                // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/2.0._APIs.html#api-paths
 
                 // hmm, should all devices get the same activation time or not?
                 const auto activation_time = nmos::tai_now();

--- a/Development/nmos/channelmapping_activation.cpp
+++ b/Development/nmos/channelmapping_activation.cpp
@@ -178,7 +178,7 @@ namespace nmos
                 // At the moment, it doesn't seem necessary to enable support multiple API instances via the API selector mechanism
                 // so therefore just a single Channel Mapping API instance is mounted directly at /x-nmos/channelmapping/{version}/
                 // If it becomes necessary, each device could associated with a specific API selector
-                // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.x/docs/2.0.%20APIs.md#api-paths
+                // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/2.0.%20APIs.md#api-paths
 
                 // hmm, should all devices get the same activation time or not?
                 const auto activation_time = nmos::tai_now();

--- a/Development/nmos/channelmapping_api.cpp
+++ b/Development/nmos/channelmapping_api.cpp
@@ -45,7 +45,7 @@ namespace nmos
         // so therefore just mount the Channel Mapping API instance directly at /x-nmos/channelmapping/{version}/
         // If it becomes necessary, nmos::node_mode::channelmapping_resources could become a map from {selector} to nmos::resources
         // and the 'unmounted' API instance handler also mounted after a "child resources" handler based on the API selectors
-        // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/2.0.%20APIs.md#api-paths
+        // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/2.0._APIs.html#api-paths
         channelmapping_api.mount(U("/x-nmos/") + nmos::patterns::channelmapping_api.pattern + U("/") + nmos::patterns::version.pattern, make_unmounted_channelmapping_api(model, validate_merged, gate));
 
         return channelmapping_api;
@@ -154,14 +154,14 @@ namespace nmos
                 {
                     // When "one field of Output channel object is null but other is not", the entire request must be rejected
                     // with the 400 Bad Request response.
-                    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#activation-responses
+                    // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/4.0._Behaviour.html#activation-responses
                     if (!input_channel_index_or_null.is_null())
                     {
                         throw web::json::json_exception("invalid channel_index when input is null");
                     }
 
                     // "If no [routing] restrictions exist, the routable_inputs field MUST be set to null."
-                    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#output-routing-constraints
+                    // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/4.0._Behaviour.html#output-routing-constraints
                     if (!routable_inputs_or_null.is_null())
                     {
                         // "If the Device allows the Output to have unrouted channels, the list SHOULD also include null."
@@ -178,7 +178,7 @@ namespace nmos
 
                     // When "one field of Output channel object is null but other is not", the entire request must be rejected
                     // with the 400 Bad Request response.
-                    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#activation-responses
+                    // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/4.0._Behaviour.html#activation-responses
                     if (input_channel_index_or_null.is_null())
                     {
                         throw web::json::json_exception("invalid channel_index when input is not null");
@@ -186,7 +186,7 @@ namespace nmos
                     const auto input_channel_index = input_channel_index_or_null.as_integer();
 
                     // "If no [routing] restrictions exist, the routable_inputs field MUST be set to null."
-                    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#output-routing-constraints
+                    // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/4.0._Behaviour.html#output-routing-constraints
                     if (!routable_inputs_or_null.is_null())
                     {
                         // "If an Input is listed in an Output's routable input list then channels from that input can be routed
@@ -223,7 +223,7 @@ namespace nmos
 
             // When an "Output is modified by an already scheduled activation", the entire request must be rejected
             // with the 423 Locked response.
-            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#activation-responses
+            // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/4.0._Behaviour.html#activation-responses
 
             const auto& mode = nmos::fields::mode(nmos::fields::activation(nmos::fields::endpoint_staged(output.data)));
 
@@ -245,13 +245,13 @@ namespace nmos
 
             // "If the Input [...] cannot perform re-ordering, [...] there MUST be a fixed offset
             // for all Input and Output channel indexes in the mapping."
-            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#re-ordering
+            // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/4.0._Behaviour.html#re-ordering
             bool current_reorderable = false;
             std::map<nmos::channelmapping_id, int> channel_offsets;
 
             // "It MUST be that either all Input channels in a block are routed to an Output, or none are routed.
             // All Input channels in a block MUST be routed to the same Output when routed."
-            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#channel-block-sizes
+            // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/4.0._Behaviour.html#channel-block-sizes
             unsigned int current_block_size = 0;
             std::set<int> channels_in_current_block;
 
@@ -312,7 +312,7 @@ namespace nmos
                         if (input_channel_index % current_block_size != 0)
                         {
                             // "All blocks MUST start with an input channel where channel_index is zero or a multiple of the block_size parameter."
-                            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#channel-block-sizes
+                            // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/4.0._Behaviour.html#channel-block-sizes
                             return make_channelmapping_activation_post_error_response(status_codes::BadRequest, U("Bad Request; ") + make_channelmapping_input_block_not_reorderable_error(input_id));
                         }
                     }

--- a/Development/nmos/channelmapping_api.cpp
+++ b/Development/nmos/channelmapping_api.cpp
@@ -45,7 +45,7 @@ namespace nmos
         // so therefore just mount the Channel Mapping API instance directly at /x-nmos/channelmapping/{version}/
         // If it becomes necessary, nmos::node_mode::channelmapping_resources could become a map from {selector} to nmos::resources
         // and the 'unmounted' API instance handler also mounted after a "child resources" handler based on the API selectors
-        // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.x/docs/2.0.%20APIs.md#api-paths
+        // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/2.0.%20APIs.md#api-paths
         channelmapping_api.mount(U("/x-nmos/") + nmos::patterns::channelmapping_api.pattern + U("/") + nmos::patterns::version.pattern, make_unmounted_channelmapping_api(model, validate_merged, gate));
 
         return channelmapping_api;
@@ -154,14 +154,14 @@ namespace nmos
                 {
                     // When "one field of Output channel object is null but other is not", the entire request must be rejected
                     // with the 400 Bad Request response.
-                    // See https://nmos.amwa.tv/nmos-audio-channel-mapping/branches/v1.0.x/docs/4.0._Behaviour.html#activation-responses
+                    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#activation-responses
                     if (!input_channel_index_or_null.is_null())
                     {
                         throw web::json::json_exception("invalid channel_index when input is null");
                     }
 
                     // "If no [routing] restrictions exist, the routable_inputs field MUST be set to null."
-                    // See https://nmos.amwa.tv/nmos-audio-channel-mapping/branches/v1.0.x/docs/4.0._Behaviour.html#output-routing-constraints
+                    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#output-routing-constraints
                     if (!routable_inputs_or_null.is_null())
                     {
                         // "If the Device allows the Output to have unrouted channels, the list SHOULD also include null."
@@ -178,7 +178,7 @@ namespace nmos
 
                     // When "one field of Output channel object is null but other is not", the entire request must be rejected
                     // with the 400 Bad Request response.
-                    // See https://nmos.amwa.tv/nmos-audio-channel-mapping/branches/v1.0.x/docs/4.0._Behaviour.html#activation-responses
+                    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#activation-responses
                     if (input_channel_index_or_null.is_null())
                     {
                         throw web::json::json_exception("invalid channel_index when input is not null");
@@ -186,7 +186,7 @@ namespace nmos
                     const auto input_channel_index = input_channel_index_or_null.as_integer();
 
                     // "If no [routing] restrictions exist, the routable_inputs field MUST be set to null."
-                    // See https://nmos.amwa.tv/nmos-audio-channel-mapping/branches/v1.0.x/docs/4.0._Behaviour.html#output-routing-constraints
+                    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#output-routing-constraints
                     if (!routable_inputs_or_null.is_null())
                     {
                         // "If an Input is listed in an Output's routable input list then channels from that input can be routed
@@ -223,7 +223,7 @@ namespace nmos
 
             // When an "Output is modified by an already scheduled activation", the entire request must be rejected
             // with the 423 Locked response.
-            // See https://nmos.amwa.tv/nmos-audio-channel-mapping/branches/v1.0.x/docs/4.0._Behaviour.html#activation-responses
+            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#activation-responses
 
             const auto& mode = nmos::fields::mode(nmos::fields::activation(nmos::fields::endpoint_staged(output.data)));
 
@@ -245,13 +245,13 @@ namespace nmos
 
             // "If the Input [...] cannot perform re-ordering, [...] there MUST be a fixed offset
             // for all Input and Output channel indexes in the mapping."
-            // See https://nmos.amwa.tv/nmos-audio-channel-mapping/branches/v1.0.x/docs/4.0._Behaviour.html#re-ordering
+            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#re-ordering
             bool current_reorderable = false;
             std::map<nmos::channelmapping_id, int> channel_offsets;
 
             // "It MUST be that either all Input channels in a block are routed to an Output, or none are routed.
             // All Input channels in a block MUST be routed to the same Output when routed."
-            // See https://nmos.amwa.tv/nmos-audio-channel-mapping/branches/v1.0.x/docs/4.0._Behaviour.html#channel-block-sizes
+            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#channel-block-sizes
             unsigned int current_block_size = 0;
             std::set<int> channels_in_current_block;
 
@@ -312,7 +312,7 @@ namespace nmos
                         if (input_channel_index % current_block_size != 0)
                         {
                             // "All blocks MUST start with an input channel where channel_index is zero or a multiple of the block_size parameter."
-                            // See https://nmos.amwa.tv/nmos-audio-channel-mapping/branches/v1.0.x/docs/4.0._Behaviour.html#channel-block-sizes
+                            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0%20Behaviour.md#channel-block-sizes
                             return make_channelmapping_activation_post_error_response(status_codes::BadRequest, U("Bad Request; ") + make_channelmapping_input_block_not_reorderable_error(input_id));
                         }
                     }

--- a/Development/nmos/channelmapping_api.h
+++ b/Development/nmos/channelmapping_api.h
@@ -11,7 +11,7 @@ namespace slog
 }
 
 // Channel Mapping API implementation
-// See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.x/APIs/ChannelMappingAPI.raml
+// See https://specs.amwa.tv/is-08/releases/v1.0.1/APIs/ChannelMappingAPI.html
 namespace nmos
 {
     struct node_model;

--- a/Development/nmos/channelmapping_resources.h
+++ b/Development/nmos/channelmapping_resources.h
@@ -11,7 +11,7 @@ namespace nmos
     struct resource;
 
     // IS-08 Channel Mapping API resources
-    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.x/docs/1.0.%20Overview.md#api-structure
+    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/1.0.%20Overview.md#api-structure
     // Each IS-08 input and output's data are json objects with an identifier field 
     // and a field for the resource's view in the /io endpoint, also used for
     // the individual endpoints, "properties", "caps" and so on
@@ -27,7 +27,7 @@ namespace nmos
     // Note that the input/output identifiers used in the Channel Mapping API are not universally unique
     // and one input and one output in an API instance may even share the same identifier
     // so these need to be prefixed with the resource type to make the nmos::resource::id locally unique
-    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.x/docs/4.0.%20Behaviour.md#identifiers
+    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0.%20Behaviour.md#identifiers
     typedef utility::string_t channelmapping_id;
 
     nmos::id make_channelmapping_resource_id(const std::pair<nmos::channelmapping_id, nmos::type>& id_type);

--- a/Development/nmos/channelmapping_resources.h
+++ b/Development/nmos/channelmapping_resources.h
@@ -11,23 +11,23 @@ namespace nmos
     struct resource;
 
     // IS-08 Channel Mapping API resources
-    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/1.0.%20Overview.md#api-structure
+    // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/1.0._Overview.html#api-structure
     // Each IS-08 input and output's data are json objects with an identifier field 
     // and a field for the resource's view in the /io endpoint, also used for
     // the individual endpoints, "properties", "caps" and so on
-    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.x/APIs/schemas/io-response-schema.json
+    // See https://specs.amwa.tv/is-08/releases/v1.0.1/APIs/schemas/with-refs/io-response-schema.html
     // The output resource type also has a field for that output's /map/active endpoint
     // and a field that represents a 'staged' endpoint which contains the output-specific
     // "action" when there is a scheduled or in-flight immediate activation for that
     // output (an "activation_id" and the "activation" object are also included so that
     // the /map/activations endpoints can be implemented similarly to the /io endpoint)
-    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.x/APIs/schemas/map-active-output-response-schema.json
-    // and https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.x/APIs/schemas/map-activations-activation-get-response-schema.json
+    // See https://specs.amwa.tv/is-08/releases/v1.0.1/APIs/schemas/with-refs/map-active-output-response-schema.html
+    // and https://specs.amwa.tv/is-08/releases/v1.0.1/APIs/schemas/with-refs/map-activations-activation-get-response-schema.html
 
     // Note that the input/output identifiers used in the Channel Mapping API are not universally unique
     // and one input and one output in an API instance may even share the same identifier
     // so these need to be prefixed with the resource type to make the nmos::resource::id locally unique
-    // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/4.0.%20Behaviour.md#identifiers
+    // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/4.0._Behaviour.html#identifiers
     typedef utility::string_t channelmapping_id;
 
     nmos::id make_channelmapping_resource_id(const std::pair<nmos::channelmapping_id, nmos::type>& id_type);

--- a/Development/nmos/channels.h
+++ b/Development/nmos/channels.h
@@ -15,7 +15,7 @@ namespace web
 namespace nmos
 {
     // Audio channel symbols (used in audio sources) from VSF TR-03 Appendix A
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_audio.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_audio.html
     // and http://www.videoservicesforum.org/download/technical_recommendations/VSF_TR-03_2015-11-12.pdf
     DEFINE_STRING_ENUM(channel_symbol)
     namespace channel_symbols

--- a/Development/nmos/channels.h
+++ b/Development/nmos/channels.h
@@ -15,7 +15,7 @@ namespace web
 namespace nmos
 {
     // Audio channel symbols (used in audio sources) from VSF TR-03 Appendix A
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_audio.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_audio.json
     // and http://www.videoservicesforum.org/download/technical_recommendations/VSF_TR-03_2015-11-12.pdf
     DEFINE_STRING_ENUM(channel_symbol)
     namespace channel_symbols

--- a/Development/nmos/clock_name.h
+++ b/Development/nmos/clock_name.h
@@ -7,9 +7,9 @@
 namespace nmos
 {
     // Clock name
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_internal.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_ptp.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_core.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/clock_internal.html
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/clock_ptp.html
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_core.html
     DEFINE_STRING_ENUM(clock_name)
     namespace clock_names
     {

--- a/Development/nmos/clock_name.h
+++ b/Development/nmos/clock_name.h
@@ -7,9 +7,9 @@
 namespace nmos
 {
     // Clock name
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/clock_internal.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/clock_ptp.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_core.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_internal.json
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_ptp.json
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_core.json
     DEFINE_STRING_ENUM(clock_name)
     namespace clock_names
     {

--- a/Development/nmos/clock_ref_type.h
+++ b/Development/nmos/clock_ref_type.h
@@ -6,8 +6,8 @@
 namespace nmos
 {
     // Clock reference type
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/clock_internal.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/clock_ptp.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_internal.json
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_ptp.json
     DEFINE_STRING_ENUM(clock_ref_type)
     namespace clock_ref_types
     {

--- a/Development/nmos/clock_ref_type.h
+++ b/Development/nmos/clock_ref_type.h
@@ -6,8 +6,8 @@
 namespace nmos
 {
     // Clock reference type
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_internal.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_ptp.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/clock_internal.html
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/clock_ptp.html
     DEFINE_STRING_ENUM(clock_ref_type)
     namespace clock_ref_types
     {

--- a/Development/nmos/colorspace.h
+++ b/Development/nmos/colorspace.h
@@ -6,7 +6,7 @@
 namespace nmos
 {
     // Colorspace (used in video flows)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
     // and https://github.com/AMWA-TV/nmos-parameter-registers/tree/main/flow-attributes#colorspace
     DEFINE_STRING_ENUM(colorspace)
     namespace colorspaces

--- a/Development/nmos/colorspace.h
+++ b/Development/nmos/colorspace.h
@@ -6,8 +6,8 @@
 namespace nmos
 {
     // Colorspace (used in video flows)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
-    // and https://github.com/AMWA-TV/nmos-parameter-registers/tree/main/flow-attributes#colorspace
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video.html
+    // and https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#colorspace
     DEFINE_STRING_ENUM(colorspace)
     namespace colorspaces
     {

--- a/Development/nmos/components.h
+++ b/Development/nmos/components.h
@@ -7,8 +7,8 @@
 namespace nmos
 {
     // Components (for raw video flows since IS-04 v1.1, extended to coded video Flows since v1.3 by the entry in the Flow Attributes register)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video_raw.json
-    // and https://github.com/AMWA-TV/nmos-parameter-registers/tree/main/flow-attributes#components
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video_raw.html
+    // and https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#components
     DEFINE_STRING_ENUM(component_name)
     namespace component_names
     {

--- a/Development/nmos/components.h
+++ b/Development/nmos/components.h
@@ -7,7 +7,7 @@
 namespace nmos
 {
     // Components (for raw video flows since IS-04 v1.1, extended to coded video Flows since v1.3 by the entry in the Flow Attributes register)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video_raw.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video_raw.json
     // and https://github.com/AMWA-TV/nmos-parameter-registers/tree/main/flow-attributes#components
     DEFINE_STRING_ENUM(component_name)
     namespace component_names

--- a/Development/nmos/connection_activation.cpp
+++ b/Development/nmos/connection_activation.cpp
@@ -147,7 +147,7 @@ namespace nmos
                             // the resolve_auto callback may throw exceptions, which will prevent activation in order that
                             // "if there is an error condition that means `auto` cannot be resolved, the active transport parameters
                             // must not change, and the underlying sender [or receiver] must continue as before."
-                            // see https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L308-L309
+                            // see https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/ConnectionAPI.html#single_senders__senderid__active_get
                             resolve_auto(*matching_resource, connection_resource, nmos::fields::transport_params(endpoint_active));
 
                             active = nmos::fields::master_enable(endpoint_active);

--- a/Development/nmos/connection_activation.cpp
+++ b/Development/nmos/connection_activation.cpp
@@ -147,7 +147,7 @@ namespace nmos
                             // the resolve_auto callback may throw exceptions, which will prevent activation in order that
                             // "if there is an error condition that means `auto` cannot be resolved, the active transport parameters
                             // must not change, and the underlying sender [or receiver] must continue as before."
-                            // see https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/ConnectionAPI.raml#L308-L309
+                            // see https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L308-L309
                             resolve_auto(*matching_resource, connection_resource, nmos::fields::transport_params(endpoint_active));
 
                             active = nmos::fields::master_enable(endpoint_active);

--- a/Development/nmos/connection_api.cpp
+++ b/Development/nmos/connection_api.cpp
@@ -64,7 +64,7 @@ namespace nmos
         if (resource.version.minor <= version.minor) return true;
 
         // "Where a transport type is added in a new version of the Connection Management API specification, earlier versioned APIs must not list any Senders or Receivers which make use of this new transport type."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/5.0.%20Upgrade%20Path.md#requirements-for-connection-management-apis
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/5.0._Upgrade_Path.html#requirements-for-connection-management-apis
 
         typedef const std::map<nmos::api_version, std::set<nmos::transport>> versions_transport_bases_t;
         versions_transport_bases_t versions_transport_bases
@@ -137,8 +137,8 @@ namespace nmos
         static const std::map<nmos::type, std::set<utility::string_t>>& rtp_auto_constraints()
         {
             // These are the constraints that support "auto" in /staged; cf. resolve_rtp_auto
-            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_rtp.json
-            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_rtp.json
+            // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender_transport_params_rtp.html
+            // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_rtp.html
             static const std::map<nmos::type, std::set<utility::string_t>> auto_constraints
             {
                 {
@@ -178,8 +178,8 @@ namespace nmos
         static const std::map<nmos::type, std::set<utility::string_t>>& websocket_auto_constraints()
         {
             // These are the constraints that support "auto" in /staged
-            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_websocket.json
-            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_websocket.json
+            // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender_transport_params_websocket.html
+            // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_websocket.html
             static const std::map<nmos::type, std::set<utility::string_t>> auto_constraints
             {
                 {
@@ -202,8 +202,8 @@ namespace nmos
         static const std::map<nmos::type, std::set<utility::string_t>>& mqtt_auto_constraints()
         {
             // These are the constraints that support "auto" in /staged
-            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_mqtt.json
-            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_mqtt.json
+            // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender_transport_params_mqtt.html
+            // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_mqtt.html
             static const std::map<nmos::type, std::set<utility::string_t>> auto_constraints
             {
                 {
@@ -313,8 +313,8 @@ namespace nmos
         std::pair<utility::string_t, utility::string_t> get_transport_type_data(const web::json::value& transport_file)
         {
             // "'data' and 'type' must both be strings or both be null"
-            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.2/APIs/schemas/v1.0-receiver-response-schema.json
-            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver-transport-file.json
+            // See https://specs.amwa.tv/is-05/releases/v1.0.2/APIs/schemas/with-refs/v1.0-receiver-response-schema.html
+            // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver-transport-file.html
 
             if (!transport_file.has_field(nmos::fields::data)) throw transport_file_error("data is required");
 
@@ -436,7 +436,7 @@ namespace nmos
 
                         // "If a 'bulk' request includes multiple sets of parameters for the same Sender or Receiver ID the behaviour is defined by the implementation.
                         // In order to maximise interoperability clients are encouraged not to include the same Sender or Receiver ID multiple times in the same 'bulk' request."
-                        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.2/docs/4.0.%20Behaviour.md#salvo-operation
+                        // See https://specs.amwa.tv/is-05/releases/v1.0.2/docs/4.0._Behaviour.html#salvo-operation
                         if (!requested_time_or_null.is_null() && request_time == web::json::as<nmos::tai>(requested_time_or_null))
                         {
                             slog::log<slog::severities::error>(gate, SLOG_FLF) << "Rejecting PATCH request for " << id_type << " due to a pending immediate activation from the same bulk request";
@@ -444,7 +444,7 @@ namespace nmos
                             return details::make_connection_resource_patch_error_response(status_codes::BadRequest);
                         }
                         // "If an API implementation receives a new PATCH request to the /staged resource while an activation is in progress it SHOULD block the request until the previous activation is complete."
-                        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.0.%20Behaviour.md#in-progress-activations
+                        // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.0._Behaviour.html#in-progress-activations
                         else if (!details::wait_immediate_activation_not_pending(model, lock, id_type) || model.shutdown)
                         {
                             slog::log<slog::severities::error>(gate, SLOG_FLF) << "Rejecting PATCH request for " << id_type << " due to a pending immediate activation";
@@ -480,12 +480,12 @@ namespace nmos
 
                 // "In the case where the transport file and transport parameters are updated in the same PATCH request
                 // transport parameters specified in the request object take precedence over those in the transport file."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L369
+                // See https://specs.amwa.tv/is-05/releases/v1.0.0/APIs/ConnectionAPI.html#single_receivers__receiverid__staged_patch
                 // "In all other cases the most recently received PATCH request takes priority."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#interpretation-of-sdp-files
+                // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/4.1._Behaviour_-_RTP_Transport_Type.html#interpretation-of-sdp-files
 
                 // First, validate and merge the transport file (this resource must be a receiver)
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L344-L363
+                // See https://specs.amwa.tv/is-05/releases/v1.0.0/APIs/ConnectionAPI.html#single_receivers__receiverid__staged_patch
 
                 auto& transport_file = nmos::fields::transport_file(patch);
                 if (!transport_file.is_null() && !transport_file.as_object().empty())
@@ -648,7 +648,7 @@ namespace nmos
 
                             // "It is strongly recommended that the following caching headers are included via the /transportfile endpoint (or whatever this endpoint redirects to).
                             // This is important to ensure that connection management clients do not cache the contents of transport files which are liable to change."
-                            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/4.0.%20Behaviour.md#transport-files--caching
+                            // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/4.0._Behaviour.html#transport-files--caching
                             res.headers().set_cache_control(U("no-cache"));
                         }
                         else
@@ -666,16 +666,9 @@ namespace nmos
                         // (or this is an internal server error, but since a 5xx response is not defined, assume one of the former cases)
                         slog::log<slog::severities::warning>(gate, SLOG_FLF) << "Transport file requested for " << id_type << " which does not have one";
 
-                        // An HTTP 404 response may be returned if "the transport type does not require a transport file".
-                        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L339-L340
-                        // "When the `master_enable` parameter is false [...] the `/transportfile` endpoint should return an HTTP 404 response."
-                        // In other words an HTTP 404 response is returned "if the sender is not currently configured".
-                        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L163-L165
-                        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L277
-                        // Those statements are going to be combined and adjusted slightly in the next specification patch release to say:
                         // An HTTP 404 response is returned if "the transport type does not require a transport file, or if the sender is not currently configured"
-                        // and "may also be returned when the `master_enable` parameter is false in /active, if the sender only maintains a transport file when transmitting."
-                        // See https://github.com/AMWA-TV/nmos-device-connection-management/pull/111
+                        // and "may also be returned when the `master_enable` parameter is `false` in /active, if the sender only maintains a transport file when transmitting."
+                        // See https://specs.amwa.tv/is-05/releases/v1.1.1/APIs/ConnectionAPI.html#http-status-code-404-6
                         set_error_reply(res, status_codes::NotFound, U("Sender is not configured with a transport file"));
                     }
                 }
@@ -722,19 +715,19 @@ namespace nmos
         // transport parameters must not change, and the underlying sender must continue as before."
         // Therefore, in case it throws an exception, resolve_auto is called on a copy of the /staged resource data,
         // before making any changes to the /active resource data.
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L300-L309
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/ConnectionAPI.html#single_senders__senderid__active_get
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/docs/2.2._APIs_-_Server_Side_Implementation.html#use-of-auto
         auto activating = staged;
         resolve_auto(activating);
 
         // "When a set of 'staged' settings is activated, these settings transition into the 'active' resource."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/1.0.%20Overview.md#active
+        // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/1.0._Overview.html#active
         active = activating;
 
         // Unclear whether the activation in the active endpoint should have values for mode, requested_time
         // (and even activation_time?) or whether they should be null? The examples have them with values.
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/examples/v1.0-receiver-active-get-200.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/examples/v1.0-sender-active-get.json
+        // See https://specs.amwa.tv/is-05/releases/v1.0.0/examples/v1.0-receiver-active-get-200.html
+        // and https://specs.amwa.tv/is-05/releases/v1.0.0/examples/v1.0-sender-active-get.html
 
         if (nmos::activation_modes::activate_scheduled_absolute == staged_mode ||
             nmos::activation_modes::activate_scheduled_relative == staged_mode)
@@ -755,10 +748,10 @@ namespace nmos
         // "This parameter returns to null on the staged endpoint once an activation is completed."
         // "This field returns to null once the activation is completed on the staged endpoint."
         // "On the staged endpoint this field returns to null once the activation is completed."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/schemas/v1.0-activation-response-schema.json
+        // See https://specs.amwa.tv/is-05/releases/v1.0.0/APIs/schemas/with-refs/v1.0-activation-response-schema.html
 
         // "A resource may be unlocked by setting `mode` in `activation` to `null`, which will cancel the pending activation."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L244
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/ConnectionAPI.html#http-status-code-423
 
         staged_activation = nmos::make_activation();
     }
@@ -775,12 +768,12 @@ namespace nmos
 
         // "The 'receiver_id' key MUST be set to `null` in all cases except where a unicast push-based Sender is configured to transmit to an NMOS Receiver, and the 'active' key is set to 'true'."
         // "The 'sender_id' key MUST be set to `null` in all cases except where the Receiver is currently configured to receive from an NMOS Sender, and the 'active' key is set to 'true'.
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.2/docs/4.3.%20Behaviour%20-%20Nodes.md#api-resources
+        // See https://specs.amwa.tv/is-04/releases/v1.2.2/docs/4.3._Behaviour_-_Nodes.html#api-resources
         const auto ci = active && !connected_id.empty() ? value::string(connected_id) : value::null();
 
         // "When the 'active' parameters of a Sender or Receiver are modified, or when a re-activation of the same parameters
         // is performed, the 'version' attribute of the relevant IS-04 Sender or Receiver must be incremented."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/3.1.%20Interoperability%20-%20NMOS%20IS-04.md#version-increments
+        // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/3.1._Interoperability_-_NMOS_IS-04.html#version-increments
         resource.data[nmos::fields::version] = at;
 
         // Senders indicate the connected receiver_id, receivers indicate the connected sender_id
@@ -826,7 +819,7 @@ namespace nmos
         // "Where a Receiver supports SMPTE 2022-7 but is required to Receive a non-SMPTE 2022-7 stream,
         // only the first set of transport parameters should be used. rtp_enabled in the second set of parameters
         // must be set to false"
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#operation-with-smpte-2022-7
+        // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/4.1._Behaviour_-_RTP_Transport_Type.html#operation-with-smpte-2022-7
         if (2 == legs && 1 == sdp_transport_params.second.size())
         {
             web::json::push_back(sdp_transport_params.second, web::json::value_of({ { U("rtp_enabled"), false } }));
@@ -836,17 +829,17 @@ namespace nmos
     }
 
     // "On activation all instances of "auto" should be resolved into the actual values that will be used"
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L300-L301
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_rtp.json
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_rtp.json
+    // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/ConnectionAPI.html#single_senders__senderid__active_get
+    // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender_transport_params_rtp.html
+    // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_rtp.html
     // "In many cases this is a simple operation, and the behaviour is very clearly defined in the relevant transport parameter schemas.
     // For example a port number may be offset from the RTP port number by a pre-determined value. The specification makes suggestions
     // of a sensible default value for "auto" to resolve to, but the Sender or Receiver may choose any value permitted by the schema
     // and constraints."
     // This function implements those sensible defaults for the RTP transport type.
     // "In some cases the behaviour is more complex, and may be determined by the vendor."
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#use-of-auto
+    // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/2.2._APIs_-_Server_Side_Implementation.html#use-of-auto
+    // and https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.1._Behaviour_-_RTP_Transport_Type.html#use-of-auto
     // This function therefore does not select a value for e.g. sender "source_ip" or receiver "interface_ip".
     void resolve_rtp_auto(const nmos::type& type, web::json::value& transport_params, int auto_rtp_port)
     {
@@ -908,8 +901,8 @@ namespace nmos
 
         // "The API should actively return an HTTP 405 if a GET is called on the [/bulk/senders and /bulk/receivers] endpoint[s]."
         // This is provided for free by the api_router which also identifies the handler for POST as a "near miss"
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L39-L44
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L73-L78
+        // See https://specs.amwa.tv/is-05/releases/v1.0.0/APIs/ConnectionAPI.html#bulk_senders_get
+        // and https://specs.amwa.tv/is-05/releases/v1.0.0/APIs/ConnectionAPI.html#bulk_receivers_get
 
         connection_api.support(U("/bulk/") + nmos::patterns::connectorType.pattern + U("/?"), methods::POST, [&model, parse_transport_file, validate_merged, &gate_](http_request req, http_response res, const string_t&, const route_parameters& parameters)
         {
@@ -933,7 +926,7 @@ namespace nmos
                 // underlying Senders and Receivers, it may choose to perform 'bulk' resource operations
                 // in a parallel fashion internally. This is an implementation decision and is not a
                 // requirement of this specification."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/4.0.%20Behaviour.md
+                // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/4.0._Behaviour.html
 
                 const auto type = nmos::type_from_resourceType(resourceType);
 
@@ -1025,7 +1018,7 @@ namespace nmos
                     if (web::http::is_success_status_code(result.first))
                     {
                         // make a bulk response success item
-                        // see https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.1/APIs/schemas/v1.0-bulk-response-schema.json
+                        // see https://specs.amwa.tv/is-05/releases/v1.0.1/APIs/schemas/with-refs/v1.0-bulk-response-schema.html
                         result.second = value_of({
                             { nmos::fields::id, id },
                             { U("code"), result.first }
@@ -1266,7 +1259,7 @@ namespace nmos
                         if (details::immediate_activation_pending == staged_state)
                         {
                             // "Any GET requests to `/staged` during this time [while an activation is in progress] MAY also be blocked until the activation is complete."
-                            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.0.%20Behaviour.md#in-progress-activations
+                            // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.0._Behaviour.html#in-progress-activations
                             if (!details::wait_immediate_activation_not_pending(model, lock, id_type) || model.shutdown)
                             {
                                 slog::log<slog::severities::error>(gate, SLOG_FLF) << "Rejecting GET request for " << id_type << " due to a pending immediate activation";
@@ -1354,7 +1347,7 @@ namespace nmos
                 if (nmos::is_connection_api_permitted_downgrade(*matching_resource, *resource, version))
                 {
                     // "Returns the URN base for the transport type employed by this sender with any subclassifications or versions removed."
-                    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L349
+                    // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/ConnectionAPI.html#single_senders__senderid__transporttype_get
                     const nmos::transport transport_subclassification(nmos::fields::transport(matching_resource->data));
                     set_reply(res, status_codes::OK, web::json::value::string(nmos::transport_base(transport_subclassification).name));
                 }

--- a/Development/nmos/connection_api.cpp
+++ b/Development/nmos/connection_api.cpp
@@ -64,7 +64,7 @@ namespace nmos
         if (resource.version.minor <= version.minor) return true;
 
         // "Where a transport type is added in a new version of the Connection Management API specification, earlier versioned APIs must not list any Senders or Receivers which make use of this new transport type."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/5.0.%20Upgrade%20Path.md#requirements-for-connection-management-apis
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/5.0.%20Upgrade%20Path.md#requirements-for-connection-management-apis
 
         typedef const std::map<nmos::api_version, std::set<nmos::transport>> versions_transport_bases_t;
         versions_transport_bases_t versions_transport_bases
@@ -137,8 +137,8 @@ namespace nmos
         static const std::map<nmos::type, std::set<utility::string_t>>& rtp_auto_constraints()
         {
             // These are the constraints that support "auto" in /staged; cf. resolve_rtp_auto
-            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender_transport_params_rtp.json
-            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_rtp.json
+            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_rtp.json
+            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_rtp.json
             static const std::map<nmos::type, std::set<utility::string_t>> auto_constraints
             {
                 {
@@ -178,8 +178,8 @@ namespace nmos
         static const std::map<nmos::type, std::set<utility::string_t>>& websocket_auto_constraints()
         {
             // These are the constraints that support "auto" in /staged
-            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender_transport_params_websocket.json
-            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_websocket.json
+            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_websocket.json
+            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_websocket.json
             static const std::map<nmos::type, std::set<utility::string_t>> auto_constraints
             {
                 {
@@ -202,8 +202,8 @@ namespace nmos
         static const std::map<nmos::type, std::set<utility::string_t>>& mqtt_auto_constraints()
         {
             // These are the constraints that support "auto" in /staged
-            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender_transport_params_mqtt.json
-            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_mqtt.json
+            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_mqtt.json
+            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_mqtt.json
             static const std::map<nmos::type, std::set<utility::string_t>> auto_constraints
             {
                 {
@@ -314,7 +314,7 @@ namespace nmos
         {
             // "'data' and 'type' must both be strings or both be null"
             // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.2/APIs/schemas/v1.0-receiver-response-schema.json
-            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver-transport-file.json
+            // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver-transport-file.json
 
             if (!transport_file.has_field(nmos::fields::data)) throw transport_file_error("data is required");
 
@@ -444,7 +444,7 @@ namespace nmos
                             return details::make_connection_resource_patch_error_response(status_codes::BadRequest);
                         }
                         // "If an API implementation receives a new PATCH request to the /staged resource while an activation is in progress it SHOULD block the request until the previous activation is complete."
-                        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.0.%20Behaviour.md#in-progress-activations
+                        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.0.%20Behaviour.md#in-progress-activations
                         else if (!details::wait_immediate_activation_not_pending(model, lock, id_type) || model.shutdown)
                         {
                             slog::log<slog::severities::error>(gate, SLOG_FLF) << "Rejecting PATCH request for " << id_type << " due to a pending immediate activation";
@@ -480,12 +480,12 @@ namespace nmos
 
                 // "In the case where the transport file and transport parameters are updated in the same PATCH request
                 // transport parameters specified in the request object take precedence over those in the transport file."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/ConnectionAPI.raml#L369
+                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L369
                 // "In all other cases the most recently received PATCH request takes priority."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#interpretation-of-sdp-files
+                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#interpretation-of-sdp-files
 
                 // First, validate and merge the transport file (this resource must be a receiver)
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/ConnectionAPI.raml#L344-L363
+                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L344-L363
 
                 auto& transport_file = nmos::fields::transport_file(patch);
                 if (!transport_file.is_null() && !transport_file.as_object().empty())
@@ -648,7 +648,7 @@ namespace nmos
 
                             // "It is strongly recommended that the following caching headers are included via the /transportfile endpoint (or whatever this endpoint redirects to).
                             // This is important to ensure that connection management clients do not cache the contents of transport files which are liable to change."
-                            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/4.0.%20Behaviour.md#transport-files--caching
+                            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/4.0.%20Behaviour.md#transport-files--caching
                             res.headers().set_cache_control(U("no-cache"));
                         }
                         else
@@ -667,11 +667,11 @@ namespace nmos
                         slog::log<slog::severities::warning>(gate, SLOG_FLF) << "Transport file requested for " << id_type << " which does not have one";
 
                         // An HTTP 404 response may be returned if "the transport type does not require a transport file".
-                        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/ConnectionAPI.raml#L339-L340
+                        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L339-L340
                         // "When the `master_enable` parameter is false [...] the `/transportfile` endpoint should return an HTTP 404 response."
                         // In other words an HTTP 404 response is returned "if the sender is not currently configured".
-                        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/ConnectionAPI.raml#L163-L165
-                        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/ConnectionAPI.raml#L277
+                        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L163-L165
+                        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L277
                         // Those statements are going to be combined and adjusted slightly in the next specification patch release to say:
                         // An HTTP 404 response is returned if "the transport type does not require a transport file, or if the sender is not currently configured"
                         // and "may also be returned when the `master_enable` parameter is false in /active, if the sender only maintains a transport file when transmitting."
@@ -722,19 +722,19 @@ namespace nmos
         // transport parameters must not change, and the underlying sender must continue as before."
         // Therefore, in case it throws an exception, resolve_auto is called on a copy of the /staged resource data,
         // before making any changes to the /active resource data.
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/ConnectionAPI.raml#L300-L309
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L300-L309
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
         auto activating = staged;
         resolve_auto(activating);
 
         // "When a set of 'staged' settings is activated, these settings transition into the 'active' resource."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/1.0.%20Overview.md#active
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/1.0.%20Overview.md#active
         active = activating;
 
         // Unclear whether the activation in the active endpoint should have values for mode, requested_time
         // (and even activation_time?) or whether they should be null? The examples have them with values.
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/examples/v1.0-receiver-active-get-200.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/examples/v1.0-sender-active-get.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/examples/v1.0-receiver-active-get-200.json
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/examples/v1.0-sender-active-get.json
 
         if (nmos::activation_modes::activate_scheduled_absolute == staged_mode ||
             nmos::activation_modes::activate_scheduled_relative == staged_mode)
@@ -755,10 +755,10 @@ namespace nmos
         // "This parameter returns to null on the staged endpoint once an activation is completed."
         // "This field returns to null once the activation is completed on the staged endpoint."
         // "On the staged endpoint this field returns to null once the activation is completed."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/schemas/v1.0-activation-response-schema.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/schemas/v1.0-activation-response-schema.json
 
         // "A resource may be unlocked by setting `mode` in `activation` to `null`, which will cancel the pending activation."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/ConnectionAPI.raml#L244
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L244
 
         staged_activation = nmos::make_activation();
     }
@@ -780,7 +780,7 @@ namespace nmos
 
         // "When the 'active' parameters of a Sender or Receiver are modified, or when a re-activation of the same parameters
         // is performed, the 'version' attribute of the relevant IS-04 Sender or Receiver must be incremented."
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/3.1.%20Interoperability%20-%20NMOS%20IS-04.md#version-increments
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/3.1.%20Interoperability%20-%20NMOS%20IS-04.md#version-increments
         resource.data[nmos::fields::version] = at;
 
         // Senders indicate the connected receiver_id, receivers indicate the connected sender_id
@@ -826,7 +826,7 @@ namespace nmos
         // "Where a Receiver supports SMPTE 2022-7 but is required to Receive a non-SMPTE 2022-7 stream,
         // only the first set of transport parameters should be used. rtp_enabled in the second set of parameters
         // must be set to false"
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#operation-with-smpte-2022-7
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#operation-with-smpte-2022-7
         if (2 == legs && 1 == sdp_transport_params.second.size())
         {
             web::json::push_back(sdp_transport_params.second, web::json::value_of({ { U("rtp_enabled"), false } }));
@@ -836,17 +836,17 @@ namespace nmos
     }
 
     // "On activation all instances of "auto" should be resolved into the actual values that will be used"
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/ConnectionAPI.raml#L300-L301
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender_transport_params_rtp.json
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_rtp.json
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L300-L301
+    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_rtp.json
+    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_rtp.json
     // "In many cases this is a simple operation, and the behaviour is very clearly defined in the relevant transport parameter schemas.
     // For example a port number may be offset from the RTP port number by a pre-determined value. The specification makes suggestions
     // of a sensible default value for "auto" to resolve to, but the Sender or Receiver may choose any value permitted by the schema
     // and constraints."
     // This function implements those sensible defaults for the RTP transport type.
     // "In some cases the behaviour is more complex, and may be determined by the vendor."
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#use-of-auto
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
+    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#use-of-auto
     // This function therefore does not select a value for e.g. sender "source_ip" or receiver "interface_ip".
     void resolve_rtp_auto(const nmos::type& type, web::json::value& transport_params, int auto_rtp_port)
     {
@@ -908,8 +908,8 @@ namespace nmos
 
         // "The API should actively return an HTTP 405 if a GET is called on the [/bulk/senders and /bulk/receivers] endpoint[s]."
         // This is provided for free by the api_router which also identifies the handler for POST as a "near miss"
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/ConnectionAPI.raml#L39-L44
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/ConnectionAPI.raml#L73-L78
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L39-L44
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/APIs/ConnectionAPI.raml#L73-L78
 
         connection_api.support(U("/bulk/") + nmos::patterns::connectorType.pattern + U("/?"), methods::POST, [&model, parse_transport_file, validate_merged, &gate_](http_request req, http_response res, const string_t&, const route_parameters& parameters)
         {
@@ -933,7 +933,7 @@ namespace nmos
                 // underlying Senders and Receivers, it may choose to perform 'bulk' resource operations
                 // in a parallel fashion internally. This is an implementation decision and is not a
                 // requirement of this specification."
-                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/4.0.%20Behaviour.md
+                // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/4.0.%20Behaviour.md
 
                 const auto type = nmos::type_from_resourceType(resourceType);
 
@@ -1025,7 +1025,7 @@ namespace nmos
                     if (web::http::is_success_status_code(result.first))
                     {
                         // make a bulk response success item
-                        // see https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/APIs/schemas/v1.0-bulk-response-schema.json
+                        // see https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.1/APIs/schemas/v1.0-bulk-response-schema.json
                         result.second = value_of({
                             { nmos::fields::id, id },
                             { U("code"), result.first }
@@ -1266,7 +1266,7 @@ namespace nmos
                         if (details::immediate_activation_pending == staged_state)
                         {
                             // "Any GET requests to `/staged` during this time [while an activation is in progress] MAY also be blocked until the activation is complete."
-                            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.0.%20Behaviour.md#in-progress-activations
+                            // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.0.%20Behaviour.md#in-progress-activations
                             if (!details::wait_immediate_activation_not_pending(model, lock, id_type) || model.shutdown)
                             {
                                 slog::log<slog::severities::error>(gate, SLOG_FLF) << "Rejecting GET request for " << id_type << " due to a pending immediate activation";
@@ -1354,7 +1354,7 @@ namespace nmos
                 if (nmos::is_connection_api_permitted_downgrade(*matching_resource, *resource, version))
                 {
                     // "Returns the URN base for the transport type employed by this sender with any subclassifications or versions removed."
-                    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/ConnectionAPI.raml#L349
+                    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L349
                     const nmos::transport transport_subclassification(nmos::fields::transport(matching_resource->data));
                     set_reply(res, status_codes::OK, web::json::value::string(nmos::transport_base(transport_subclassification).name));
                 }

--- a/Development/nmos/connection_api.h
+++ b/Development/nmos/connection_api.h
@@ -10,7 +10,7 @@ namespace slog
 }
 
 // Connection API implementation
-// See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/ConnectionAPI.raml
+// See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml
 namespace nmos
 {
     struct api_version;
@@ -74,17 +74,17 @@ namespace nmos
     web::json::value parse_rtp_transport_file(const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate);
 
     // "On activation all instances of "auto" must be resolved into the actual values that will be used by the sender, unless there is an error condition."
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/ConnectionAPI.raml#L300-L301
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender_transport_params_rtp.json
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_rtp.json
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L300-L301
+    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_rtp.json
+    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_rtp.json
     // "In many cases this is a simple operation, and the behaviour is very clearly defined in the relevant transport parameter schemas.
     // For example a port number may be offset from the RTP port number by a pre-determined value. The specification makes suggestions
     // of a sensible default value for "auto" to resolve to, but the Sender or Receiver may choose any value permitted by the schema
     // and constraints."
     // This function implements those sensible defaults for the RTP transport type.
     // "In some cases the behaviour is more complex, and may be determined by the vendor."
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#use-of-auto
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
+    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#use-of-auto
     // This function therefore does not select a value for e.g. sender "source_ip" or receiver "interface_ip".
     void resolve_rtp_auto(const nmos::type& type, web::json::value& transport_params, int auto_rtp_port = 5004);
 

--- a/Development/nmos/connection_api.h
+++ b/Development/nmos/connection_api.h
@@ -10,7 +10,7 @@ namespace slog
 }
 
 // Connection API implementation
-// See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml
+// See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/ConnectionAPI.html
 namespace nmos
 {
     struct api_version;
@@ -74,17 +74,17 @@ namespace nmos
     web::json::value parse_rtp_transport_file(const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate);
 
     // "On activation all instances of "auto" must be resolved into the actual values that will be used by the sender, unless there is an error condition."
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/ConnectionAPI.raml#L300-L301
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_rtp.json
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_rtp.json
+    // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/ConnectionAPI.html#single_senders__senderid__active_get
+    // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender_transport_params_rtp.html
+    // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_rtp.html
     // "In many cases this is a simple operation, and the behaviour is very clearly defined in the relevant transport parameter schemas.
     // For example a port number may be offset from the RTP port number by a pre-determined value. The specification makes suggestions
     // of a sensible default value for "auto" to resolve to, but the Sender or Receiver may choose any value permitted by the schema
     // and constraints."
     // This function implements those sensible defaults for the RTP transport type.
     // "In some cases the behaviour is more complex, and may be determined by the vendor."
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/2.2.%20APIs%20-%20Server%20Side%20Implementation.md#use-of-auto
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#use-of-auto
+    // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/2.2._APIs_-_Server_Side_Implementation.html#use-of-auto
+    // and https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.1._Behaviour_-_RTP_Transport_Type.html#use-of-auto
     // This function therefore does not select a value for e.g. sender "source_ip" or receiver "interface_ip".
     void resolve_rtp_auto(const nmos::type& type, web::json::value& transport_params, int auto_rtp_port = 5004);
 

--- a/Development/nmos/connection_resources.cpp
+++ b/Development/nmos/connection_resources.cpp
@@ -32,8 +32,8 @@ namespace nmos
             return redundant ? value_of({ value, value }) : value_of({ value });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender-response-schema.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver-response-schema.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender-response-schema.json
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver-response-schema.json
         web::json::value make_connection_resource_staging_core(bool redundant)
         {
             using web::json::value;
@@ -50,7 +50,7 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver-transport-file.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver-transport-file.json
         web::json::value make_connection_receiver_staging_transport_file()
         {
             using web::json::value;
@@ -76,8 +76,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#sender-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/constraints-schema-rtp.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#sender-parameter-sets
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-rtp.json
         web::json::value make_connection_rtp_sender_core_constraints()
         {
             using web::json::value;
@@ -93,8 +93,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#sender-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender_transport_params_rtp.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#sender-parameter-sets
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_rtp.json
         web::json::value make_connection_rtp_sender_staged_core_parameter_set()
         {
             using web::json::value;
@@ -109,8 +109,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#receiver-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/constraints-schema-rtp.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#receiver-parameter-sets
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-rtp.json
         web::json::value make_connection_rtp_receiver_core_constraints()
         {
             using web::json::value;
@@ -126,8 +126,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#receiver-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_rtp.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#receiver-parameter-sets
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_rtp.json
         web::json::value make_connection_rtp_receiver_staged_core_parameter_set()
         {
             using web::json::value;
@@ -243,8 +243,8 @@ namespace nmos
             return indeterminate(v) ? web::json::value::string(U("auto")) : web::json::value::boolean(bool(v));
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/constraints-schema-websocket.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender_transport_params_websocket.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-websocket.json
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_websocket.json
         web::json::value make_connection_websocket_sender_core_constraints(const web::uri& connection_uri, boost::tribool connection_authorization)
         {
             using web::json::value;
@@ -262,8 +262,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.3.%20Behaviour%20-%20WebSocket%20Transport%20Type.md#sender-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender_transport_params_websocket.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.3.%20Behaviour%20-%20WebSocket%20Transport%20Type.md#sender-parameter-sets
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_websocket.json
         web::json::value make_connection_websocket_sender_staged_core_parameter_set(const web::uri& connection_uri, boost::tribool connection_authorization)
         {
             using web::json::value;
@@ -275,8 +275,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/constraints-schema-websocket.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_websocket.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-websocket.json
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_websocket.json
         web::json::value make_connection_websocket_receiver_core_constraints(boost::tribool connection_authorization)
         {
             using web::json::value;
@@ -289,8 +289,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.3.%20Behaviour%20-%20WebSocket%20Transport%20Type.md#receiver-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_websocket.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.3.%20Behaviour%20-%20WebSocket%20Transport%20Type.md#receiver-parameter-sets
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_websocket.json
         web::json::value make_connection_websocket_receiver_staged_core_parameter_set(boost::tribool connection_authorization)
         {
             using web::json::value;
@@ -302,8 +302,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/constraints-schema-mqtt.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender_transport_params_mqtt.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-mqtt.json
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_mqtt.json
         web::json::value make_connection_mqtt_sender_core_constraints(boost::tribool broker_secure, boost::tribool broker_authorization, const utility::string_t& broker_topic, const utility::string_t& connection_status_broker_topic)
         {
             using web::json::value;
@@ -332,8 +332,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.2.%20Behaviour%20-%20MQTT%20Transport%20Type.md#sender-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender_transport_params_mqtt.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.2.%20Behaviour%20-%20MQTT%20Transport%20Type.md#sender-parameter-sets
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_mqtt.json
         web::json::value make_connection_mqtt_sender_staged_core_parameter_set(boost::tribool broker_secure, boost::tribool broker_authorization, const utility::string_t& broker_topic, const utility::string_t& connection_status_broker_topic)
         {
             using web::json::value;
@@ -349,8 +349,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/constraints-schema-mqtt.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_mqtt.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-mqtt.json
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_mqtt.json
         web::json::value make_connection_mqtt_receiver_core_constraints(boost::tribool broker_secure, boost::tribool broker_authorization)
         {
             using web::json::value;
@@ -371,8 +371,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/docs/4.2.%20Behaviour%20-%20MQTT%20Transport%20Type.md#receiver-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_mqtt.json
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.2.%20Behaviour%20-%20MQTT%20Transport%20Type.md#receiver-parameter-sets
+        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_mqtt.json
         web::json::value make_connection_mqtt_receiver_staged_core_parameter_set(boost::tribool broker_secure, boost::tribool broker_authorization)
         {
             using web::json::value;
@@ -388,8 +388,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/sender_transport_params_ext.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
+        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/sender_transport_params_ext.json
         web::json::value make_connection_events_websocket_sender_ext_constraints(const nmos::id& source_id, const web::uri& rest_api_url)
         {
             using web::json::value;
@@ -409,8 +409,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/sender_transport_params_ext.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
+        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/sender_transport_params_ext.json
         web::json::value make_connection_events_websocket_sender_staged_ext_parameter_set(const nmos::id& source_id, const web::uri& rest_api_url)
         {
             using web::json::value;
@@ -422,8 +422,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/receiver_transport_params_ext.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
+        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/receiver_transport_params_ext.json
         web::json::value make_connection_events_websocket_receiver_ext_constraints()
         {
             using web::json::value;
@@ -436,8 +436,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/receiver_transport_params_ext.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
+        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/receiver_transport_params_ext.json
         web::json::value make_connection_events_websocket_receiver_staged_ext_parameter_set()
         {
             using web::json::value;
@@ -449,8 +449,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/sender_transport_params_ext.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
+        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/sender_transport_params_ext.json
         web::json::value make_connection_events_mqtt_sender_ext_constraints(const web::uri& rest_api_url)
         {
             using web::json::value;
@@ -465,8 +465,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/sender_transport_params_ext.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
+        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/sender_transport_params_ext.json
         web::json::value make_connection_events_mqtt_sender_staged_ext_parameter_set(const web::uri& rest_api_url)
         {
             using web::json::value;
@@ -477,8 +477,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/receiver_transport_params_ext.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
+        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/receiver_transport_params_ext.json
         web::json::value make_connection_events_mqtt_receiver_ext_constraints()
         {
             using web::json::value;
@@ -490,8 +490,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/receiver_transport_params_ext.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
+        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/receiver_transport_params_ext.json
         web::json::value make_connection_events_mqtt_receiver_staged_ext_parameter_set()
         {
             using web::json::value;
@@ -505,7 +505,7 @@ namespace nmos
 
     // Although these functions make "connection" (IS-05) resources, the details are defined by IS-07 Event & Tally
     // so maybe these belong in nmos/events_resources.h or their own file, e.g. nmos/connection_events_resources.h?
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
     nmos::resource make_connection_events_websocket_sender(const nmos::id& id, const nmos::id& device_id, const nmos::id& source_id, const nmos::settings& settings)
     {
         using web::json::value;

--- a/Development/nmos/connection_resources.cpp
+++ b/Development/nmos/connection_resources.cpp
@@ -32,8 +32,8 @@ namespace nmos
             return redundant ? value_of({ value, value }) : value_of({ value });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender-response-schema.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver-response-schema.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender-response-schema.html
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver-response-schema.html
         web::json::value make_connection_resource_staging_core(bool redundant)
         {
             using web::json::value;
@@ -50,7 +50,7 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver-transport-file.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver-transport-file.html
         web::json::value make_connection_receiver_staging_transport_file()
         {
             using web::json::value;
@@ -76,8 +76,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#sender-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-rtp.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.1._Behaviour_-_RTP_Transport_Type.html#sender-parameter-sets
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/constraints-schema-rtp.html
         web::json::value make_connection_rtp_sender_core_constraints()
         {
             using web::json::value;
@@ -93,8 +93,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#sender-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_rtp.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.1._Behaviour_-_RTP_Transport_Type.html#sender-parameter-sets
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender_transport_params_rtp.html
         web::json::value make_connection_rtp_sender_staged_core_parameter_set()
         {
             using web::json::value;
@@ -109,8 +109,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#receiver-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-rtp.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.1._Behaviour_-_RTP_Transport_Type.html#receiver-parameter-sets
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/constraints-schema-rtp.html
         web::json::value make_connection_rtp_receiver_core_constraints()
         {
             using web::json::value;
@@ -126,8 +126,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#receiver-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_rtp.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.1._Behaviour_-_RTP_Transport_Type.html#receiver-parameter-sets
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_rtp.html
         web::json::value make_connection_rtp_receiver_staged_core_parameter_set()
         {
             using web::json::value;
@@ -243,8 +243,8 @@ namespace nmos
             return indeterminate(v) ? web::json::value::string(U("auto")) : web::json::value::boolean(bool(v));
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-websocket.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_websocket.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/constraints-schema-websocket.html
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender_transport_params_websocket.html
         web::json::value make_connection_websocket_sender_core_constraints(const web::uri& connection_uri, boost::tribool connection_authorization)
         {
             using web::json::value;
@@ -262,8 +262,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.3.%20Behaviour%20-%20WebSocket%20Transport%20Type.md#sender-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_websocket.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.3._Behaviour_-_WebSocket_Transport_Type.html#sender-parameter-sets
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender_transport_params_websocket.html
         web::json::value make_connection_websocket_sender_staged_core_parameter_set(const web::uri& connection_uri, boost::tribool connection_authorization)
         {
             using web::json::value;
@@ -275,8 +275,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-websocket.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_websocket.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/constraints-schema-websocket.html
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_websocket.html
         web::json::value make_connection_websocket_receiver_core_constraints(boost::tribool connection_authorization)
         {
             using web::json::value;
@@ -289,8 +289,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.3.%20Behaviour%20-%20WebSocket%20Transport%20Type.md#receiver-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_websocket.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.3._Behaviour_-_WebSocket_Transport_Type.html#receiver-parameter-sets
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_websocket.html
         web::json::value make_connection_websocket_receiver_staged_core_parameter_set(boost::tribool connection_authorization)
         {
             using web::json::value;
@@ -302,8 +302,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-mqtt.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_mqtt.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/constraints-schema-mqtt.html
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender_transport_params_mqtt.html
         web::json::value make_connection_mqtt_sender_core_constraints(boost::tribool broker_secure, boost::tribool broker_authorization, const utility::string_t& broker_topic, const utility::string_t& connection_status_broker_topic)
         {
             using web::json::value;
@@ -332,8 +332,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.2.%20Behaviour%20-%20MQTT%20Transport%20Type.md#sender-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender_transport_params_mqtt.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.2._Behaviour_-_MQTT_Transport_Type.html#sender-parameter-sets
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender_transport_params_mqtt.html
         web::json::value make_connection_mqtt_sender_staged_core_parameter_set(boost::tribool broker_secure, boost::tribool broker_authorization, const utility::string_t& broker_topic, const utility::string_t& connection_status_broker_topic)
         {
             using web::json::value;
@@ -349,8 +349,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema-mqtt.json
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_mqtt.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/constraints-schema-mqtt.html
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_mqtt.html
         web::json::value make_connection_mqtt_receiver_core_constraints(boost::tribool broker_secure, boost::tribool broker_authorization)
         {
             using web::json::value;
@@ -371,8 +371,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/docs/4.2.%20Behaviour%20-%20MQTT%20Transport%20Type.md#receiver-parameter-sets
-        // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_mqtt.json
+        // See https://specs.amwa.tv/is-05/releases/v1.1.0/docs/4.2._Behaviour_-_MQTT_Transport_Type.html#receiver-parameter-sets
+        // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_mqtt.html
         web::json::value make_connection_mqtt_receiver_staged_core_parameter_set(boost::tribool broker_secure, boost::tribool broker_authorization)
         {
             using web::json::value;
@@ -388,8 +388,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/sender_transport_params_ext.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#3-connection-management
+        // and https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/sender_transport_params_ext.html
         web::json::value make_connection_events_websocket_sender_ext_constraints(const nmos::id& source_id, const web::uri& rest_api_url)
         {
             using web::json::value;
@@ -409,8 +409,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/sender_transport_params_ext.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#3-connection-management
+        // and https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/sender_transport_params_ext.html
         web::json::value make_connection_events_websocket_sender_staged_ext_parameter_set(const nmos::id& source_id, const web::uri& rest_api_url)
         {
             using web::json::value;
@@ -422,8 +422,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/receiver_transport_params_ext.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#3-connection-management
+        // and https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/receiver_transport_params_ext.html
         web::json::value make_connection_events_websocket_receiver_ext_constraints()
         {
             using web::json::value;
@@ -436,8 +436,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/receiver_transport_params_ext.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#3-connection-management
+        // and https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/receiver_transport_params_ext.html
         web::json::value make_connection_events_websocket_receiver_staged_ext_parameter_set()
         {
             using web::json::value;
@@ -449,8 +449,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/sender_transport_params_ext.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.1._Transport_-_MQTT.html#3-connection-management
+        // and https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/sender_transport_params_ext.html
         web::json::value make_connection_events_mqtt_sender_ext_constraints(const web::uri& rest_api_url)
         {
             using web::json::value;
@@ -465,8 +465,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/sender_transport_params_ext.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.1._Transport_-_MQTT.html#3-connection-management
+        // and https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/sender_transport_params_ext.html
         web::json::value make_connection_events_mqtt_sender_staged_ext_parameter_set(const web::uri& rest_api_url)
         {
             using web::json::value;
@@ -477,8 +477,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/receiver_transport_params_ext.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.1._Transport_-_MQTT.html#3-connection-management
+        // and https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/receiver_transport_params_ext.html
         web::json::value make_connection_events_mqtt_receiver_ext_constraints()
         {
             using web::json::value;
@@ -490,8 +490,8 @@ namespace nmos
             });
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.1.%20Transport%20-%20MQTT.md#3-connection-management
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/receiver_transport_params_ext.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.1._Transport_-_MQTT.html#3-connection-management
+        // and https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/receiver_transport_params_ext.html
         web::json::value make_connection_events_mqtt_receiver_staged_ext_parameter_set()
         {
             using web::json::value;
@@ -505,7 +505,7 @@ namespace nmos
 
     // Although these functions make "connection" (IS-05) resources, the details are defined by IS-07 Event & Tally
     // so maybe these belong in nmos/events_resources.h or their own file, e.g. nmos/connection_events_resources.h?
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#3-connection-management
     nmos::resource make_connection_events_websocket_sender(const nmos::id& id, const nmos::id& device_id, const nmos::id& source_id, const nmos::settings& settings)
     {
         using web::json::value;
@@ -583,7 +583,7 @@ namespace nmos
 
         // "The sender should append the relative path sources/{source_id}/"
         // I'd rather be consistent with the general guidance regarding trailing slashes
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/4.0.%20Core%20models.md#ext_is_07_rest_api_url
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/4.0._Core_models.html#ext_is_07_rest_api_url
         return web::uri_builder()
             .set_scheme(nmos::http_scheme(settings))
             .set_host(nmos::get_host(settings))
@@ -598,7 +598,7 @@ namespace nmos
 
         // "To facilitate filtering, the recommended format is x-nmos/events/{version}/sources/{sourceId},
         // where {version} is the version of this specification, e.g. v1.0, and {sourceId} is the associated source id."
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/5.1.%20Transport%20-%20MQTT.md#32-broker_topic
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.1._Transport_-_MQTT.html#32-broker_topic
         return U("x-nmos/events/") + make_api_version(version) + U("/sources/") + source_id;
     }
 
@@ -608,7 +608,7 @@ namespace nmos
 
         // "The connection_status_broker_topic parameter holds the sender's MQTT connection status topic.
         // The recommended format is x-nmos/events/{version}/connections/{connectionId}."
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/5.1.%20Transport%20-%20MQTT.md#33-connection_status_broker_topic
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.1._Transport_-_MQTT.html#33-connection_status_broker_topic
         return U("x-nmos/events/") + make_api_version(version) + U("/connections/") + connection_id;
     }
 }

--- a/Development/nmos/connection_resources.h
+++ b/Development/nmos/connection_resources.h
@@ -20,7 +20,7 @@ namespace nmos
     // IS-05 Connection API resources
     // "The UUIDs used to advertise Senders and Receivers in the Connection Management API must match
     // those used in a corresponding IS-04 implementation."
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/3.1.%20Interoperability%20-%20NMOS%20IS-04.md#sender--receiver-ids
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/3.1.%20Interoperability%20-%20NMOS%20IS-04.md#sender--receiver-ids
     // Whereas the data of the IS-04 resources corresponds to a particular Node API resource endpoint,
     // each IS-05 resource's data is a json object with an "id" field and a field for each Connection API
     // endpoint of that logical single resource
@@ -29,9 +29,9 @@ namespace nmos
     // "staged" and "active" fields, which must each have a value conforming to the sender-response-schema or receiver-response-schema,
     // and for senders, also a "transportfile" field, the value of which must be an object, with either
     // "data" and "type" fields, or an "href" field
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/constraints-schema.json
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/sender-response-schema.json
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver-response-schema.json
+    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema.json
+    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender-response-schema.json
+    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver-response-schema.json
 
     // The caller must resolve all instances of "auto" in the /active endpoint into the actual values that will be used!
     // See nmos::resolve_rtp_auto
@@ -51,7 +51,7 @@ namespace nmos
 
     // Although these functions make "connection" (IS-05) resources, the details are defined by IS-07 Event & Tally
     // so maybe these belong in nmos/events_resources.h or their own file, e.g. nmos/connection_events_resources.h?
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
     nmos::resource make_connection_events_websocket_sender(const nmos::id& id, const nmos::id& device_id, const nmos::id& source_id, const nmos::settings& settings);
     nmos::resource make_connection_events_websocket_receiver(const nmos::id& id, const nmos::settings& settings);
 

--- a/Development/nmos/connection_resources.h
+++ b/Development/nmos/connection_resources.h
@@ -20,7 +20,7 @@ namespace nmos
     // IS-05 Connection API resources
     // "The UUIDs used to advertise Senders and Receivers in the Connection Management API must match
     // those used in a corresponding IS-04 implementation."
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/3.1.%20Interoperability%20-%20NMOS%20IS-04.md#sender--receiver-ids
+    // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/3.1._Interoperability_-_NMOS_IS-04.html#sender--receiver-ids
     // Whereas the data of the IS-04 resources corresponds to a particular Node API resource endpoint,
     // each IS-05 resource's data is a json object with an "id" field and a field for each Connection API
     // endpoint of that logical single resource
@@ -29,9 +29,9 @@ namespace nmos
     // "staged" and "active" fields, which must each have a value conforming to the sender-response-schema or receiver-response-schema,
     // and for senders, also a "transportfile" field, the value of which must be an object, with either
     // "data" and "type" fields, or an "href" field
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/constraints-schema.json
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/sender-response-schema.json
-    // and https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver-response-schema.json
+    // See https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/constraints-schema.html
+    // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/sender-response-schema.html
+    // and https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver-response-schema.html
 
     // The caller must resolve all instances of "auto" in the /active endpoint into the actual values that will be used!
     // See nmos::resolve_rtp_auto
@@ -51,7 +51,7 @@ namespace nmos
 
     // Although these functions make "connection" (IS-05) resources, the details are defined by IS-07 Event & Tally
     // so maybe these belong in nmos/events_resources.h or their own file, e.g. nmos/connection_events_resources.h?
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#3-connection-management
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#3-connection-management
     nmos::resource make_connection_events_websocket_sender(const nmos::id& id, const nmos::id& device_id, const nmos::id& source_id, const nmos::settings& settings);
     nmos::resource make_connection_events_websocket_receiver(const nmos::id& id, const nmos::settings& settings);
 

--- a/Development/nmos/device_type.h
+++ b/Development/nmos/device_type.h
@@ -6,8 +6,8 @@
 namespace nmos
 {
     // Device types
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.1.%20APIs%20-%20Common%20Keys.md#type-devices
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/device.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#type-devices
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/device.json
     DEFINE_STRING_ENUM(device_type)
     namespace device_types
     {

--- a/Development/nmos/device_type.h
+++ b/Development/nmos/device_type.h
@@ -6,8 +6,8 @@
 namespace nmos
 {
     // Device types
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#type-devices
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/device.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.1._APIs_-_Common_Keys.html#type-devices
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/device.html
     DEFINE_STRING_ENUM(device_type)
     namespace device_types
     {

--- a/Development/nmos/did_sdid.cpp
+++ b/Development/nmos/did_sdid.cpp
@@ -19,7 +19,7 @@ namespace nmos
     }
 
     // Data identification and Secondary data identification words
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_sdianc_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
     utility::string_t make_did_or_sdid(const uint8_t& did_or_sdid)
     {
         utility::ostringstream_t os;
@@ -38,7 +38,7 @@ namespace nmos
     }
 
     // Data identification and Secondary data identification words
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_sdianc_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
     web::json::value make_did_sdid(const nmos::did_sdid& did_sdid)
     {
         return web::json::value_of({

--- a/Development/nmos/did_sdid.cpp
+++ b/Development/nmos/did_sdid.cpp
@@ -19,7 +19,7 @@ namespace nmos
     }
 
     // Data identification and Secondary data identification words
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_sdianc_data.html
     utility::string_t make_did_or_sdid(const uint8_t& did_or_sdid)
     {
         utility::ostringstream_t os;
@@ -38,7 +38,7 @@ namespace nmos
     }
 
     // Data identification and Secondary data identification words
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_sdianc_data.html
     web::json::value make_did_sdid(const nmos::did_sdid& did_sdid)
     {
         return web::json::value_of({

--- a/Development/nmos/did_sdid.h
+++ b/Development/nmos/did_sdid.h
@@ -41,12 +41,12 @@ namespace nmos
     }
 
     // Data identification and Secondary data identification words
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_sdianc_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
     utility::string_t make_did_or_sdid(const uint8_t& did_or_sdid);
     uint8_t parse_did_or_sdid(const utility::string_t& did_or_sdid);
 
     // Data identification and Secondary data identification words
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_sdianc_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
     web::json::value make_did_sdid(const nmos::did_sdid& did_sdid);
     nmos::did_sdid parse_did_sdid(const web::json::value& did_sdid);
 

--- a/Development/nmos/did_sdid.h
+++ b/Development/nmos/did_sdid.h
@@ -41,12 +41,12 @@ namespace nmos
     }
 
     // Data identification and Secondary data identification words
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_sdianc_data.html
     utility::string_t make_did_or_sdid(const uint8_t& did_or_sdid);
     uint8_t parse_did_or_sdid(const utility::string_t& did_or_sdid);
 
     // Data identification and Secondary data identification words
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_sdianc_data.html
     web::json::value make_did_sdid(const nmos::did_sdid& did_sdid);
     nmos::did_sdid parse_did_sdid(const web::json::value& did_sdid);
 

--- a/Development/nmos/event_type.h
+++ b/Development/nmos/event_type.h
@@ -6,21 +6,21 @@
 namespace nmos
 {
     // IS-07 Event & Tally event types
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/3.0.%20Event%20types.md
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md
     DEFINE_STRING_ENUM(event_type)
     namespace event_types
     {
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/3.0.%20Event%20types.md#21-boolean
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#21-boolean
         const event_type boolean{ U("boolean") };
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/3.0.%20Event%20types.md#22-string
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#22-string
         const event_type string{ U("string") };
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/3.0.%20Event%20types.md#23-number
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#23-number
         const event_type number{ U("number") };
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/3.0.%20Event%20types.md#4-object
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#4-object
         // "The usage of the object event type is out of scope of this specification for version 1.0"
         const event_type object{ U("object") };
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/3.0.%20Event%20types.md#231-measurements
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#231-measurements
         inline const event_type measurement(const utility::string_t& name, const utility::string_t& unit)
         {
             // specific measurement types are always "number/{Name}/{Unit}"
@@ -28,13 +28,13 @@ namespace nmos
             return event_type{ number.name + U('/') + name + U('/') + unit };
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/3.0.%20Event%20types.md#3-enum
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#3-enum
         inline const event_type named_enum(const event_type& base_type, const utility::string_t& name)
         {
             return event_type{ base_type.name + U("/enum/") + name };
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/3.0.%20Event%20types.md#event-types-capability-management
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#event-types-capability-management
         // "A wildcard (*) must replace a whole word and can only be used at the end of an event_type definition."
         struct wildcard_type
         {
@@ -76,7 +76,7 @@ namespace nmos
         }
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/3.0.%20Event%20types.md#event-types-capability-management
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#event-types-capability-management
     inline bool is_matching_event_type(const event_type& capability, const event_type& type)
     {
         // "Comparisons between event_type values must be case sensitive."

--- a/Development/nmos/event_type.h
+++ b/Development/nmos/event_type.h
@@ -6,21 +6,21 @@
 namespace nmos
 {
     // IS-07 Event & Tally event types
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html
     DEFINE_STRING_ENUM(event_type)
     namespace event_types
     {
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#21-boolean
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#21-boolean
         const event_type boolean{ U("boolean") };
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#22-string
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#22-string
         const event_type string{ U("string") };
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#23-number
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#23-number
         const event_type number{ U("number") };
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#4-object
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#4-object-out-of-scope-for-version-10-of-this-specification
         // "The usage of the object event type is out of scope of this specification for version 1.0"
         const event_type object{ U("object") };
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#231-measurements
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#231-measurements
         inline const event_type measurement(const utility::string_t& name, const utility::string_t& unit)
         {
             // specific measurement types are always "number/{Name}/{Unit}"
@@ -28,13 +28,13 @@ namespace nmos
             return event_type{ number.name + U('/') + name + U('/') + unit };
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#3-enum
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#3-enum
         inline const event_type named_enum(const event_type& base_type, const utility::string_t& name)
         {
             return event_type{ base_type.name + U("/enum/") + name };
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#event-types-capability-management
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#event-types-capability-management
         // "A wildcard (*) must replace a whole word and can only be used at the end of an event_type definition."
         struct wildcard_type
         {
@@ -76,11 +76,11 @@ namespace nmos
         }
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/3.0.%20Event%20types.md#event-types-capability-management
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#event-types-capability-management
     inline bool is_matching_event_type(const event_type& capability, const event_type& type)
     {
         // "Comparisons between event_type values must be case sensitive."
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/3.0.%20Event%20types.md#1-introduction
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#1-introduction
         auto& c = capability.name;
         auto& t = type.name;
         // The wildcard in a partial event type matches zero or more 'levels', e.g. "number/*" matches both "number" and "number/temperature/C".

--- a/Development/nmos/events_api.cpp
+++ b/Development/nmos/events_api.cpp
@@ -141,8 +141,8 @@ namespace nmos
                     // specified transports because it will pass from the source through a flow and out on the network through the sender."
                     // Therefore, since the stored data in the event resources is also used to generate the messages on the transport, it
                     // *should* include the flow id. It will be removed to generate the Events API /state response.
-                    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
-                    // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/4.0.%20Core%20models.md#1-introduction
+                    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
+                    // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/4.0.%20Core%20models.md#1-introduction
                     auto state = endpoint(resource->data);
                     auto& identity = nmos::fields::identity(state);
                     if (identity.has_field(nmos::fields::flow_id))

--- a/Development/nmos/events_api.cpp
+++ b/Development/nmos/events_api.cpp
@@ -141,8 +141,8 @@ namespace nmos
                     // specified transports because it will pass from the source through a flow and out on the network through the sender."
                     // Therefore, since the stored data in the event resources is also used to generate the messages on the transport, it
                     // *should* include the flow id. It will be removed to generate the Events API /state response.
-                    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
-                    // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/4.0.%20Core%20models.md#1-introduction
+                    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#11-the-state-message-type
+                    // and https://specs.amwa.tv/is-07/releases/v1.0.1/docs/4.0._Core_models.html#1-introduction
                     auto state = endpoint(resource->data);
                     auto& identity = nmos::fields::identity(state);
                     if (identity.has_field(nmos::fields::flow_id))

--- a/Development/nmos/events_api.h
+++ b/Development/nmos/events_api.h
@@ -9,7 +9,7 @@ namespace slog
 }
 
 // Events API implementation
-// See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/EventsAPI.raml
+// See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/EventsAPI.html
 namespace nmos
 {
     struct node_model;

--- a/Development/nmos/events_api.h
+++ b/Development/nmos/events_api.h
@@ -9,7 +9,7 @@ namespace slog
 }
 
 // Events API implementation
-// See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/EventsAPI.raml
+// See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/EventsAPI.raml
 namespace nmos
 {
     struct node_model;

--- a/Development/nmos/events_resources.cpp
+++ b/Development/nmos/events_resources.cpp
@@ -22,14 +22,14 @@ namespace nmos
 
     namespace details
     {
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_core.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_core.json
         // "The flow_id will NOT be included in the response to a [REST API query for the] state because the state is held by
         // the source which has no dependency on a flow. It will, however, appear when being sent through one of the two
         // specified transports because it will pass from the source through a flow and out on the network through the sender."
         // Therefore, since the stored data in the event resources is also used to generate the messages on the transport, it
         // *should* include the flow id. It will be removed to generate the Events API /state response.
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/4.0.%20Core%20models.md#1-introduction
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
+        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/4.0.%20Core%20models.md#1-introduction
         web::json::value make_events_state_identity(const nmos::details::events_state_identity& identity)
         {
             using web::json::value_of;
@@ -40,7 +40,7 @@ namespace nmos
             }, true);
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_core.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_core.json
         web::json::value make_events_state_timing(const nmos::details::events_state_timing& timing)
         {
             using web::json::value_of;
@@ -52,7 +52,7 @@ namespace nmos
             }, true);
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_core.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_core.json
         web::json::value make_events_state(const nmos::details::events_state_identity& identity, web::json::value payload, const nmos::event_type& type, const nmos::details::events_state_timing& timing)
         {
             using web::json::value_of;
@@ -91,28 +91,28 @@ namespace nmos
         }
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_boolean.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_boolean.json
     web::json::value make_events_boolean_state(const nmos::details::events_state_identity& identity, bool payload_value, const nmos::event_type& type, const nmos::details::events_state_timing& timing)
     {
         // should check type is nmos::event_types::boolean or a derived type
         return details::make_events_state(identity, details::make_payload(payload_value), type, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_number.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_number.json
     web::json::value make_events_number_state(const nmos::details::events_state_identity& identity, const events_number& payload, const nmos::event_type& type, const nmos::details::events_state_timing& timing)
     {
         // should check type is nmos::event_types::number or a derived type
         return details::make_events_state(identity, details::make_payload(payload), type, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_string.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_string.json
     web::json::value make_events_string_state(const nmos::details::events_state_identity& identity, const utility::string_t& payload_value, const nmos::event_type& type, const nmos::details::events_state_timing& timing)
     {
         // should check type is nmos::event_types::string or a derived type
         return details::make_events_state(identity, details::make_payload(payload_value), type, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_object.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_object.json
     // (out of scope for version 1.0 of this specification)
     web::json::value make_events_object_state(const nmos::details::events_state_identity& identity, const web::json::value& payload, const nmos::event_type& type, const nmos::details::events_state_timing& timing)
     {
@@ -120,7 +120,7 @@ namespace nmos
         return details::make_events_state(identity, payload, type, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_boolean.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_boolean.json
     web::json::value make_events_boolean_type()
     {
         using web::json::value_of;
@@ -128,7 +128,7 @@ namespace nmos
         return value_of({ { U("type"), nmos::event_types::boolean.name } });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_number.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_number.json
     web::json::value make_events_number_type(const events_number& min, const events_number& max, const events_number& step, const utility::string_t& unit, int64_t scale)
     {
         using web::json::value_of;
@@ -143,7 +143,7 @@ namespace nmos
         });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_string.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_string.json
     web::json::value make_events_string_type(int64_t min_length, int64_t max_length, const utility::string_t& pattern)
     {
         using web::json::value_of;
@@ -172,7 +172,7 @@ namespace nmos
         }
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_boolean_enum.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_boolean_enum.json
     // hmm, map or vector-of-pair?
     web::json::value make_events_boolean_enum_type(const std::vector<std::pair<bool, events_enum_element_details>>& values)
     {
@@ -185,7 +185,7 @@ namespace nmos
         });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_number_enum.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_number_enum.json
     web::json::value make_events_number_enum_type(const std::vector<std::pair<double, events_enum_element_details>>& values)
     {
         // hmm, web::json::number rather than double?
@@ -199,7 +199,7 @@ namespace nmos
         });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_string_enum.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_string_enum.json
     web::json::value make_events_string_enum_type(const std::vector<std::pair<utility::string_t, events_enum_element_details>>& values)
     {
         using web::json::value_of;
@@ -231,7 +231,7 @@ namespace nmos
         });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/command_health.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/command_health.json
     web::json::value make_events_health_command(const nmos::tai& timestamp)
     {
         using web::json::value_of;

--- a/Development/nmos/events_resources.cpp
+++ b/Development/nmos/events_resources.cpp
@@ -22,14 +22,14 @@ namespace nmos
 
     namespace details
     {
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_core.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_core.html
         // "The flow_id will NOT be included in the response to a [REST API query for the] state because the state is held by
         // the source which has no dependency on a flow. It will, however, appear when being sent through one of the two
         // specified transports because it will pass from the source through a flow and out on the network through the sender."
         // Therefore, since the stored data in the event resources is also used to generate the messages on the transport, it
         // *should* include the flow id. It will be removed to generate the Events API /state response.
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/4.0.%20Core%20models.md#1-introduction
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#11-the-state-message-type
+        // and https://specs.amwa.tv/is-07/releases/v1.0.1/docs/4.0._Core_models.html#1-introduction
         web::json::value make_events_state_identity(const nmos::details::events_state_identity& identity)
         {
             using web::json::value_of;
@@ -40,7 +40,7 @@ namespace nmos
             }, true);
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_core.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_core.html
         web::json::value make_events_state_timing(const nmos::details::events_state_timing& timing)
         {
             using web::json::value_of;
@@ -52,7 +52,7 @@ namespace nmos
             }, true);
         }
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_core.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_core.html
         web::json::value make_events_state(const nmos::details::events_state_identity& identity, web::json::value payload, const nmos::event_type& type, const nmos::details::events_state_timing& timing)
         {
             using web::json::value_of;
@@ -91,28 +91,28 @@ namespace nmos
         }
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_boolean.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_boolean.html
     web::json::value make_events_boolean_state(const nmos::details::events_state_identity& identity, bool payload_value, const nmos::event_type& type, const nmos::details::events_state_timing& timing)
     {
         // should check type is nmos::event_types::boolean or a derived type
         return details::make_events_state(identity, details::make_payload(payload_value), type, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_number.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_number.html
     web::json::value make_events_number_state(const nmos::details::events_state_identity& identity, const events_number& payload, const nmos::event_type& type, const nmos::details::events_state_timing& timing)
     {
         // should check type is nmos::event_types::number or a derived type
         return details::make_events_state(identity, details::make_payload(payload), type, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_string.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_string.html
     web::json::value make_events_string_state(const nmos::details::events_state_identity& identity, const utility::string_t& payload_value, const nmos::event_type& type, const nmos::details::events_state_timing& timing)
     {
         // should check type is nmos::event_types::string or a derived type
         return details::make_events_state(identity, details::make_payload(payload_value), type, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_object.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_object.html
     // (out of scope for version 1.0 of this specification)
     web::json::value make_events_object_state(const nmos::details::events_state_identity& identity, const web::json::value& payload, const nmos::event_type& type, const nmos::details::events_state_timing& timing)
     {
@@ -120,7 +120,7 @@ namespace nmos
         return details::make_events_state(identity, payload, type, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_boolean.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_boolean.html
     web::json::value make_events_boolean_type()
     {
         using web::json::value_of;
@@ -128,7 +128,7 @@ namespace nmos
         return value_of({ { U("type"), nmos::event_types::boolean.name } });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_number.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_number.html
     web::json::value make_events_number_type(const events_number& min, const events_number& max, const events_number& step, const utility::string_t& unit, int64_t scale)
     {
         using web::json::value_of;
@@ -143,7 +143,7 @@ namespace nmos
         });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_string.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_string.html
     web::json::value make_events_string_type(int64_t min_length, int64_t max_length, const utility::string_t& pattern)
     {
         using web::json::value_of;
@@ -172,7 +172,7 @@ namespace nmos
         }
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_boolean_enum.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_boolean_enum.html
     // hmm, map or vector-of-pair?
     web::json::value make_events_boolean_enum_type(const std::vector<std::pair<bool, events_enum_element_details>>& values)
     {
@@ -185,7 +185,7 @@ namespace nmos
         });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_number_enum.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_number_enum.html
     web::json::value make_events_number_enum_type(const std::vector<std::pair<double, events_enum_element_details>>& values)
     {
         // hmm, web::json::number rather than double?
@@ -199,7 +199,7 @@ namespace nmos
         });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_string_enum.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_string_enum.html
     web::json::value make_events_string_enum_type(const std::vector<std::pair<utility::string_t, events_enum_element_details>>& values)
     {
         using web::json::value_of;
@@ -219,7 +219,7 @@ namespace nmos
         return value_of({ { U("type"), nmos::event_types::object.name } });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/APIs/schemas/command_subscription.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/command_subscription.html
     web::json::value make_events_subscription_command(const std::vector<nmos::id>& sources)
     {
         using web::json::value_of;
@@ -231,7 +231,7 @@ namespace nmos
         });
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/command_health.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/command_health.html
     web::json::value make_events_health_command(const nmos::tai& timestamp)
     {
         using web::json::value_of;

--- a/Development/nmos/events_resources.h
+++ b/Development/nmos/events_resources.h
@@ -11,20 +11,20 @@ namespace nmos
     struct resource;
 
     // IS-07 Events API resources
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/6.0.%20Event%20and%20tally%20rest%20api.md#1-introduction
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/6.0._Event_and_tally_rest_api.html#1-introduction
     // Each IS-07 source's data is a json object with an "id" field
     // and a field for the Events API endpoints of that logical single resource
     // i.e.
     // a "type" field, which must have a value conforming to the type schema,
     // and a "state" field, which must have a value conforming to the event schema
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type.json
-    // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type.html
+    // and https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event.html
     // For WebSocket connections, subscription and grain resources will also be added
 
     nmos::resource make_events_source(const nmos::id& id, const web::json::value& state, const web::json::value& type);
 
     // Events API source state
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/6.0.%20Event%20and%20tally%20rest%20api.md#3-usage
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/6.0._Event_and_tally_rest_api.html#3-usage
 
     namespace details
     {
@@ -52,21 +52,21 @@ namespace nmos
             nmos::tai action_timestamp;
         };
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_core.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_core.html
         // "The flow_id will NOT be included in the response to a [REST API query for the] state because the state is held by
         // the source which has no dependency on a flow. It will, however, appear when being sent through one of the two
         // specified transports because it will pass from the source through a flow and out on the network through the sender."
         // Therefore, since the stored data in the event resources is also used to generate the messages on the transport, it
         // *should* include the flow id. It will be removed to generate the Events API /state response.
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/4.0.%20Core%20models.md#1-introduction
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#11-the-state-message-type
+        // and https://specs.amwa.tv/is-07/releases/v1.0.1/docs/4.0._Core_models.html#1-introduction
         web::json::value make_events_state_identity(const nmos::details::events_state_identity& identity);
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_core.json
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_core.html
         web::json::value make_events_state_timing(const nmos::details::events_state_timing& timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/number.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/number.html
     struct events_number
     {
         events_number() : value(), scale() {}
@@ -81,28 +81,28 @@ namespace nmos
         int64_t scale;
     };
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_boolean.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_boolean.html
     web::json::value make_events_boolean_state(const nmos::details::events_state_identity& identity, bool payload_value, const nmos::event_type& type = nmos::event_types::boolean, const nmos::details::events_state_timing& timing = {});
     inline web::json::value make_events_boolean_state(const nmos::details::events_state_identity& identity, bool payload_value, const nmos::details::events_state_timing& timing)
     {
         return make_events_boolean_state(identity, payload_value, nmos::event_types::boolean, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_number.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_number.html
     web::json::value make_events_number_state(const nmos::details::events_state_identity& identity, const events_number& payload, const nmos::event_type& type = nmos::event_types::number, const nmos::details::events_state_timing& timing = {});
     inline web::json::value make_events_number_state(const nmos::details::events_state_identity& identity, const events_number& payload, const nmos::details::events_state_timing& timing)
     {
         return make_events_number_state(identity, payload, nmos::event_types::number, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_string.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_string.html
     web::json::value make_events_string_state(const nmos::details::events_state_identity& identity, const utility::string_t& payload_value, const nmos::event_type& type = nmos::event_types::string, const nmos::details::events_state_timing& timing = {});
     inline web::json::value make_events_string_state(const nmos::details::events_state_identity& identity, const utility::string_t& payload_value, const nmos::details::events_state_timing& timing)
     {
         return make_events_string_state(identity, payload_value, nmos::event_types::string, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_object.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/event_object.html
     // (out of scope for version 1.0 of this specification)
     web::json::value make_events_object_state(const nmos::details::events_state_identity& identity, const web::json::value& payload, const nmos::event_type& type = nmos::event_types::object, const nmos::details::events_state_timing& timing = {});
     inline web::json::value make_events_object_state(const nmos::details::events_state_identity& identity, const web::json::value& payload, const nmos::details::events_state_timing& timing)
@@ -111,15 +111,15 @@ namespace nmos
     }
 
     // Events API source type
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/6.0.%20Event%20and%20tally%20rest%20api.md#3-usage
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/6.0._Event_and_tally_rest_api.html#3-usage
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_boolean.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_boolean.html
     web::json::value make_events_boolean_type();
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_number.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_number.html
     web::json::value make_events_number_type(const events_number& min, const events_number& max, const events_number& step = {}, const utility::string_t& unit = {}, int64_t scale = {});
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_string.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_string.html
     web::json::value make_events_string_type(int64_t min_length = {}, int64_t max_length = {}, const utility::string_t& pattern = {});
 
     struct events_enum_element_details
@@ -132,14 +132,14 @@ namespace nmos
         utility::string_t description;
     };
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_boolean_enum.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_boolean_enum.html
     // hmm, map or vector-of-pair?
     web::json::value make_events_boolean_enum_type(const std::vector<std::pair<bool, events_enum_element_details>>& values);
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_number_enum.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_number_enum.html
     web::json::value make_events_number_enum_type(const std::vector<std::pair<double, events_enum_element_details>>& values);
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_string_enum.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/type_string_enum.html
     web::json::value make_events_string_enum_type(const std::vector<std::pair<utility::string_t, events_enum_element_details>>& values);
 
     // (out of scope for version 1.0 of this specification)
@@ -147,12 +147,12 @@ namespace nmos
 
     // Events commands
     // These are not resources, so maybe these belong in their own file, e.g. nmos/events_commands.h?
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/5.2.%20Transport%20-%20Websocket.md#4-subscriptions-strategy
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#4-subscriptions-strategy
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/APIs/schemas/command_subscription.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/command_subscription.html
     web::json::value make_events_subscription_command(const std::vector<nmos::id>& sources);
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/command_health.json
+    // See https://specs.amwa.tv/is-07/releases/v1.0.1/APIs/schemas/with-refs/command_health.html
     web::json::value make_events_health_command(const nmos::tai& timestamp = tai_now());
 }
 

--- a/Development/nmos/events_resources.h
+++ b/Development/nmos/events_resources.h
@@ -11,20 +11,20 @@ namespace nmos
     struct resource;
 
     // IS-07 Events API resources
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/6.0.%20Event%20and%20tally%20rest%20api.md#1-introduction
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/6.0.%20Event%20and%20tally%20rest%20api.md#1-introduction
     // Each IS-07 source's data is a json object with an "id" field
     // and a field for the Events API endpoints of that logical single resource
     // i.e.
     // a "type" field, which must have a value conforming to the type schema,
     // and a "state" field, which must have a value conforming to the event schema
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type.json
-    // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type.json
+    // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event.json
     // For WebSocket connections, subscription and grain resources will also be added
 
     nmos::resource make_events_source(const nmos::id& id, const web::json::value& state, const web::json::value& type);
 
     // Events API source state
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/6.0.%20Event%20and%20tally%20rest%20api.md#3-usage
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/6.0.%20Event%20and%20tally%20rest%20api.md#3-usage
 
     namespace details
     {
@@ -52,21 +52,21 @@ namespace nmos
             nmos::tai action_timestamp;
         };
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_core.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_core.json
         // "The flow_id will NOT be included in the response to a [REST API query for the] state because the state is held by
         // the source which has no dependency on a flow. It will, however, appear when being sent through one of the two
         // specified transports because it will pass from the source through a flow and out on the network through the sender."
         // Therefore, since the stored data in the event resources is also used to generate the messages on the transport, it
         // *should* include the flow id. It will be removed to generate the Events API /state response.
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
-        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/4.0.%20Core%20models.md#1-introduction
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
+        // and https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/4.0.%20Core%20models.md#1-introduction
         web::json::value make_events_state_identity(const nmos::details::events_state_identity& identity);
 
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_core.json
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_core.json
         web::json::value make_events_state_timing(const nmos::details::events_state_timing& timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/number.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/number.json
     struct events_number
     {
         events_number() : value(), scale() {}
@@ -81,28 +81,28 @@ namespace nmos
         int64_t scale;
     };
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_boolean.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_boolean.json
     web::json::value make_events_boolean_state(const nmos::details::events_state_identity& identity, bool payload_value, const nmos::event_type& type = nmos::event_types::boolean, const nmos::details::events_state_timing& timing = {});
     inline web::json::value make_events_boolean_state(const nmos::details::events_state_identity& identity, bool payload_value, const nmos::details::events_state_timing& timing)
     {
         return make_events_boolean_state(identity, payload_value, nmos::event_types::boolean, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_number.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_number.json
     web::json::value make_events_number_state(const nmos::details::events_state_identity& identity, const events_number& payload, const nmos::event_type& type = nmos::event_types::number, const nmos::details::events_state_timing& timing = {});
     inline web::json::value make_events_number_state(const nmos::details::events_state_identity& identity, const events_number& payload, const nmos::details::events_state_timing& timing)
     {
         return make_events_number_state(identity, payload, nmos::event_types::number, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_string.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_string.json
     web::json::value make_events_string_state(const nmos::details::events_state_identity& identity, const utility::string_t& payload_value, const nmos::event_type& type = nmos::event_types::string, const nmos::details::events_state_timing& timing = {});
     inline web::json::value make_events_string_state(const nmos::details::events_state_identity& identity, const utility::string_t& payload_value, const nmos::details::events_state_timing& timing)
     {
         return make_events_string_state(identity, payload_value, nmos::event_types::string, timing);
     }
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/event_object.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/event_object.json
     // (out of scope for version 1.0 of this specification)
     web::json::value make_events_object_state(const nmos::details::events_state_identity& identity, const web::json::value& payload, const nmos::event_type& type = nmos::event_types::object, const nmos::details::events_state_timing& timing = {});
     inline web::json::value make_events_object_state(const nmos::details::events_state_identity& identity, const web::json::value& payload, const nmos::details::events_state_timing& timing)
@@ -111,15 +111,15 @@ namespace nmos
     }
 
     // Events API source type
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/6.0.%20Event%20and%20tally%20rest%20api.md#3-usage
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/6.0.%20Event%20and%20tally%20rest%20api.md#3-usage
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_boolean.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_boolean.json
     web::json::value make_events_boolean_type();
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_number.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_number.json
     web::json::value make_events_number_type(const events_number& min, const events_number& max, const events_number& step = {}, const utility::string_t& unit = {}, int64_t scale = {});
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_string.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_string.json
     web::json::value make_events_string_type(int64_t min_length = {}, int64_t max_length = {}, const utility::string_t& pattern = {});
 
     struct events_enum_element_details
@@ -132,14 +132,14 @@ namespace nmos
         utility::string_t description;
     };
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_boolean_enum.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_boolean_enum.json
     // hmm, map or vector-of-pair?
     web::json::value make_events_boolean_enum_type(const std::vector<std::pair<bool, events_enum_element_details>>& values);
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_number_enum.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_number_enum.json
     web::json::value make_events_number_enum_type(const std::vector<std::pair<double, events_enum_element_details>>& values);
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/type_string_enum.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/type_string_enum.json
     web::json::value make_events_string_enum_type(const std::vector<std::pair<utility::string_t, events_enum_element_details>>& values);
 
     // (out of scope for version 1.0 of this specification)
@@ -152,7 +152,7 @@ namespace nmos
     // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/APIs/schemas/command_subscription.json
     web::json::value make_events_subscription_command(const std::vector<nmos::id>& sources);
 
-    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/APIs/schemas/command_health.json
+    // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/APIs/schemas/command_health.json
     web::json::value make_events_health_command(const nmos::tai& timestamp = tai_now());
 }
 

--- a/Development/nmos/events_ws_api.cpp
+++ b/Development/nmos/events_ws_api.cpp
@@ -286,7 +286,7 @@ namespace nmos
     }
 
     // reboot message
-    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#12-the-reboot-message-type
+    // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#12-the-reboot-message-type
     web::json::value make_events_reboot_message(const nmos::details::events_state_identity& identity, const nmos::details::events_state_timing& timing)
     {
         using web::json::value_of;
@@ -299,7 +299,7 @@ namespace nmos
     }
 
     // shutdown message
-    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#13-the-shutdown-message-type
+    // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#13-the-shutdown-message-type
     web::json::value make_events_shutdown_message(const nmos::details::events_state_identity& identity, const nmos::details::events_state_timing& timing)
     {
         using web::json::value_of;
@@ -312,7 +312,7 @@ namespace nmos
     }
 
     // health message
-    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#15-the-health-message
+    // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#15-the-health-message-type
     web::json::value make_events_health_message(const nmos::details::events_state_timing& timing)
     {
         using web::json::value_of;
@@ -427,7 +427,7 @@ namespace nmos
                     else if (event.has_field(U("post")))
                     {
                         // state message
-                        // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
+                        // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#11-the-state-message-type
                         // and nmos::make_events_boolean_state, nmos::make_events_number_state, etc.
                         // and nmos::details::make_resource_event
                         const web::json::value& state = nmos::fields::endpoint_state(event.at(U("post")));

--- a/Development/nmos/events_ws_api.cpp
+++ b/Development/nmos/events_ws_api.cpp
@@ -286,7 +286,7 @@ namespace nmos
     }
 
     // reboot message
-    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/2.0.%20Message%20types.md#12-the-reboot-message-type
+    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#12-the-reboot-message-type
     web::json::value make_events_reboot_message(const nmos::details::events_state_identity& identity, const nmos::details::events_state_timing& timing)
     {
         using web::json::value_of;
@@ -299,7 +299,7 @@ namespace nmos
     }
 
     // shutdown message
-    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/2.0.%20Message%20types.md#13-the-shutdown-message-type
+    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#13-the-shutdown-message-type
     web::json::value make_events_shutdown_message(const nmos::details::events_state_identity& identity, const nmos::details::events_state_timing& timing)
     {
         using web::json::value_of;
@@ -312,7 +312,7 @@ namespace nmos
     }
 
     // health message
-    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/2.0.%20Message%20types.md#15-the-health-message
+    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#15-the-health-message
     web::json::value make_events_health_message(const nmos::details::events_state_timing& timing)
     {
         using web::json::value_of;
@@ -427,7 +427,7 @@ namespace nmos
                     else if (event.has_field(U("post")))
                     {
                         // state message
-                        // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
+                        // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#11-the-state-message-type
                         // and nmos::make_events_boolean_state, nmos::make_events_number_state, etc.
                         // and nmos::details::make_resource_event
                         const web::json::value& state = nmos::fields::endpoint_state(event.at(U("post")));

--- a/Development/nmos/events_ws_api.h
+++ b/Development/nmos/events_ws_api.h
@@ -10,7 +10,7 @@ namespace slog
 }
 
 // Events API websocket implementation
-// See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md
+// See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md
 namespace nmos
 {
     struct node_model;
@@ -42,7 +42,7 @@ namespace nmos
     web::json::value make_events_shutdown_message(const nmos::details::events_state_identity& identity, const nmos::details::events_state_timing& timing = {});
 
     // health message
-    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/2.0.%20Message%20types.md#15-the-health-message
+    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#15-the-health-message
     web::json::value make_events_health_message(const nmos::details::events_state_timing& timing);
 
     void send_events_ws_messages_thread(web::websockets::experimental::listener::websocket_listener& listener, nmos::node_model& model, nmos::websockets& websockets, slog::base_gate& gate);

--- a/Development/nmos/events_ws_api.h
+++ b/Development/nmos/events_ws_api.h
@@ -10,7 +10,7 @@ namespace slog
 }
 
 // Events API websocket implementation
-// See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md
+// See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html
 namespace nmos
 {
     struct node_model;
@@ -34,15 +34,15 @@ namespace nmos
     // Maybe these belong in their own file, e.g. nmos/events_messages.h?
 
     // reboot message
-    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/2.0.%20Message%20types.md#12-the-reboot-message-type
+    // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#12-the-reboot-message-type
     web::json::value make_events_reboot_message(const nmos::details::events_state_identity& identity, const nmos::details::events_state_timing& timing = {});
 
     // shutdown message
-    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/2.0.%20Message%20types.md#13-the-shutdown-message-type
+    // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#13-the-shutdown-message-type
     web::json::value make_events_shutdown_message(const nmos::details::events_state_identity& identity, const nmos::details::events_state_timing& timing = {});
 
     // health message
-    // see https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/2.0.%20Message%20types.md#15-the-health-message
+    // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#15-the-health-message-type
     web::json::value make_events_health_message(const nmos::details::events_state_timing& timing);
 
     void send_events_ws_messages_thread(web::websockets::experimental::listener::websocket_listener& listener, nmos::node_model& model, nmos::websockets& websockets, slog::base_gate& gate);

--- a/Development/nmos/events_ws_client.cpp
+++ b/Development/nmos/events_ws_client.cpp
@@ -150,7 +150,7 @@ namespace nmos
                         // "A disconnection IS-05 PATCH request should always trigger the client to remove the associated source id
                         // from the current WebSocket subscriptions list. If the source is the last item in the subscriptions list,
                         // then it is recommended for the client to close the underlying WebSocket connection."
-                        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.1/docs/5.2.%20Transport%20-%20Websocket.md#35-disconnectingparking
+                        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#35-disconnectingparking
                         // Doesn't seem much point in sending an empty subscription command, so just close the connection in that case...
 
                         auto& by_connection_uri = subscriptions.get<nmos::tags::events_ws_subscription>();
@@ -268,7 +268,7 @@ namespace nmos
                     auto heartbeats = result.then([this, client, token]() mutable
                     {
                         // "Upon connection, the client is required to report its health every 5 seconds in order to maintain its session and subscription."
-                        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
+                        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#41-heartbeats
 
                         return pplx::do_while([this, client, token]() mutable
                         {

--- a/Development/nmos/events_ws_client.cpp
+++ b/Development/nmos/events_ws_client.cpp
@@ -268,7 +268,7 @@ namespace nmos
                     auto heartbeats = result.then([this, client, token]() mutable
                     {
                         // "Upon connection, the client is required to report its health every 5 seconds in order to maintain its session and subscription."
-                        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
+                        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
 
                         return pplx::do_while([this, client, token]() mutable
                         {

--- a/Development/nmos/events_ws_client.h
+++ b/Development/nmos/events_ws_client.h
@@ -18,7 +18,7 @@ namespace slog
 }
 
 // Events API websocket implementation
-// See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md
+// See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md
 namespace nmos
 {
     namespace details

--- a/Development/nmos/events_ws_client.h
+++ b/Development/nmos/events_ws_client.h
@@ -18,7 +18,7 @@ namespace slog
 }
 
 // Events API websocket implementation
-// See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md
+// See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html
 namespace nmos
 {
     namespace details

--- a/Development/nmos/format.h
+++ b/Development/nmos/format.h
@@ -6,10 +6,10 @@
 namespace nmos
 {
     // Formats (used in sources, flows and receivers)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.1.%20APIs%20-%20Common%20Keys.md#format
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_generic.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_audio.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#format
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_audio.json
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
     // etc.
     DEFINE_STRING_ENUM(format)
     namespace formats

--- a/Development/nmos/format.h
+++ b/Development/nmos/format.h
@@ -6,10 +6,10 @@
 namespace nmos
 {
     // Formats (used in sources, flows and receivers)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#format
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_audio.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.1._APIs_-_Common_Keys.html#format
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_generic.html
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_audio.html
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video.html
     // etc.
     DEFINE_STRING_ENUM(format)
     namespace formats

--- a/Development/nmos/group_hint.h
+++ b/Development/nmos/group_hint.h
@@ -5,7 +5,7 @@
 #include "nmos/string_enum.h"
 
 // Group Hint
-// See https://github.com/AMWA-TV/nmos-parameter-registers/blob/main/tags/grouphint.md
+// See https://specs.amwa.tv/nmos-parameter-registers/branches/main/tags/grouphint.html
 namespace nmos
 {
     namespace fields
@@ -38,4 +38,4 @@ namespace nmos
     group_hint parse_group_hint(const utility::string_t& group_hint);
 }
 
-#endif
+/#endif

--- a/Development/nmos/group_hint.h
+++ b/Development/nmos/group_hint.h
@@ -38,4 +38,4 @@ namespace nmos
     group_hint parse_group_hint(const utility::string_t& group_hint);
 }
 
-/#endif
+#endif

--- a/Development/nmos/id.h
+++ b/Development/nmos/id.h
@@ -7,7 +7,7 @@
 namespace nmos
 {
     // "Each logical entity is identified by a UUID"
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/5.1.%20Data%20Model%20-%20Identifier%20Mapping.md
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/5.1.%20Data%20Model%20-%20Identifier%20Mapping.md
 
     // Since identifiers are passed as strings in the APIs, and the formatting of identifiers has been a little
     // inconsistent between implementations in the past, they are currently stored simply as strings...

--- a/Development/nmos/id.h
+++ b/Development/nmos/id.h
@@ -7,7 +7,7 @@
 namespace nmos
 {
     // "Each logical entity is identified by a UUID"
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/5.1.%20Data%20Model%20-%20Identifier%20Mapping.md
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/5.1._Data_Model_-_Identifier_Mapping.html
 
     // Since identifiers are passed as strings in the APIs, and the formatting of identifiers has been a little
     // inconsistent between implementations in the past, they are currently stored simply as strings...

--- a/Development/nmos/interlace_mode.h
+++ b/Development/nmos/interlace_mode.h
@@ -6,7 +6,7 @@
 namespace nmos
 {
     // Interlace modes (used in video flows)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video.html
     DEFINE_STRING_ENUM(interlace_mode)
     namespace interlace_modes
     {

--- a/Development/nmos/interlace_mode.h
+++ b/Development/nmos/interlace_mode.h
@@ -6,7 +6,7 @@
 namespace nmos
 {
     // Interlace modes (used in video flows)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
     DEFINE_STRING_ENUM(interlace_mode)
     namespace interlace_modes
     {

--- a/Development/nmos/logging_api.cpp
+++ b/Development/nmos/logging_api.cpp
@@ -261,7 +261,7 @@ namespace nmos
 
                 // RFC 5988 allows relative URLs, but NMOS specification examples are all absolute URLs
                 // See https://tools.ietf.org/html/rfc5988#section-5
-                // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.5.%20APIs%20-%20Query%20Parameters.md
+                // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md
 
                 // get the request host and port (or use the primary host address, and port, from settings)
                 auto req_host_port = web::http::get_host_port(req);

--- a/Development/nmos/logging_api.cpp
+++ b/Development/nmos/logging_api.cpp
@@ -261,7 +261,7 @@ namespace nmos
 
                 // RFC 5988 allows relative URLs, but NMOS specification examples are all absolute URLs
                 // See https://tools.ietf.org/html/rfc5988#section-5
-                // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md
+                // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.5._APIs_-_Query_Parameters.html
 
                 // get the request host and port (or use the primary host address, and port, from settings)
                 auto req_host_port = web::http::get_host_port(req);

--- a/Development/nmos/mdns.cpp
+++ b/Development/nmos/mdns.cpp
@@ -18,9 +18,9 @@
 namespace nmos
 {
     // "APIs MUST produce an mDNS advertisement [...] accompanied by DNS TXT records"
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/RegistrationAPI.raml#L17
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/QueryAPI.raml#L122
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/NodeAPI.raml#L37
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/RegistrationAPI.raml#L17
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/QueryAPI.raml#L122
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/NodeAPI.raml#L37
 
     // For now, the TXT record keys and the functions to make/parse the values are kept as implementation details
 
@@ -76,7 +76,7 @@ namespace nmos
         {
             // "The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'.
             // There should be no whitespace between commas, and versions should be listed in ascending order."
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/RegistrationAPI.raml#L33
+            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/RegistrationAPI.raml#L33
             std::vector<std::string> api_vers;
             boost::algorithm::split(api_vers, api_ver, [](char c){ return ',' == c; });
             // Since ascending order is recommended, not required, convert straight to an ordered set without checking that.
@@ -296,7 +296,7 @@ namespace nmos
 
             // advertise "_nmos-register._tcp" for v1.3 (and as an experimental extension, for lower versions)
             // don't advertise "_nmos-registration._tcp" if only v1.3
-            // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3/docs/3.1.%20Discovery%20-%20Registered%20Operation.md#dns-sd-advertisement
+            // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/docs/3.1.%20Discovery%20-%20Registered%20Operation.md#dns-sd-advertisement
             if (nmos::service_types::registration == service)
             {
                 if (*api_ver.begin() < nmos::is04_versions::v1_3)
@@ -306,7 +306,7 @@ namespace nmos
                 advertiser.register_service(instance_name, nmos::service_types::register_, instance_port, domain, host_name, txt_records).wait();
             }
             // don't advertise "_nmos-node._tcp" if only v1.3
-            // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3/docs/3.2.%20Discovery%20-%20Peer%20to%20Peer%20Operation.md#dns-sd-advertisement
+            // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/docs/3.2.%20Discovery%20-%20Peer%20to%20Peer%20Operation.md#dns-sd-advertisement
             else if (nmos::service_types::node == service)
             {
                 if (*api_ver.begin() < nmos::is04_versions::v1_3)
@@ -419,7 +419,7 @@ namespace nmos
                     const bool cancel = pplx::canceled == discovery.resolve([=](const mdns::resolve_result& resolved)
                     {
                         // "The Node [filters] out any APIs which do not support its required API version, protocol and authorization mode (TXT api_ver, api_proto and api_auth)."
-                        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3/docs/3.1.%20Discovery%20-%20Registered%20Operation.md#client-interaction-procedure
+                        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/docs/3.1.%20Discovery%20-%20Registered%20Operation.md#client-interaction-procedure
 
                         // note, since we specified the interface_id, we expect only one result...
 

--- a/Development/nmos/mdns.cpp
+++ b/Development/nmos/mdns.cpp
@@ -18,9 +18,9 @@
 namespace nmos
 {
     // "APIs MUST produce an mDNS advertisement [...] accompanied by DNS TXT records"
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/RegistrationAPI.raml#L17
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/QueryAPI.raml#L122
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/NodeAPI.raml#L37
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/RegistrationAPI.html#dns_sd_advertisement
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/QueryAPI.html#dns_sd_advertisement
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/NodeAPI.html#dns_sd_advertisement
 
     // For now, the TXT record keys and the functions to make/parse the values are kept as implementation details
 
@@ -76,7 +76,7 @@ namespace nmos
         {
             // "The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'.
             // There should be no whitespace between commas, and versions should be listed in ascending order."
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/RegistrationAPI.raml#L33
+            // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/RegistrationAPI.html#dns_sd_advertisement
             std::vector<std::string> api_vers;
             boost::algorithm::split(api_vers, api_ver, [](char c){ return ',' == c; });
             // Since ascending order is recommended, not required, convert straight to an ordered set without checking that.
@@ -296,7 +296,7 @@ namespace nmos
 
             // advertise "_nmos-register._tcp" for v1.3 (and as an experimental extension, for lower versions)
             // don't advertise "_nmos-registration._tcp" if only v1.3
-            // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/docs/3.1.%20Discovery%20-%20Registered%20Operation.md#dns-sd-advertisement
+            // see https://specs.amwa.tv/is-04/releases/v1.3.0/docs/3.1._Discovery_-_Registered_Operation.html#dns-sd-advertisement
             if (nmos::service_types::registration == service)
             {
                 if (*api_ver.begin() < nmos::is04_versions::v1_3)
@@ -306,7 +306,7 @@ namespace nmos
                 advertiser.register_service(instance_name, nmos::service_types::register_, instance_port, domain, host_name, txt_records).wait();
             }
             // don't advertise "_nmos-node._tcp" if only v1.3
-            // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/docs/3.2.%20Discovery%20-%20Peer%20to%20Peer%20Operation.md#dns-sd-advertisement
+            // see https://specs.amwa.tv/is-04/releases/v1.3.0/docs/3.2._Discovery_-_Peer_to_Peer_Operation.html#dns-sd-advertisement
             else if (nmos::service_types::node == service)
             {
                 if (*api_ver.begin() < nmos::is04_versions::v1_3)
@@ -419,7 +419,7 @@ namespace nmos
                     const bool cancel = pplx::canceled == discovery.resolve([=](const mdns::resolve_result& resolved)
                     {
                         // "The Node [filters] out any APIs which do not support its required API version, protocol and authorization mode (TXT api_ver, api_proto and api_auth)."
-                        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/docs/3.1.%20Discovery%20-%20Registered%20Operation.md#client-interaction-procedure
+                        // See https://specs.amwa.tv/is-04/releases/v1.3.0/docs/3.1._Discovery_-_Registered_Operation.html#client-interaction-procedure
 
                         // note, since we specified the interface_id, we expect only one result...
 

--- a/Development/nmos/mdns.h
+++ b/Development/nmos/mdns.h
@@ -16,7 +16,7 @@ namespace mdns
 namespace nmos
 {
     // "APIs MUST produce an mDNS advertisement [...] accompanied by DNS TXT records"
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/RegistrationAPI.raml#L17 etc.
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/RegistrationAPI.html#dns_sd_advertisement etc.
 
     typedef std::string service_type;
 
@@ -31,9 +31,9 @@ namespace nmos
         // IS-04 Registration API
         // "RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement
         // is 16 characters when including the leading underscore, but "_nmos-registration" is 18 characters."
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.1/APIs/RegistrationAPI.raml#L19
-        // This is to be addressed in v1.3, by specifying a shorter service type, "_nmos-register._tcp".
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/pull/71
+        // See https://specs.amwa.tv/is-04/releases/v1.2.1/APIs/RegistrationAPI.html#dns_sd_advertisement
+        // This was addressed in v1.3, by specifying a shorter service type, "_nmos-register._tcp".
+        // See https://specs.amwa.tv/is-04/releases/v1.3.0/docs/3.1._Discovery_-_Registered_Operation.html#dns-sd-advertisement
         const service_type registration{ "_nmos-registration._tcp" };
 
         // IS-09 System API (originally specified in JT-NM TR-1001-1:2018 Annex A)

--- a/Development/nmos/mdns.h
+++ b/Development/nmos/mdns.h
@@ -16,7 +16,7 @@ namespace mdns
 namespace nmos
 {
     // "APIs MUST produce an mDNS advertisement [...] accompanied by DNS TXT records"
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/RegistrationAPI.raml#L17 etc.
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/RegistrationAPI.raml#L17 etc.
 
     typedef std::string service_type;
 

--- a/Development/nmos/media_type.h
+++ b/Development/nmos/media_type.h
@@ -7,9 +7,9 @@
 namespace nmos
 {
     // Media types (used in flows and receivers)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_audio_raw.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_video.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio_raw.json
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_video.json
     // etc.
     DEFINE_STRING_ENUM(media_type)
     namespace media_types

--- a/Development/nmos/media_type.h
+++ b/Development/nmos/media_type.h
@@ -7,9 +7,9 @@
 namespace nmos
 {
     // Media types (used in flows and receivers)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio_raw.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_video.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video.html
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_audio_raw.html
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_video.html
     // etc.
     DEFINE_STRING_ENUM(media_type)
     namespace media_types

--- a/Development/nmos/node_api.h
+++ b/Development/nmos/node_api.h
@@ -5,7 +5,7 @@
 #include "nmos/node_api_target_handler.h"
 
 // Node API implementation
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/NodeAPI.raml
+// See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/NodeAPI.html
 namespace nmos
 {
     struct model;

--- a/Development/nmos/node_api.h
+++ b/Development/nmos/node_api.h
@@ -5,7 +5,7 @@
 #include "nmos/node_api_target_handler.h"
 
 // Node API implementation
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/NodeAPI.raml
+// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/NodeAPI.raml
 namespace nmos
 {
     struct model;

--- a/Development/nmos/node_api_target_handler.cpp
+++ b/Development/nmos/node_api_target_handler.cpp
@@ -56,7 +56,7 @@ namespace nmos
                 }).then([&model, receiver_id, sender_id, parse_transport_file, validate_merged, &gate](const utility::string_t& sdp)
                 {
                     // "The Connection Management API supersedes the now deprecated method of updating the 'target' resource on Node API Receivers in order to establish connections."
-                    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/3.1.%20Interoperability%20-%20NMOS%20IS-04.md#support-for-legacy-is-04-connection-management
+                    // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/3.1._Interoperability_-_NMOS_IS-04.html#support-for-legacy-is-04-connection-management
 
                     const auto patch = value_of({
                         { nmos::fields::sender_id, sender_id },

--- a/Development/nmos/node_api_target_handler.cpp
+++ b/Development/nmos/node_api_target_handler.cpp
@@ -56,7 +56,7 @@ namespace nmos
                 }).then([&model, receiver_id, sender_id, parse_transport_file, validate_merged, &gate](const utility::string_t& sdp)
                 {
                     // "The Connection Management API supersedes the now deprecated method of updating the 'target' resource on Node API Receivers in order to establish connections."
-                    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/3.1.%20Interoperability%20-%20NMOS%20IS-04.md#support-for-legacy-is-04-connection-management
+                    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/3.1.%20Interoperability%20-%20NMOS%20IS-04.md#support-for-legacy-is-04-connection-management
 
                     const auto patch = value_of({
                         { nmos::fields::sender_id, sender_id },

--- a/Development/nmos/node_behaviour.cpp
+++ b/Development/nmos/node_behaviour.cpp
@@ -79,7 +79,7 @@ namespace nmos
     {
         // The possible states of node behaviour represent the two primary modes (registered operation and peer-to-peer operation)
         // and a few hopefully ephemeral states as the node works through the "Standard Registration Sequences".
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md
+        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md
         enum
         {
             initial_discovery,
@@ -97,7 +97,7 @@ namespace nmos
         details::advertise_node_service(model, advertiser);
 
         // "If the chosen Registration API does not respond correctly at any time, another Registration API should be selected from the discovered list."
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/3.1.%20Discovery%20-%20Registered%20Operation.md
+        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/3.1.%20Discovery%20-%20Registered%20Operation.md
 
         // hmm, it seems inefficient to store the discovered list in settings, when it's currently only used by this thread, but TR-1001-1:2018 insists
         // "Media Nodes should, through product-specific means, provide a status parameter indicating which registration service is currently in use."
@@ -147,7 +147,7 @@ namespace nmos
 
                     // "Should a 5xx error be encountered when interacting with all discoverable Registration APIs it is recommended that clients
                     // implement an exponential backoff algorithm in their next attempts until a non-5xx response code is received."
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-500-or-other-5xx-inability-to-connect-or-a-timeout-on-heartbeat
+                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-500-or-other-5xx-inability-to-connect-or-a-timeout-on-heartbeat
                     auto lock = model.read_lock();
                     discovery_backoff = (std::min)((std::max)((double)nmos::fields::discovery_backoff_min(model.settings), discovery_backoff * nmos::fields::discovery_backoff_factor(model.settings)), (double)nmos::fields::discovery_backoff_max(model.settings));
                 }
@@ -428,13 +428,13 @@ namespace nmos
             // "For HTTP codes 400 and upwards, a JSON format response MUST be returned [in which]
             // the 'code' should always match the HTTP status code. 'error' must always be present
             // and in string format. 'debug' may be null if no further debug information is available"
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.0.%20APIs.md#error-codes--responses
+            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.0.%20APIs.md#error-codes--responses
             // Especially in the case of client (4xx) errors, logging these would be a good idea, but
             // would necessitate blocking for the response body, and extracting them from the json
             // and dealing with potential errors along the way...
 
             // "A 500 [or other 5xx] error, inability to connect or a timeout indicates a server side or connectivity issue."
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-500-or-other-5xx-inability-to-connect-or-a-timeout-on-heartbeat
+            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-500-or-other-5xx-inability-to-connect-or-a-timeout-on-heartbeat
             if (handle_client_error_as_server_error ? web::http::is_error_status_code(response.status_code()) : web::http::is_server_error_status_code(response.status_code()))
             {
                 // this could be regarded as a 'severe' error - presumably it is for the registry
@@ -446,7 +446,7 @@ namespace nmos
             }
             // "A 400 [or other 4xx] error [in response to a POST] indicates a client error which is likely
             // to be the result of a validation failure identified by the Registration API."
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-400-or-other-4xx-on-registration
+            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-400-or-other-4xx-on-registration
             else if (web::http::is_client_error_status_code(response.status_code()))
             {
                 // the severity here is trickier, since if it truly indicated a validation failure, this is a 'severe' error
@@ -507,7 +507,7 @@ namespace nmos
             // A 'removed' event calls for registration deletion, i.e. a DELETE request with a 204 'No Content' response
             // A 'modified' event calls for a registration update, i.e. a POST request with a 200 'OK' response (201 'Created'is unexpected)
             // A 'sync' event is also an (unnecessary) registration update, i.e. a POST request with a 200 'OK' response
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/RegistrationAPI.raml
+            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/RegistrationAPI.raml
 
             const bool creation = resource_added_event == event_type;
             const bool update = resource_modified_event == event_type || resource_unchanged_event == event_type;
@@ -526,7 +526,7 @@ namespace nmos
 
                     // "On first registration with a Registration API this should result in a '201 Created' HTTP response code.
                     // If a Node receives a 200 code in this case, a previous record of the Node can be assumed to still exist."
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-200-on-first-registration
+                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-200-on-first-registration
 
                     if (web::http::status_codes::Created == response.status_code())
                     {
@@ -654,7 +654,7 @@ namespace nmos
                     slog::log<slog::severities::error>(gate, SLOG_FLF) << "Registration heartbeat error: " << response.status_code() << " " << response.reason_phrase();
 
                     // "On encountering this code, a Node must re-register each of its resources with the Registration API in order."
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-404-on-heartbeat
+                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-404-on-heartbeat
                     return false;
                 }
                 else
@@ -996,7 +996,7 @@ namespace nmos
                             }
 
                             // "Following deletion of all other resources, the Node resource may be deleted and heartbeating stopped."
-                            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#controlled-unregistration
+                            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#controlled-unregistration
                             if (self_id == id_type.first && resource_removed_event == event_type)
                             {
                                 node_unregistered = true;

--- a/Development/nmos/node_behaviour.cpp
+++ b/Development/nmos/node_behaviour.cpp
@@ -79,7 +79,7 @@ namespace nmos
     {
         // The possible states of node behaviour represent the two primary modes (registered operation and peer-to-peer operation)
         // and a few hopefully ephemeral states as the node works through the "Standard Registration Sequences".
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md
+        // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html
         enum
         {
             initial_discovery,
@@ -97,7 +97,7 @@ namespace nmos
         details::advertise_node_service(model, advertiser);
 
         // "If the chosen Registration API does not respond correctly at any time, another Registration API should be selected from the discovered list."
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/3.1.%20Discovery%20-%20Registered%20Operation.md
+        // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/3.1._Discovery_-_Registered_Operation.html
 
         // hmm, it seems inefficient to store the discovered list in settings, when it's currently only used by this thread, but TR-1001-1:2018 insists
         // "Media Nodes should, through product-specific means, provide a status parameter indicating which registration service is currently in use."
@@ -147,7 +147,7 @@ namespace nmos
 
                     // "Should a 5xx error be encountered when interacting with all discoverable Registration APIs it is recommended that clients
                     // implement an exponential backoff algorithm in their next attempts until a non-5xx response code is received."
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-500-or-other-5xx-inability-to-connect-or-a-timeout-on-heartbeat
+                    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#node-encounters-http-500-or-other-5xx-inability-to-connect-or-a-timeout-on-heartbeat
                     auto lock = model.read_lock();
                     discovery_backoff = (std::min)((std::max)((double)nmos::fields::discovery_backoff_min(model.settings), discovery_backoff * nmos::fields::discovery_backoff_factor(model.settings)), (double)nmos::fields::discovery_backoff_max(model.settings));
                 }
@@ -428,13 +428,13 @@ namespace nmos
             // "For HTTP codes 400 and upwards, a JSON format response MUST be returned [in which]
             // the 'code' should always match the HTTP status code. 'error' must always be present
             // and in string format. 'debug' may be null if no further debug information is available"
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.0.%20APIs.md#error-codes--responses
+            // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.0._APIs.html#error-codes--responses
             // Especially in the case of client (4xx) errors, logging these would be a good idea, but
             // would necessitate blocking for the response body, and extracting them from the json
             // and dealing with potential errors along the way...
 
             // "A 500 [or other 5xx] error, inability to connect or a timeout indicates a server side or connectivity issue."
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-500-or-other-5xx-inability-to-connect-or-a-timeout-on-heartbeat
+            // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#node-encounters-http-500-or-other-5xx-inability-to-connect-or-a-timeout-on-heartbeat
             if (handle_client_error_as_server_error ? web::http::is_error_status_code(response.status_code()) : web::http::is_server_error_status_code(response.status_code()))
             {
                 // this could be regarded as a 'severe' error - presumably it is for the registry
@@ -446,7 +446,7 @@ namespace nmos
             }
             // "A 400 [or other 4xx] error [in response to a POST] indicates a client error which is likely
             // to be the result of a validation failure identified by the Registration API."
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-400-or-other-4xx-on-registration
+            // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#node-encounters-http-400-or-other-4xx-on-registration
             else if (web::http::is_client_error_status_code(response.status_code()))
             {
                 // the severity here is trickier, since if it truly indicated a validation failure, this is a 'severe' error
@@ -507,7 +507,7 @@ namespace nmos
             // A 'removed' event calls for registration deletion, i.e. a DELETE request with a 204 'No Content' response
             // A 'modified' event calls for a registration update, i.e. a POST request with a 200 'OK' response (201 'Created'is unexpected)
             // A 'sync' event is also an (unnecessary) registration update, i.e. a POST request with a 200 'OK' response
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/RegistrationAPI.raml
+            // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/RegistrationAPI.html
 
             const bool creation = resource_added_event == event_type;
             const bool update = resource_modified_event == event_type || resource_unchanged_event == event_type;
@@ -526,7 +526,7 @@ namespace nmos
 
                     // "On first registration with a Registration API this should result in a '201 Created' HTTP response code.
                     // If a Node receives a 200 code in this case, a previous record of the Node can be assumed to still exist."
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-200-on-first-registration
+                    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#node-encounters-http-200-on-first-registration
 
                     if (web::http::status_codes::Created == response.status_code())
                     {
@@ -654,7 +654,7 @@ namespace nmos
                     slog::log<slog::severities::error>(gate, SLOG_FLF) << "Registration heartbeat error: " << response.status_code() << " " << response.reason_phrase();
 
                     // "On encountering this code, a Node must re-register each of its resources with the Registration API in order."
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#node-encounters-http-404-on-heartbeat
+                    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#node-encounters-http-404-on-heartbeat
                     return false;
                 }
                 else
@@ -729,7 +729,7 @@ namespace nmos
 
                     // "Nodes which support multiple versions simultaneously MUST ensure that all of their resources meet the schemas for each corresponding version of the specification[...]
                     // It may be necessary to expose only a limited subset of a Node's resources from lower versioned endpoints."
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.2/docs/6.0.%20Upgrade%20Path.md#version-translations
+                    // See https://specs.amwa.tv/is-04/releases/v1.2.2/docs/6.0._Upgrade_Path.html#version-translations
 
                     // base uri should be like http://api.example.com/x-nmos/registration/{version}
                     const auto registry_version = parse_api_version(web::uri::split_path(base_uri.path()).back());
@@ -996,7 +996,7 @@ namespace nmos
                             }
 
                             // "Following deletion of all other resources, the Node resource may be deleted and heartbeating stopped."
-                            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#controlled-unregistration
+                            // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#controlled-unregistration
                             if (self_id == id_type.first && resource_removed_event == event_type)
                             {
                                 node_unregistered = true;

--- a/Development/nmos/node_behaviour.h
+++ b/Development/nmos/node_behaviour.h
@@ -21,8 +21,8 @@ namespace mdns
 }
 
 // Node behaviour including both registered operation and peer to peer operation
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md
-// and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/3.1.%20Discovery%20-%20Registered%20Operation.md
+// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md
+// and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/3.1.%20Discovery%20-%20Registered%20Operation.md
 namespace nmos
 {
     struct model;

--- a/Development/nmos/node_behaviour.h
+++ b/Development/nmos/node_behaviour.h
@@ -21,8 +21,8 @@ namespace mdns
 }
 
 // Node behaviour including both registered operation and peer to peer operation
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md
-// and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/3.1.%20Discovery%20-%20Registered%20Operation.md
+// See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html
+// and https://specs.amwa.tv/is-04/releases/v1.2.0/docs/3.1._Discovery_-_Registered_Operation.html
 namespace nmos
 {
     struct model;

--- a/Development/nmos/node_resource.cpp
+++ b/Development/nmos/node_resource.cpp
@@ -9,7 +9,7 @@
 
 namespace nmos
 {
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/node.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/node.html
     nmos::resource make_node(const nmos::id& id, const web::json::value& clocks, const web::json::value& interfaces, const nmos::settings& settings)
     {
         using web::json::value;
@@ -56,7 +56,7 @@ namespace nmos
         return make_node(id, {}, {}, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_internal.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/clock_internal.html
     web::json::value make_internal_clock(const nmos::clock_name& clk)
     {
         using web::json::value_of;
@@ -67,7 +67,7 @@ namespace nmos
         });
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_ptp.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/clock_ptp.html
     web::json::value make_ptp_clock(const nmos::clock_name& clk, bool traceable, const utility::string_t& gmid, bool locked)
     {
         using web::json::value_of;

--- a/Development/nmos/node_resource.cpp
+++ b/Development/nmos/node_resource.cpp
@@ -9,7 +9,7 @@
 
 namespace nmos
 {
-    // See  https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/schemas/node.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/node.json
     nmos::resource make_node(const nmos::id& id, const web::json::value& clocks, const web::json::value& interfaces, const nmos::settings& settings)
     {
         using web::json::value;
@@ -56,7 +56,7 @@ namespace nmos
         return make_node(id, {}, {}, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/clock_internal.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_internal.json
     web::json::value make_internal_clock(const nmos::clock_name& clk)
     {
         using web::json::value_of;
@@ -67,7 +67,7 @@ namespace nmos
         });
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/clock_ptp.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_ptp.json
     web::json::value make_ptp_clock(const nmos::clock_name& clk, bool traceable, const utility::string_t& gmid, bool locked)
     {
         using web::json::value_of;

--- a/Development/nmos/node_resource.h
+++ b/Development/nmos/node_resource.h
@@ -20,14 +20,14 @@ namespace nmos
     struct clock_name;
     struct resource;
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/node.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/node.html
     nmos::resource make_node(const nmos::id& id, const web::json::value& clocks, const web::json::value& interfaces, const nmos::settings& settings);
     nmos::resource make_node(const nmos::id& id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_internal.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/clock_internal.html
     web::json::value make_internal_clock(const nmos::clock_name& clock_name);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_ptp.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/clock_ptp.html
     web::json::value make_ptp_clock(const nmos::clock_name& clock_name, bool traceable, const utility::string_t& gmid, bool locked);
 }
 

--- a/Development/nmos/node_resource.h
+++ b/Development/nmos/node_resource.h
@@ -20,14 +20,14 @@ namespace nmos
     struct clock_name;
     struct resource;
 
-    // See  https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/schemas/node.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/node.json
     nmos::resource make_node(const nmos::id& id, const web::json::value& clocks, const web::json::value& interfaces, const nmos::settings& settings);
     nmos::resource make_node(const nmos::id& id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/clock_internal.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_internal.json
     web::json::value make_internal_clock(const nmos::clock_name& clock_name);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/clock_ptp.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/clock_ptp.json
     web::json::value make_ptp_clock(const nmos::clock_name& clock_name, bool traceable, const utility::string_t& gmid, bool locked);
 }
 

--- a/Development/nmos/node_resources.cpp
+++ b/Development/nmos/node_resources.cpp
@@ -25,7 +25,7 @@
 
 namespace nmos
 {
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/device.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/device.html
     nmos::resource make_device(const nmos::id& id, const nmos::id& node_id, const std::vector<nmos::id>& senders, const std::vector<nmos::id>& receivers, const nmos::settings& settings)
     {
         using web::json::value;
@@ -86,7 +86,7 @@ namespace nmos
             // At the moment, it doesn't seem necessary to enable support multiple API instances via the API selector mechanism
             // so therefore just a single Channel Mapping API instance is mounted directly at /x-nmos/channelmapping/{version}/
             // If it becomes necessary, each device could associated with a specific API selector
-            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/2.0.%20APIs.md#api-paths
+            // See https://specs.amwa.tv/is-08/releases/v1.0.1/docs/2.0._APIs.html#api-paths
 
             for (const auto& version : nmos::is08_versions::from_settings(settings))
             {
@@ -108,7 +108,7 @@ namespace nmos
 
         if (0 <= nmos::experimental::fields::manifest_port(settings))
         {
-            // See https://github.com/AMWA-TV/nmos-parameter-registers/blob/main/device-control-types/manifest-base.md
+            // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/device-control-types/manifest-base.html
             // and nmos::experimental::make_manifest_api_manifest
             auto manifest_uri = web::uri_builder()
                 .set_scheme(nmos::http_scheme(settings))
@@ -128,7 +128,7 @@ namespace nmos
         return{ is04_versions::v1_3, types::device, std::move(data), false };
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_core.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_core.html
     nmos::resource make_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings)
     {
         using web::json::value;
@@ -144,7 +144,7 @@ namespace nmos
         return{ is04_versions::v1_3, types::source, std::move(data), false };
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_generic.html
     nmos::resource make_generic_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::format& format, const nmos::settings& settings)
     {
         using web::json::value;
@@ -162,7 +162,7 @@ namespace nmos
         return make_generic_source(id, device_id, {}, grain_rate, format, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_generic.html
     nmos::resource make_video_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings)
     {
         return make_generic_source(id, device_id, clk, grain_rate, nmos::formats::video, settings);
@@ -173,7 +173,7 @@ namespace nmos
         return make_video_source(id, device_id, {}, grain_rate, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_generic.html
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings)
     {
         return make_generic_source(id, device_id, clk, grain_rate, nmos::formats::data, settings);
@@ -184,7 +184,7 @@ namespace nmos
         return make_data_source(id, device_id, {}, grain_rate, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/APIs/schemas/source_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.3.0/APIs/schemas/with-refs/source_data.html
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::event_type& event_type, const nmos::settings& settings)
     {
         using web::json::value;
@@ -202,7 +202,7 @@ namespace nmos
         return make_data_source(id, device_id, {}, grain_rate, event_type, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_audio.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_audio.html
     nmos::resource make_audio_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const std::vector<channel>& channels, const nmos::settings& settings)
     {
         using web::json::value;
@@ -237,7 +237,7 @@ namespace nmos
         return make_mux_source(id, device_id, {}, grain_rate, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_core.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_core.html
     nmos::resource make_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings)
     {
         using web::json::value;
@@ -253,7 +253,7 @@ namespace nmos
         return{ is04_versions::v1_3, types::flow, std::move(data), false };
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video.html
     nmos::resource make_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const nmos::settings& settings)
     {
         using web::json::value;
@@ -271,7 +271,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video_raw.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video_raw.html
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const sdp::sampling& color_sampling, unsigned int bit_depth, const nmos::settings& settings)
     {
         using web::json::value;
@@ -307,7 +307,7 @@ namespace nmos
         return make_raw_video_flow(id, source_id, device_id, {}, 1920, 1080, nmos::interlace_modes::interlaced_bff, nmos::colorspaces::BT709, nmos::transfer_characteristics::SDR, YCbCr422, 10, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video_coded.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video_coded.html
     // (media_type must *not* be nmos::media_types::video_raw; cf. nmos::make_raw_video_flow)
     nmos::resource make_coded_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const nmos::media_type& media_type, const nmos::settings& settings)
     {
@@ -321,7 +321,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_audio.html
     nmos::resource make_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, const nmos::settings& settings)
     {
         using web::json::value;
@@ -335,7 +335,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio_raw.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_audio_raw.html
     nmos::resource make_raw_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, unsigned int bit_depth, const nmos::settings& settings)
     {
         using web::json::value;
@@ -354,7 +354,7 @@ namespace nmos
         return make_raw_audio_flow(id, source_id, device_id, 48000, 24, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio_coded.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_audio_coded.html
     // (media_type must *not* be nmos::media_types::audio_L(bit_depth); cf. nmos::make_raw_audio_flow)
     nmos::resource make_coded_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, const nmos::media_type& media_type, const nmos::settings& settings)
     {
@@ -368,7 +368,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_sdianc_data.html
     nmos::resource make_sdianc_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const std::vector<nmos::did_sdid>& did_sdids, const nmos::settings& settings)
     {
         using web::json::value;
@@ -395,7 +395,7 @@ namespace nmos
         return make_sdianc_data_flow(id, source_id, device_id, {}, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/APIs/schemas/flow_json_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.3.0/APIs/schemas/with-refs/flow_json_data.html
     nmos::resource make_json_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::event_type& event_type, const nmos::settings& settings)
     {
         using web::json::value;
@@ -419,7 +419,7 @@ namespace nmos
         return make_json_data_flow(id, source_id, device_id, {}, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_data.html
     // (media_type must *not* be nmos::media_types::video_smpte291 or nmos::media_types::application_json; cf. nmos::make_sdianc_data_flow and nmos::make_json_data_flow)
     nmos::resource make_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::media_type& media_type, const nmos::settings& settings)
     {
@@ -434,7 +434,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_mux.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_mux.html
     nmos::resource make_mux_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::media_type& media_type, const nmos::settings& settings)
     {
         using web::json::value;
@@ -453,7 +453,7 @@ namespace nmos
         return make_mux_flow(id, source_id, device_id, nmos::media_types::video_SMPTE2022_6, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/sender.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/sender.html
     nmos::resource make_sender(const nmos::id& id, const nmos::id& flow_id, const nmos::transport& transport, const nmos::id& device_id, const utility::string_t& manifest_href, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings)
     {
         using web::json::value;
@@ -483,7 +483,7 @@ namespace nmos
         nmos::resource result{ is04_versions::v1_3, types::sender, std::move(data), false };
 
         // only RTP Senders are permitted prior to v1.3, so specify an appropriate minimum API version
-        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#transport
+        // see https://specs.amwa.tv/is-04/releases/v1.3.0/docs/2.1._APIs_-_Common_Keys.html#transport
         result.downgrade_version = nmos::transports::rtp == nmos::transport_base(transport)
             ? is04_versions::v1_0
             : is04_versions::v1_3;
@@ -509,7 +509,7 @@ namespace nmos
         return make_sender(id, flow_id, nmos::transports::rtp_mcast, device_id, experimental::make_manifest_api_manifest(id, settings).to_string(), interfaces, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_core.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_core.html
     nmos::resource make_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings)
     {
         using web::json::value;
@@ -533,7 +533,7 @@ namespace nmos
         nmos::resource result{ is04_versions::v1_3, types::receiver, std::move(data), false };
 
         // only RTP Receivers are permitted prior to v1.3, so specify an appropriate minimum API version
-        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#transport
+        // see https://specs.amwa.tv/is-04/releases/v1.3.0/docs/2.1._APIs_-_Common_Keys.html#transport
         result.downgrade_version = nmos::transports::rtp == nmos::transport_base(transport)
             ? is04_versions::v1_0
             : is04_versions::v1_3;
@@ -541,7 +541,7 @@ namespace nmos
         return result;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_video.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_video.html
     nmos::resource make_video_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings)
     {
         using web::json::value;
@@ -555,7 +555,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_audio.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_audio.html
     nmos::resource make_audio_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const std::vector<unsigned int>& bit_depths, const nmos::settings& settings)
     {
         using web::json::value;
@@ -577,7 +577,7 @@ namespace nmos
         return make_audio_receiver(id, device_id, transport, interfaces, std::vector<unsigned int>{ bit_depth }, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_data.html
     nmos::resource make_sdianc_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings)
     {
         using web::json::value;
@@ -591,7 +591,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_data.html
     // (media_type must *not* be nmos::media_types::video_smpte291; cf. nmos::make_sdianc_data_receiver)
     nmos::resource make_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::media_type& media_type, const std::vector<nmos::event_type>& event_types, const nmos::settings& settings)
     {
@@ -615,7 +615,7 @@ namespace nmos
         return make_data_receiver(id, device_id, transport, interfaces, media_type, {}, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_mux.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_mux.html
     nmos::resource make_mux_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::media_type& media_type, const nmos::settings& settings)
     {
         using web::json::value;

--- a/Development/nmos/node_resources.cpp
+++ b/Development/nmos/node_resources.cpp
@@ -25,7 +25,7 @@
 
 namespace nmos
 {
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/device.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/device.json
     nmos::resource make_device(const nmos::id& id, const nmos::id& node_id, const std::vector<nmos::id>& senders, const std::vector<nmos::id>& receivers, const nmos::settings& settings)
     {
         using web::json::value;
@@ -86,7 +86,7 @@ namespace nmos
             // At the moment, it doesn't seem necessary to enable support multiple API instances via the API selector mechanism
             // so therefore just a single Channel Mapping API instance is mounted directly at /x-nmos/channelmapping/{version}/
             // If it becomes necessary, each device could associated with a specific API selector
-            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.x/docs/2.0.%20APIs.md#api-paths
+            // See https://github.com/AMWA-TV/nmos-audio-channel-mapping/blob/v1.0.1/docs/2.0.%20APIs.md#api-paths
 
             for (const auto& version : nmos::is08_versions::from_settings(settings))
             {
@@ -128,7 +128,7 @@ namespace nmos
         return{ is04_versions::v1_3, types::device, std::move(data), false };
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_core.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_core.json
     nmos::resource make_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings)
     {
         using web::json::value;
@@ -144,7 +144,7 @@ namespace nmos
         return{ is04_versions::v1_3, types::source, std::move(data), false };
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_generic.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
     nmos::resource make_generic_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::format& format, const nmos::settings& settings)
     {
         using web::json::value;
@@ -162,7 +162,7 @@ namespace nmos
         return make_generic_source(id, device_id, {}, grain_rate, format, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_generic.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
     nmos::resource make_video_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings)
     {
         return make_generic_source(id, device_id, clk, grain_rate, nmos::formats::video, settings);
@@ -173,7 +173,7 @@ namespace nmos
         return make_video_source(id, device_id, {}, grain_rate, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_generic.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings)
     {
         return make_generic_source(id, device_id, clk, grain_rate, nmos::formats::data, settings);
@@ -184,7 +184,7 @@ namespace nmos
         return make_data_source(id, device_id, {}, grain_rate, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3/APIs/schemas/source_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/APIs/schemas/source_data.json
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::event_type& event_type, const nmos::settings& settings)
     {
         using web::json::value;
@@ -202,7 +202,7 @@ namespace nmos
         return make_data_source(id, device_id, {}, grain_rate, event_type, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_audio.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_audio.json
     nmos::resource make_audio_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const std::vector<channel>& channels, const nmos::settings& settings)
     {
         using web::json::value;
@@ -237,7 +237,7 @@ namespace nmos
         return make_mux_source(id, device_id, {}, grain_rate, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_core.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_core.json
     nmos::resource make_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings)
     {
         using web::json::value;
@@ -253,7 +253,7 @@ namespace nmos
         return{ is04_versions::v1_3, types::flow, std::move(data), false };
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
     nmos::resource make_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const nmos::settings& settings)
     {
         using web::json::value;
@@ -271,7 +271,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video_raw.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video_raw.json
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const sdp::sampling& color_sampling, unsigned int bit_depth, const nmos::settings& settings)
     {
         using web::json::value;
@@ -307,7 +307,7 @@ namespace nmos
         return make_raw_video_flow(id, source_id, device_id, {}, 1920, 1080, nmos::interlace_modes::interlaced_bff, nmos::colorspaces::BT709, nmos::transfer_characteristics::SDR, YCbCr422, 10, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video_coded.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video_coded.json
     // (media_type must *not* be nmos::media_types::video_raw; cf. nmos::make_raw_video_flow)
     nmos::resource make_coded_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const nmos::media_type& media_type, const nmos::settings& settings)
     {
@@ -321,7 +321,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_audio.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio.json
     nmos::resource make_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, const nmos::settings& settings)
     {
         using web::json::value;
@@ -335,7 +335,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_audio_raw.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio_raw.json
     nmos::resource make_raw_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, unsigned int bit_depth, const nmos::settings& settings)
     {
         using web::json::value;
@@ -354,7 +354,7 @@ namespace nmos
         return make_raw_audio_flow(id, source_id, device_id, 48000, 24, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_audio_coded.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio_coded.json
     // (media_type must *not* be nmos::media_types::audio_L(bit_depth); cf. nmos::make_raw_audio_flow)
     nmos::resource make_coded_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, const nmos::media_type& media_type, const nmos::settings& settings)
     {
@@ -368,7 +368,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_sdianc_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
     nmos::resource make_sdianc_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const std::vector<nmos::did_sdid>& did_sdids, const nmos::settings& settings)
     {
         using web::json::value;
@@ -395,7 +395,7 @@ namespace nmos
         return make_sdianc_data_flow(id, source_id, device_id, {}, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3/APIs/schemas/flow_json_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/APIs/schemas/flow_json_data.json
     nmos::resource make_json_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::event_type& event_type, const nmos::settings& settings)
     {
         using web::json::value;
@@ -419,7 +419,7 @@ namespace nmos
         return make_json_data_flow(id, source_id, device_id, {}, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_data.json
     // (media_type must *not* be nmos::media_types::video_smpte291 or nmos::media_types::application_json; cf. nmos::make_sdianc_data_flow and nmos::make_json_data_flow)
     nmos::resource make_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::media_type& media_type, const nmos::settings& settings)
     {
@@ -434,7 +434,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_mux.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_mux.json
     nmos::resource make_mux_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::media_type& media_type, const nmos::settings& settings)
     {
         using web::json::value;
@@ -453,7 +453,7 @@ namespace nmos
         return make_mux_flow(id, source_id, device_id, nmos::media_types::video_SMPTE2022_6, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/sender.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/sender.json
     nmos::resource make_sender(const nmos::id& id, const nmos::id& flow_id, const nmos::transport& transport, const nmos::id& device_id, const utility::string_t& manifest_href, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings)
     {
         using web::json::value;
@@ -483,7 +483,7 @@ namespace nmos
         nmos::resource result{ is04_versions::v1_3, types::sender, std::move(data), false };
 
         // only RTP Senders are permitted prior to v1.3, so specify an appropriate minimum API version
-        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3/docs/2.1.%20APIs%20-%20Common%20Keys.md#transport
+        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#transport
         result.downgrade_version = nmos::transports::rtp == nmos::transport_base(transport)
             ? is04_versions::v1_0
             : is04_versions::v1_3;
@@ -509,7 +509,7 @@ namespace nmos
         return make_sender(id, flow_id, nmos::transports::rtp_mcast, device_id, experimental::make_manifest_api_manifest(id, settings).to_string(), interfaces, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_core.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_core.json
     nmos::resource make_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings)
     {
         using web::json::value;
@@ -533,7 +533,7 @@ namespace nmos
         nmos::resource result{ is04_versions::v1_3, types::receiver, std::move(data), false };
 
         // only RTP Receivers are permitted prior to v1.3, so specify an appropriate minimum API version
-        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3/docs/2.1.%20APIs%20-%20Common%20Keys.md#transport
+        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#transport
         result.downgrade_version = nmos::transports::rtp == nmos::transport_base(transport)
             ? is04_versions::v1_0
             : is04_versions::v1_3;
@@ -541,7 +541,7 @@ namespace nmos
         return result;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_video.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_video.json
     nmos::resource make_video_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings)
     {
         using web::json::value;
@@ -555,7 +555,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_audio.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_audio.json
     nmos::resource make_audio_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const std::vector<unsigned int>& bit_depths, const nmos::settings& settings)
     {
         using web::json::value;
@@ -577,7 +577,7 @@ namespace nmos
         return make_audio_receiver(id, device_id, transport, interfaces, std::vector<unsigned int>{ bit_depth }, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_data.json
     nmos::resource make_sdianc_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings)
     {
         using web::json::value;
@@ -591,7 +591,7 @@ namespace nmos
         return resource;
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_data.json
     // (media_type must *not* be nmos::media_types::video_smpte291; cf. nmos::make_sdianc_data_receiver)
     nmos::resource make_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::media_type& media_type, const std::vector<nmos::event_type>& event_types, const nmos::settings& settings)
     {
@@ -615,7 +615,7 @@ namespace nmos
         return make_data_receiver(id, device_id, transport, interfaces, media_type, {}, settings);
     }
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_mux.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_mux.json
     nmos::resource make_mux_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::media_type& media_type, const nmos::settings& settings)
     {
         using web::json::value;

--- a/Development/nmos/node_resources.h
+++ b/Development/nmos/node_resources.h
@@ -32,79 +32,79 @@ namespace nmos
     struct transfer_characteristic;
     struct transport;
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/device.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/device.html
     nmos::resource make_device(const nmos::id& id, const nmos::id& node_id, const std::vector<nmos::id>& senders, const std::vector<nmos::id>& receivers, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_core.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_core.html
     nmos::resource make_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_generic.html
     nmos::resource make_generic_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::format& format, const nmos::settings& settings);
     nmos::resource make_generic_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::format& format, const nmos::settings& settings);
     nmos::resource make_video_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings);
     nmos::resource make_video_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_generic.html
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings);
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/APIs/schemas/source_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.3.0/APIs/schemas/with-refs/source_data.html
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::event_type& event_type, const nmos::settings& settings);
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::event_type& event_type, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_audio.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_audio.html
     nmos::resource make_audio_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const std::vector<nmos::channel>& channels, const nmos::settings& settings);
     nmos::resource make_audio_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const std::vector<nmos::channel>& channels, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/source_generic.html
     nmos::resource make_mux_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings);
     nmos::resource make_mux_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_core.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_core.html
     nmos::resource make_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video.html
     nmos::resource make_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video_raw.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video_raw.html
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const sdp::sampling& color_sampling, unsigned int bit_depth, const nmos::settings& settings);
     // deprecated, see overload with sdp::sampling
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, chroma_subsampling chroma_subsampling, unsigned int bit_depth, const nmos::settings& settings);
     // deprecated, constructs a 1920 x 1080, interlaced, BT709, SDR, YCbCr-4:2:2, 10 bit raw video Flow
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video_coded.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video_coded.html
     // (media_type must *not* be nmos::media_types::video_raw; cf. nmos::make_raw_video_flow)
     nmos::resource make_coded_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const nmos::media_type& media_type, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_audio.html
     nmos::resource make_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio_raw.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_audio_raw.html
     nmos::resource make_raw_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, unsigned int bit_depth, const nmos::settings& settings);
     nmos::resource make_raw_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio_coded.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_audio_coded.html
     // (media_type must *not* be nmos::media_types::audio_L(bit_depth); cf. nmos::make_raw_audio_flow)
     nmos::resource make_coded_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, const nmos::media_type& media_type, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_sdianc_data.html
     nmos::resource make_sdianc_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const std::vector<nmos::did_sdid>& did_sdids, const nmos::settings& settings);
     nmos::resource make_sdianc_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/APIs/schemas/flow_json_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.3.0/APIs/schemas/with-refs/flow_json_data.html
     nmos::resource make_json_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::event_type& event_type, const nmos::settings& settings);
     nmos::resource make_json_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_data.html
     // (media_type must *not* be nmos::media_types::video_smpte291 or nmos::media_types::application_json; cf. nmos::make_sdianc_data_flow and nmos::make_json_data_flow)
     nmos::resource make_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::media_type& media_type, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_mux.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_mux.html
     nmos::resource make_mux_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::media_type& media_type, const nmos::settings& settings);
     nmos::resource make_mux_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/sender.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/sender.html
     nmos::resource make_sender(const nmos::id& id, const nmos::id& flow_id, const nmos::transport& transport, const nmos::id& device_id, const utility::string_t& manifest_href, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
     namespace experimental
@@ -114,25 +114,25 @@ namespace nmos
     
     nmos::resource make_sender(const nmos::id& id, const nmos::id& flow_id, const nmos::id& device_id, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_core.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_core.html
     nmos::resource make_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_video.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_video.html
     nmos::resource make_video_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_audio.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_audio.html
     nmos::resource make_audio_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const std::vector<unsigned int>& bit_depths, const nmos::settings& settings);
     nmos::resource make_audio_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, unsigned int bit_depth, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_data.html
     nmos::resource make_sdianc_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/APIs/schemas/receiver_data.json
+    // See https://specs.amwa.tv/is-04/releases/v1.3.0/APIs/schemas/with-refs/receiver_data.html
     // (media_type must *not* be nmos::media_types::video_smpte291; cf. nmos::make_sdianc_data_receiver)
     nmos::resource make_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::media_type& media_type, const std::vector<nmos::event_type>& event_types, const nmos::settings& settings);
     nmos::resource make_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::media_type& media_type, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_mux.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_mux.html
     nmos::resource make_mux_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::media_type& media_type, const nmos::settings& settings);
     nmos::resource make_mux_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 }

--- a/Development/nmos/node_resources.h
+++ b/Development/nmos/node_resources.h
@@ -32,79 +32,79 @@ namespace nmos
     struct transfer_characteristic;
     struct transport;
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/device.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/device.json
     nmos::resource make_device(const nmos::id& id, const nmos::id& node_id, const std::vector<nmos::id>& senders, const std::vector<nmos::id>& receivers, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_core.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_core.json
     nmos::resource make_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_generic.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
     nmos::resource make_generic_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::format& format, const nmos::settings& settings);
     nmos::resource make_generic_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::format& format, const nmos::settings& settings);
     nmos::resource make_video_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings);
     nmos::resource make_video_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_generic.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings);
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3/APIs/schemas/source_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/APIs/schemas/source_data.json
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::event_type& event_type, const nmos::settings& settings);
     nmos::resource make_data_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::event_type& event_type, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_audio.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_audio.json
     nmos::resource make_audio_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const std::vector<nmos::channel>& channels, const nmos::settings& settings);
     nmos::resource make_audio_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const std::vector<nmos::channel>& channels, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/source_generic.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/source_generic.json
     nmos::resource make_mux_source(const nmos::id& id, const nmos::id& device_id, const nmos::clock_name& clk, const nmos::rational& grain_rate, const nmos::settings& settings);
     nmos::resource make_mux_source(const nmos::id& id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_core.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_core.json
     nmos::resource make_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
     nmos::resource make_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video_raw.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video_raw.json
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const sdp::sampling& color_sampling, unsigned int bit_depth, const nmos::settings& settings);
     // deprecated, see overload with sdp::sampling
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, chroma_subsampling chroma_subsampling, unsigned int bit_depth, const nmos::settings& settings);
     // deprecated, constructs a 1920 x 1080, interlaced, BT709, SDR, YCbCr-4:2:2, 10 bit raw video Flow
     nmos::resource make_raw_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video_coded.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video_coded.json
     // (media_type must *not* be nmos::media_types::video_raw; cf. nmos::make_raw_video_flow)
     nmos::resource make_coded_video_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& grain_rate, unsigned int frame_width, unsigned int frame_height, const nmos::interlace_mode& interlace_mode, const nmos::colorspace& colorspace, const nmos::transfer_characteristic& transfer_characteristic, const nmos::media_type& media_type, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_audio.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio.json
     nmos::resource make_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_audio_raw.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio_raw.json
     nmos::resource make_raw_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, unsigned int bit_depth, const nmos::settings& settings);
     nmos::resource make_raw_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_audio_coded.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_audio_coded.json
     // (media_type must *not* be nmos::media_types::audio_L(bit_depth); cf. nmos::make_raw_audio_flow)
     nmos::resource make_coded_audio_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::rational& sample_rate, const nmos::media_type& media_type, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_sdianc_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_sdianc_data.json
     nmos::resource make_sdianc_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const std::vector<nmos::did_sdid>& did_sdids, const nmos::settings& settings);
     nmos::resource make_sdianc_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3/APIs/schemas/flow_json_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/APIs/schemas/flow_json_data.json
     nmos::resource make_json_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::event_type& event_type, const nmos::settings& settings);
     nmos::resource make_json_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_data.json
     // (media_type must *not* be nmos::media_types::video_smpte291 or nmos::media_types::application_json; cf. nmos::make_sdianc_data_flow and nmos::make_json_data_flow)
     nmos::resource make_data_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::media_type& media_type, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_mux.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_mux.json
     nmos::resource make_mux_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::media_type& media_type, const nmos::settings& settings);
     nmos::resource make_mux_flow(const nmos::id& id, const nmos::id& source_id, const nmos::id& device_id, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/sender.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/sender.json
     nmos::resource make_sender(const nmos::id& id, const nmos::id& flow_id, const nmos::transport& transport, const nmos::id& device_id, const utility::string_t& manifest_href, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
     namespace experimental
@@ -114,25 +114,25 @@ namespace nmos
     
     nmos::resource make_sender(const nmos::id& id, const nmos::id& flow_id, const nmos::id& device_id, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_core.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_core.json
     nmos::resource make_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_video.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_video.json
     nmos::resource make_video_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_audio.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_audio.json
     nmos::resource make_audio_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const std::vector<unsigned int>& bit_depths, const nmos::settings& settings);
     nmos::resource make_audio_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, unsigned int bit_depth, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_data.json
     nmos::resource make_sdianc_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3/APIs/schemas/receiver_data.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.0/APIs/schemas/receiver_data.json
     // (media_type must *not* be nmos::media_types::video_smpte291; cf. nmos::make_sdianc_data_receiver)
     nmos::resource make_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::media_type& media_type, const std::vector<nmos::event_type>& event_types, const nmos::settings& settings);
     nmos::resource make_data_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::media_type& media_type, const nmos::settings& settings);
 
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_mux.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_mux.json
     nmos::resource make_mux_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::media_type& media_type, const nmos::settings& settings);
     nmos::resource make_mux_receiver(const nmos::id& id, const nmos::id& device_id, const nmos::transport& transport, const std::vector<utility::string_t>& interfaces, const nmos::settings& settings);
 }

--- a/Development/nmos/node_system_behaviour.cpp
+++ b/Development/nmos/node_system_behaviour.cpp
@@ -127,7 +127,7 @@ namespace nmos
     {
         // query DNS Service Discovery for any System API in the specified browse domain, having priority in the specified range
         // otherwise, after timeout or cancellation, returning the fallback system service
-        // see https://github.com/AMWA-TV/nmos-system/blob/v1.0/docs/3.0.%20Discovery.md
+        // see https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/3.0.%20Discovery.md
         web::json::value discover_system_services(mdns::service_discovery& discovery, const std::string& browse_domain, const std::set<nmos::api_version>& versions, const std::pair<nmos::service_priority, nmos::service_priority>& priorities, const std::set<nmos::service_protocol>& protocols, const web::uri& fallback_service, slog::base_gate& gate, const std::chrono::steady_clock::duration& timeout, const pplx::cancellation_token& token = pplx::cancellation_token::none())
         {
             std::list<web::uri> system_services;

--- a/Development/nmos/node_system_behaviour.cpp
+++ b/Development/nmos/node_system_behaviour.cpp
@@ -127,7 +127,7 @@ namespace nmos
     {
         // query DNS Service Discovery for any System API in the specified browse domain, having priority in the specified range
         // otherwise, after timeout or cancellation, returning the fallback system service
-        // see https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/3.0.%20Discovery.md
+        // see https://specs.amwa.tv/is-09/releases/v1.0.0/docs/3.0._Discovery.html
         web::json::value discover_system_services(mdns::service_discovery& discovery, const std::string& browse_domain, const std::set<nmos::api_version>& versions, const std::pair<nmos::service_priority, nmos::service_priority>& priorities, const std::set<nmos::service_protocol>& protocols, const web::uri& fallback_service, slog::base_gate& gate, const std::chrono::steady_clock::duration& timeout, const pplx::cancellation_token& token = pplx::cancellation_token::none())
         {
             std::list<web::uri> system_services;

--- a/Development/nmos/node_system_behaviour.h
+++ b/Development/nmos/node_system_behaviour.h
@@ -25,7 +25,7 @@ namespace mdns
 }
 
 // Node behaviour with the System API
-// See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/README.md
+// See https://specs.amwa.tv/is-09/v1.0.0/docs/4.0._Behaviour.html
 namespace nmos
 {
     struct model;

--- a/Development/nmos/node_system_behaviour.h
+++ b/Development/nmos/node_system_behaviour.h
@@ -25,7 +25,7 @@ namespace mdns
 }
 
 // Node behaviour with the System API
-// See https://github.com/AMWA-TV/nmos-system/blob/v1.0/README.md
+// See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/README.md
 namespace nmos
 {
     struct model;

--- a/Development/nmos/query_api.cpp
+++ b/Development/nmos/query_api.cpp
@@ -124,7 +124,7 @@ namespace nmos
 
             // RFC 5988 allows relative URLs, but NMOS specification examples are all absolute URLs
             // See https://tools.ietf.org/html/rfc5988#section-5
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md
+            // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.5._APIs_-_Query_Parameters.html
 
             // get the request host and port (or use the primary host address, and port, from settings)
             auto req_host_port = web::http::get_host_port(req);

--- a/Development/nmos/query_api.cpp
+++ b/Development/nmos/query_api.cpp
@@ -124,7 +124,7 @@ namespace nmos
 
             // RFC 5988 allows relative URLs, but NMOS specification examples are all absolute URLs
             // See https://tools.ietf.org/html/rfc5988#section-5
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.5.%20APIs%20-%20Query%20Parameters.md
+            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md
 
             // get the request host and port (or use the primary host address, and port, from settings)
             auto req_host_port = web::http::get_host_port(req);

--- a/Development/nmos/query_api.h
+++ b/Development/nmos/query_api.h
@@ -10,7 +10,7 @@ namespace slog
 }
 
 // Query API implementation
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/QueryAPI.raml
+// See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/QueryAPI.html
 namespace nmos
 {
     struct registry_model;

--- a/Development/nmos/query_api.h
+++ b/Development/nmos/query_api.h
@@ -10,7 +10,7 @@ namespace slog
 }
 
 // Query API implementation
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/QueryAPI.raml
+// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/QueryAPI.raml
 namespace nmos
 {
     struct registry_model;

--- a/Development/nmos/query_utils.cpp
+++ b/Development/nmos/query_utils.cpp
@@ -57,7 +57,7 @@ namespace nmos
                 }
                 // extract the experimental flag, used to override the default behaviour that resources
                 // "must have all [higher-versioned] keys stripped by the Query API before they are returned"
-                // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.5.%20APIs%20-%20Query%20Parameters.md#downgrade-queries
+                // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#downgrade-queries
                 else if (field.first == U("strip"))
                 {
                     strip = field.second.as_bool();
@@ -69,7 +69,7 @@ namespace nmos
                 }
                 // taking query.ancestry_id as an example, an error should be reported for unimplemented parameters
                 // "A 501 HTTP status code should be returned where an ancestry query is attempted against a Query API which does not implement it."
-                // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.5.%20APIs%20-%20Query%20Parameters.md#ancestry-queries-optional
+                // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#ancestry-queries-optional
                 else
                 {
                     throw std::runtime_error("unimplemented parameter - query." + utility::us2s(field.first));
@@ -97,7 +97,7 @@ namespace nmos
                 if (field.first == U("order"))
                 {
                     // paging.order is "create" or "update"
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/QueryAPI.raml#L40
+                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/QueryAPI.raml#L40
                     order_by_created = U("create") == field.second.as_string();
                 }
                 else if (field.first == U("until"))

--- a/Development/nmos/query_utils.cpp
+++ b/Development/nmos/query_utils.cpp
@@ -57,7 +57,7 @@ namespace nmos
                 }
                 // extract the experimental flag, used to override the default behaviour that resources
                 // "must have all [higher-versioned] keys stripped by the Query API before they are returned"
-                // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#downgrade-queries
+                // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.5._APIs_-_Query_Parameters.html#downgrade-queries
                 else if (field.first == U("strip"))
                 {
                     strip = field.second.as_bool();
@@ -69,7 +69,7 @@ namespace nmos
                 }
                 // taking query.ancestry_id as an example, an error should be reported for unimplemented parameters
                 // "A 501 HTTP status code should be returned where an ancestry query is attempted against a Query API which does not implement it."
-                // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#ancestry-queries-optional
+                // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.5._APIs_-_Query_Parameters.html#ancestry-queries-optional
                 else
                 {
                     throw std::runtime_error("unimplemented parameter - query." + utility::us2s(field.first));
@@ -97,7 +97,7 @@ namespace nmos
                 if (field.first == U("order"))
                 {
                     // paging.order is "create" or "update"
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/QueryAPI.raml#L40
+                    // See https://specs.amwa.tv/is-04/releases/v1.3.1/APIs/QueryAPI.html#nodes_get etc.
                     order_by_created = U("create") == field.second.as_string();
                 }
                 else if (field.first == U("until"))

--- a/Development/nmos/query_utils.h
+++ b/Development/nmos/query_utils.h
@@ -105,7 +105,7 @@ namespace nmos
     inline nmos::resources::index<tags::updated>::type::const_iterator lower_bound(const nmos::resources::index<tags::updated>::type& index, const nmos::tai& timestamp) { return index.lower_bound(timestamp); }
 
     // Helpers for constructing /subscriptions websocket grains
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.2.%20Behaviour%20-%20Querying.md
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.2.%20Behaviour%20-%20Querying.md
 
     // make the initial 'sync' resource events for a new grain, including all resources that match the specified version, resource path and flat query parameters
     // optionally, make 'added' resource events instead of 'sync' events

--- a/Development/nmos/query_utils.h
+++ b/Development/nmos/query_utils.h
@@ -105,7 +105,7 @@ namespace nmos
     inline nmos::resources::index<tags::updated>::type::const_iterator lower_bound(const nmos::resources::index<tags::updated>::type& index, const nmos::tai& timestamp) { return index.lower_bound(timestamp); }
 
     // Helpers for constructing /subscriptions websocket grains
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.2.%20Behaviour%20-%20Querying.md
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.2._Behaviour_-_Querying.html
 
     // make the initial 'sync' resource events for a new grain, including all resources that match the specified version, resource path and flat query parameters
     // optionally, make 'added' resource events instead of 'sync' events

--- a/Development/nmos/query_ws_api.h
+++ b/Development/nmos/query_ws_api.h
@@ -9,7 +9,7 @@ namespace slog
 }
 
 // Query API websocket implementation
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.2.%20Behaviour%20-%20Querying.md
+// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.2.%20Behaviour%20-%20Querying.md
 namespace nmos
 {
     struct registry_model;

--- a/Development/nmos/query_ws_api.h
+++ b/Development/nmos/query_ws_api.h
@@ -9,7 +9,7 @@ namespace slog
 }
 
 // Query API websocket implementation
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.2.%20Behaviour%20-%20Querying.md
+// See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.2._Behaviour_-_Querying.html
 namespace nmos
 {
     struct registry_model;

--- a/Development/nmos/registration_api.cpp
+++ b/Development/nmos/registration_api.cpp
@@ -309,7 +309,7 @@ namespace nmos
                 {
                     // "The 'senders' and 'receivers' arrays in a Device have been deprecated, but will continue to be present until v2.0."
                     // Therefore, issue warnings rather than errors here
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.1/docs/4.2.%20Behaviour%20-%20Querying.md#referential-integrity
+                    // See https://specs.amwa.tv/is-04/releases/v1.2.1/docs/4.2._Behaviour_-_Querying.html#referential-integrity
 
                     for (auto& element : nmos::fields::senders(data))
                     {
@@ -339,7 +339,7 @@ namespace nmos
                 {
                     // v1.1 introduced device_id for flow, and uses it for referential integrity rather than source_id
                     // so if the source is not (yet) registered, issue a warning not an error, and don't treat this as invalid?
-                    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.1/docs/4.1.%20Behaviour%20-%20Registration.md#referential-integrity
+                    // see https://specs.amwa.tv/is-04/releases/v1.2.1/docs/4.1._Behaviour_-_Registration.html#referential-integrity
                     if (nmos::is04_versions::v1_1 <= version)
                     {
                         const auto& source_id = nmos::fields::source_id(data);
@@ -606,7 +606,7 @@ namespace nmos
 
                     // "If a Node unregisters a resource in the incorrect order, the Registration API MUST clean up related child resources
                     // on the Node's behalf in order to prevent stale entries remaining in the registry."
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#controlled-unregistration
+                    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#controlled-unregistration
                     erase_resource(resources, resource->id, false);
 
                     slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Notifying query websockets thread"; // and anyone else who cares...

--- a/Development/nmos/registration_api.cpp
+++ b/Development/nmos/registration_api.cpp
@@ -606,7 +606,7 @@ namespace nmos
 
                     // "If a Node unregisters a resource in the incorrect order, the Registration API MUST clean up related child resources
                     // on the Node's behalf in order to prevent stale entries remaining in the registry."
-                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#controlled-unregistration
+                    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#controlled-unregistration
                     erase_resource(resources, resource->id, false);
 
                     slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Notifying query websockets thread"; // and anyone else who cares...

--- a/Development/nmos/registration_api.h
+++ b/Development/nmos/registration_api.h
@@ -9,7 +9,7 @@ namespace slog
 }
 
 // Registration API implementation
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/RegistrationAPI.raml
+// See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/RegistrationAPI.html
 namespace nmos
 {
     struct registry_model;

--- a/Development/nmos/registration_api.h
+++ b/Development/nmos/registration_api.h
@@ -9,7 +9,7 @@ namespace slog
 }
 
 // Registration API implementation
-// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/RegistrationAPI.raml
+// See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/RegistrationAPI.raml
 namespace nmos
 {
     struct registry_model;

--- a/Development/nmos/registry_server.cpp
+++ b/Development/nmos/registry_server.cpp
@@ -63,7 +63,7 @@ namespace nmos
             registry_server.api_routers[{ {}, nmos::fields::query_port(registry_model.settings) }].mount({}, nmos::make_query_api(registry_model, gate));
 
             // "Source ID of the Query API instance issuing the data Grain"
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/queryapi-subscriptions-websocket.json
+            // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/queryapi-subscriptions-websocket.html
             const nmos::id query_id = nmos::make_repeatable_id(nmos::experimental::fields::seed_id(registry_model.settings), U("/x-nmos/query"));
 
             auto& query_ws_api = registry_server.ws_handlers[{ {}, nmos::fields::query_ws_port(registry_model.settings) }];

--- a/Development/nmos/registry_server.cpp
+++ b/Development/nmos/registry_server.cpp
@@ -63,7 +63,7 @@ namespace nmos
             registry_server.api_routers[{ {}, nmos::fields::query_port(registry_model.settings) }].mount({}, nmos::make_query_api(registry_model, gate));
 
             // "Source ID of the Query API instance issuing the data Grain"
-            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/queryapi-subscriptions-websocket.json
+            // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/queryapi-subscriptions-websocket.json
             const nmos::id query_id = nmos::make_repeatable_id(nmos::experimental::fields::seed_id(registry_model.settings), U("/x-nmos/query"));
 
             auto& query_ws_api = registry_server.ws_handlers[{ {}, nmos::fields::query_ws_port(registry_model.settings) }];

--- a/Development/nmos/resource.cpp
+++ b/Development/nmos/resource.cpp
@@ -7,7 +7,7 @@ namespace nmos
 {
     namespace details
     {
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/resource_core.json
+        // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/resource_core.html
         web::json::value make_resource_core(const nmos::id& id, const utility::string_t& label, const utility::string_t& description, const web::json::value& tags)
         {
             using web::json::value;

--- a/Development/nmos/resource.cpp
+++ b/Development/nmos/resource.cpp
@@ -7,7 +7,7 @@ namespace nmos
 {
     namespace details
     {
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/resource_core.json
+        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/resource_core.json
         web::json::value make_resource_core(const nmos::id& id, const utility::string_t& label, const utility::string_t& description, const web::json::value& tags)
         {
             using web::json::value;

--- a/Development/nmos/resource.h
+++ b/Development/nmos/resource.h
@@ -63,17 +63,17 @@ namespace nmos
         // sub-resources are tracked in order to optimise resource expiry and deletion
         std::set<nmos::id> sub_resources;
 
-        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.5.%20APIs%20-%20Query%20Parameters.md#pagination
+        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#pagination
         tai created;
         tai updated;
 
-        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
+        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
         mutable details::copyable_atomic<nmos::health> health;
     };
 
     namespace details
     {
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/resource_core.json
+        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/resource_core.json
         web::json::value make_resource_core(const nmos::id& id, const utility::string_t& label, const utility::string_t& description, const web::json::value& tags = web::json::value::object());
 
         web::json::value make_resource_core(const nmos::id& id, const nmos::settings& settings);

--- a/Development/nmos/resource.h
+++ b/Development/nmos/resource.h
@@ -63,17 +63,17 @@ namespace nmos
         // sub-resources are tracked in order to optimise resource expiry and deletion
         std::set<nmos::id> sub_resources;
 
-        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#pagination
+        // see https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.5._APIs_-_Query_Parameters.html#pagination
         tai created;
         tai updated;
 
-        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
+        // see https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#heartbeating
         mutable details::copyable_atomic<nmos::health> health;
     };
 
     namespace details
     {
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/resource_core.json
+        // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/resource_core.html
         web::json::value make_resource_core(const nmos::id& id, const utility::string_t& label, const utility::string_t& description, const web::json::value& tags = web::json::value::object());
 
         web::json::value make_resource_core(const nmos::id& id, const nmos::settings& settings);

--- a/Development/nmos/resources.cpp
+++ b/Development/nmos/resources.cpp
@@ -285,7 +285,7 @@ namespace nmos
     static inline std::pair<id, type> no_resource() { return{}; }
 
     // get the super-resource id and type, according to the guidelines on referential integrity
-    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.1/docs/4.1.%20Behaviour%20-%20Registration.md#referential-integrity
+    // see https://specs.amwa.tv/is-04/releases/v1.2.1/docs/4.1._Behaviour_-_Registration.html#referential-integrity
     std::pair<id, type> get_super_resource(const api_version& version, const type& type, const web::json::value& data)
     {
         if (data.is_null())

--- a/Development/nmos/resources.h
+++ b/Development/nmos/resources.h
@@ -96,7 +96,7 @@ namespace nmos
     // Other helper functions for resources
 
     // get the super-resource id and type, according to the guidelines on referential integrity
-    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.1/docs/4.1.%20Behaviour%20-%20Registration.md#referential-integrity
+    // see https://specs.amwa.tv/is-04/releases/v1.2.1/docs/4.1._Behaviour_-_Registration.html#referential-integrity
     std::pair<id, type> get_super_resource(const api_version& version, const type& type, const web::json::value& data);
 
     inline std::pair<id, type> get_super_resource(const resource& resource)

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -864,7 +864,7 @@ namespace nmos
 
         // There isn't much of a specification for interpreting SDP files and updating the
         // equivalent transport parameters, just some examples...
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#interpretation-of-sdp-files
+        // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/4.1._Behaviour_-_RTP_Transport_Type.html#interpretation-of-sdp-files
 
         // For now, this function should handle the following cases identified in the documentation:
         // * Unicast
@@ -886,7 +886,7 @@ namespace nmos
 
             // source_ip is null when there is no source-filter, indicating that "the source IP address
             // has not been configured in unicast mode, or the Receiver is in any-source multicast mode"
-            // see https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_rtp.json
+            // see https://specs.amwa.tv/is-05/releases/v1.1.0/APIs/schemas/with-refs/receiver_transport_params_rtp.html
             params[nmos::fields::source_ip] = value::null();
 
             // session connection data is the default for each media description
@@ -1330,7 +1330,7 @@ namespace nmos
         if (!nmos::caps::meta::enabled(constraint_set)) return false;
 
         // NMOS Parameter Registers - Capabilities register
-        // See https://github.com/AMWA-TV/nmos-parameter-registers/blob/main/capabilities/README.md
+        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/
         static const std::map<utility::string_t, std::function<bool(const sdp_parameters& sdp, const value& con)>> match_constraints
         {
             // General Constraints

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -864,7 +864,7 @@ namespace nmos
 
         // There isn't much of a specification for interpreting SDP files and updating the
         // equivalent transport parameters, just some examples...
-        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#interpretation-of-sdp-files
+        // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.0.0/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#interpretation-of-sdp-files
 
         // For now, this function should handle the following cases identified in the documentation:
         // * Unicast
@@ -886,7 +886,7 @@ namespace nmos
 
             // source_ip is null when there is no source-filter, indicating that "the source IP address
             // has not been configured in unicast mode, or the Receiver is in any-source multicast mode"
-            // see https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1/APIs/schemas/receiver_transport_params_rtp.json
+            // see https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.0/APIs/schemas/receiver_transport_params_rtp.json
             params[nmos::fields::source_ip] = value::null();
 
             // session connection data is the default for each media description

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -133,15 +133,15 @@ namespace nmos
         // [registry]: used in System API resource is04 object's heartbeat_interval field
         // "Constants related to the AMWA IS-04 Discovery and Registration Specification are contained in the is04 object.
         // heartbeat_interval defines how often Nodes should perform a heartbeat to maintain their resources in the Registration API."
-        // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#amwa-is-04-nmos-discovery-and-registration-parameters
+        // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#amwa-is-04-nmos-discovery-and-registration-parameters
         // [node]:
         // "Nodes are expected to peform a heartbeat every 5 seconds by default."
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
+        // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#heartbeating
         const web::json::field_as_integer_or registration_heartbeat_interval{ U("registration_heartbeat_interval"), 5 };
 
         // registration_expiry_interval [registry]:
         // "Registration APIs should use a garbage collection interval of 12 seconds by default (triggered just after two failed heartbeats at the default 5 second interval)."
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
+        // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/4.1._Behaviour_-_Registration.html#heartbeating
         const web::json::field_as_integer_or registration_expiry_interval{ U("registration_expiry_interval"), 12 };
 
         // registration_request_max [node]: timeout for interactions with the Registration API /resource endpoint
@@ -167,13 +167,13 @@ namespace nmos
 
         // events_heartbeat_interval [node, client]:
         // "Upon connection, the client is required to report its health every 5 seconds in order to maintain its session and subscription."
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#41-heartbeats
         const web::json::field_as_integer_or events_heartbeat_interval{ U("events_heartbeat_interval"), 5 };
 
         // events_expiry_interval [node]:
         // "The server is expected to check health commands and after a 12 seconds timeout (2 consecutive missed health commands plus 2 seconds to allow for latencies)
         // it should clear the subscriptions for that particular client and close the websocket connection."
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
+        // See https://specs.amwa.tv/is-07/releases/v1.0.1/docs/5.2._Transport_-_Websocket.html#41-heartbeats
         const web::json::field_as_integer_or events_expiry_interval{ U("events_expiry_interval"), 12 };
 
         // system_services [node]: the discovered list of System APIs, in the order they should be used
@@ -292,11 +292,11 @@ namespace nmos
             //     "tag_1": [ "tag_1_value_1", "tag_1_value_2" ],
             //     "tag_2": [ "tag_2_value_1" ]
             // }
-            // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#tags
+            // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/2.1._APIs_-_Common_Keys.html#tags
             const web::json::field_as_value_or system_tags{ U("system_tags"), web::json::value::object() };
 
             // "syslog contains hostname and port for the system's syslog "version 1" server using the UDP transport (IETF RFC 5246)"
-            // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#syslog-parameters
+            // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#syslog-parameters
 
             // system_syslog_host_name [registry]: the fully-qualified host name or the IP address of the system's syslog "version 1" server
             const web::json::field_as_string_or system_syslog_host_name{ U("system_syslog_host_name"), U("") };
@@ -305,7 +305,7 @@ namespace nmos
             const web::json::field_as_integer_or system_syslog_port{ U("system_syslog_port"), 514 };
 
             // "syslogv2 contains hostname and port for the system's syslog "version 2" server using the TLS transport (IETF RFC 5245)"
-            // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#syslog-parameters
+            // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#syslog-parameters
 
             // system_syslogv2_host_name [registry]: the fully-qualified host name or the IP address of the system's syslog "version 2" server
             const web::json::field_as_string_or system_syslogv2_host_name{ U("system_syslogv2_host_name"), U("") };

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -133,15 +133,15 @@ namespace nmos
         // [registry]: used in System API resource is04 object's heartbeat_interval field
         // "Constants related to the AMWA IS-04 Discovery and Registration Specification are contained in the is04 object.
         // heartbeat_interval defines how often Nodes should perform a heartbeat to maintain their resources in the Registration API."
-        // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#amwa-is-04-nmos-discovery-and-registration-parameters
+        // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#amwa-is-04-nmos-discovery-and-registration-parameters
         // [node]:
         // "Nodes are expected to peform a heartbeat every 5 seconds by default."
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
+        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
         const web::json::field_as_integer_or registration_heartbeat_interval{ U("registration_heartbeat_interval"), 5 };
 
         // registration_expiry_interval [registry]:
         // "Registration APIs should use a garbage collection interval of 12 seconds by default (triggered just after two failed heartbeats at the default 5 second interval)."
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
+        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/4.1.%20Behaviour%20-%20Registration.md#heartbeating
         const web::json::field_as_integer_or registration_expiry_interval{ U("registration_expiry_interval"), 12 };
 
         // registration_request_max [node]: timeout for interactions with the Registration API /resource endpoint
@@ -167,13 +167,13 @@ namespace nmos
 
         // events_heartbeat_interval [node, client]:
         // "Upon connection, the client is required to report its health every 5 seconds in order to maintain its session and subscription."
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
         const web::json::field_as_integer_or events_heartbeat_interval{ U("events_heartbeat_interval"), 5 };
 
         // events_expiry_interval [node]:
         // "The server is expected to check health commands and after a 12 seconds timeout (2 consecutive missed health commands plus 2 seconds to allow for latencies)
         // it should clear the subscriptions for that particular client and close the websocket connection."
-        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
+        // See https://github.com/AMWA-TV/nmos-event-tally/blob/v1.0.0/docs/5.2.%20Transport%20-%20Websocket.md#41-heartbeats
         const web::json::field_as_integer_or events_expiry_interval{ U("events_expiry_interval"), 12 };
 
         // system_services [node]: the discovered list of System APIs, in the order they should be used
@@ -292,11 +292,11 @@ namespace nmos
             //     "tag_1": [ "tag_1_value_1", "tag_1_value_2" ],
             //     "tag_2": [ "tag_2_value_1" ]
             // }
-            // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/2.1._APIs_-_Common_Keys.html#tags
+            // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#tags
             const web::json::field_as_value_or system_tags{ U("system_tags"), web::json::value::object() };
 
             // "syslog contains hostname and port for the system's syslog "version 1" server using the UDP transport (IETF RFC 5246)"
-            // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#syslog-parameters
+            // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#syslog-parameters
 
             // system_syslog_host_name [registry]: the fully-qualified host name or the IP address of the system's syslog "version 1" server
             const web::json::field_as_string_or system_syslog_host_name{ U("system_syslog_host_name"), U("") };
@@ -305,7 +305,7 @@ namespace nmos
             const web::json::field_as_integer_or system_syslog_port{ U("system_syslog_port"), 514 };
 
             // "syslogv2 contains hostname and port for the system's syslog "version 2" server using the TLS transport (IETF RFC 5245)"
-            // See https://specs.amwa.tv/is-09/releases/v1.0.0/docs/4.2._Behaviour_-_Global_Configuration_Parameters.html#syslog-parameters
+            // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/docs/4.2.%20Behaviour%20-%20Global%20Configuration%20Parameters.md#syslog-parameters
 
             // system_syslogv2_host_name [registry]: the fully-qualified host name or the IP address of the system's syslog "version 2" server
             const web::json::field_as_string_or system_syslogv2_host_name{ U("system_syslogv2_host_name"), U("") };

--- a/Development/nmos/ssl_context_options.h
+++ b/Development/nmos/ssl_context_options.h
@@ -12,7 +12,7 @@ namespace nmos
         // "Implementations SHALL NOT use TLS 1.0 or 1.1. These are deprecated."
         // "Implementations SHALL NOT use SSL. Although the SSL protocol has previously,
         // been used to secure HTTP traffic no version of SSL is now considered secure."
-        // See https://github.com/AMWA-TV/nmos-secure-communication/blob/v1.0.x/docs/1.0.%20Secure%20Communication.md#tls
+        // See https://github.com/AMWA-TV/nmos-secure-communication/blob/v1.0.0/docs/1.0.%20Secure%20Communication.md#tls
         const auto ssl_context_options =
             ( boost::asio::ssl::context::no_sslv2
             | boost::asio::ssl::context::no_sslv3

--- a/Development/nmos/ssl_context_options.h
+++ b/Development/nmos/ssl_context_options.h
@@ -12,7 +12,7 @@ namespace nmos
         // "Implementations SHALL NOT use TLS 1.0 or 1.1. These are deprecated."
         // "Implementations SHALL NOT use SSL. Although the SSL protocol has previously,
         // been used to secure HTTP traffic no version of SSL is now considered secure."
-        // See https://github.com/AMWA-TV/nmos-secure-communication/blob/v1.0.0/docs/1.0.%20Secure%20Communication.md#tls
+        // See https://specs.amwa.tv/bcp-003-01/releases/v1.0.0/docs/1.0._Secure_Communication.html#tls
         const auto ssl_context_options =
             ( boost::asio::ssl::context::no_sslv2
             | boost::asio::ssl::context::no_sslv3

--- a/Development/nmos/system_api.h
+++ b/Development/nmos/system_api.h
@@ -9,7 +9,7 @@ namespace slog
 }
 
 // System API implementation
-// See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/APIs/SystemAPI.raml
+// See https://specs.amwa.tv/is-09/releases/v1.0.0/APIs/SystemAPI.html
 namespace nmos
 {
     struct registry_model;

--- a/Development/nmos/system_api.h
+++ b/Development/nmos/system_api.h
@@ -9,7 +9,7 @@ namespace slog
 }
 
 // System API implementation
-// See https://github.com/AMWA-TV/nmos-system/blob/v1.0/APIs/SystemAPI.raml
+// See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/APIs/SystemAPI.raml
 namespace nmos
 {
     struct registry_model;

--- a/Development/nmos/system_resources.h
+++ b/Development/nmos/system_resources.h
@@ -9,7 +9,7 @@ namespace nmos
     struct resource;
 
     // System API global configuration resource
-    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/APIs/schemas/global.json
+    // See https://specs.amwa.tv/is-09/releases/v1.0.0/APIs/schemas/with-refs/global.html
     nmos::resource make_system_global(const nmos::id& id, const nmos::settings& settings);
 
     web::json::value make_system_global_data(const nmos::id& id, const nmos::settings& settings);

--- a/Development/nmos/system_resources.h
+++ b/Development/nmos/system_resources.h
@@ -9,7 +9,7 @@ namespace nmos
     struct resource;
 
     // System API global configuration resource
-    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0/APIs/schemas/global.json
+    // See https://github.com/AMWA-TV/nmos-system/blob/v1.0.0/APIs/schemas/global.json
     nmos::resource make_system_global(const nmos::id& id, const nmos::settings& settings);
 
     web::json::value make_system_global_data(const nmos::id& id, const nmos::settings& settings);

--- a/Development/nmos/tai.h
+++ b/Development/nmos/tai.h
@@ -40,7 +40,7 @@ namespace nmos
         typedef std::chrono::time_point<tai_clock, duration> time_point;
 
         // "It is important that there are no duplicate creation or update timestamps stored against resources."
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#pagination
+        // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.5._APIs_-_Query_Parameters.html#pagination
         // Unfortunately, this clock is based on the system_clock, so may not produce monotonically increasing
         // time points; nmos::strictly_increasing_update is used to prevent duplicate values in nmos::resources
         static const bool is_steady = std::chrono::system_clock::is_steady;

--- a/Development/nmos/tai.h
+++ b/Development/nmos/tai.h
@@ -40,7 +40,7 @@ namespace nmos
         typedef std::chrono::time_point<tai_clock, duration> time_point;
 
         // "It is important that there are no duplicate creation or update timestamps stored against resources."
-        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.5.%20APIs%20-%20Query%20Parameters.md#pagination
+        // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#pagination
         // Unfortunately, this clock is based on the system_clock, so may not produce monotonically increasing
         // time points; nmos::strictly_increasing_update is used to prevent duplicate values in nmos::resources
         static const bool is_steady = std::chrono::system_clock::is_steady;

--- a/Development/nmos/test/paging_utils_test.cpp
+++ b/Development/nmos/test/paging_utils_test.cpp
@@ -112,7 +112,7 @@ namespace
 BST_TEST_CASE(testCursorBasedPagingDocumentationExamples)
 {
     // Initial test cases based on the examples in NMOS documentation
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.5.%20APIs%20-%20Query%20Parameters.md#examples
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#examples
 
     const resources resources{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
 

--- a/Development/nmos/test/paging_utils_test.cpp
+++ b/Development/nmos/test/paging_utils_test.cpp
@@ -112,7 +112,7 @@ namespace
 BST_TEST_CASE(testCursorBasedPagingDocumentationExamples)
 {
     // Initial test cases based on the examples in NMOS documentation
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.5.%20APIs%20-%20Query%20Parameters.md#examples
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.5._APIs_-_Query_Parameters.html#examples
 
     const resources resources{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
 

--- a/Development/nmos/test/query_api_test.cpp
+++ b/Development/nmos/test/query_api_test.cpp
@@ -21,7 +21,7 @@ BST_TEST_CASE(testQueryAPISubscriptionsExtensionSchema)
     };
 
     // valid subscriptions post request data
-    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.x/examples/queryapi-subscriptions-post-request.json
+    // see https://specs.amwa.tv/is-04/releases/v1.3.0/examples/queryapi-subscriptions-post-request.html
     auto data = value_of({
         { U("max_update_rate_ms"), 100 },
         { U("resource_path"), U("/nodes") },
@@ -33,7 +33,7 @@ BST_TEST_CASE(testQueryAPISubscriptionsExtensionSchema)
     });
 
     // validate successfully, i.e. no exception
-    // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.3.x/APIs/schemas/queryapi-subscriptions-post-request.json
+    // see https://specs.amwa.tv/is-04/releases/v1.3.0/APIs/schemas/with-refs/queryapi-subscriptions-post-request.html
     validator.validate(data, nmos::experimental::make_queryapi_subscriptions_post_request_schema_uri(nmos::is04_versions::v1_3));
 
     // empty path, for experimental extension

--- a/Development/nmos/test/sdp_utils_test.cpp
+++ b/Development/nmos/test/sdp_utils_test.cpp
@@ -83,7 +83,7 @@ BST_TEST_CASE(testInterpretationOfSdpFilesUnicast)
     using web::json::value;
     using web::json::value_of;
 
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#unicast
+    // See https://specs.amwa.tv/is-05/releases/v1.1.1/docs/4.1._Behaviour_-_RTP_Transport_Type.html#unicast
 
     const std::string test_sdp = R"(v=0
 o=- 2890844526 2890842807 IN IP4 10.47.16.5
@@ -117,7 +117,7 @@ BST_TEST_CASE(testInterpretationOfSdpFilesSourceSpecificMulticast)
     using web::json::value;
     using web::json::value_of;
 
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#source-specific-multicast
+    // See https://specs.amwa.tv/is-05/releases/v1.1.1/docs/4.1._Behaviour_-_RTP_Transport_Type.html#source-specific-multicast
 
     const std::string test_sdp = R"(v=0
 o=- 1497010742 1497010742 IN IP4 172.29.26.24
@@ -151,7 +151,7 @@ BST_TEST_CASE(testInterpretationOfSdpFilesSeparateSourceAddresses)
     using web::json::value;
     using web::json::value_of;
 
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#separate-source-addresses
+    // See https://specs.amwa.tv/is-05/releases/v1.1.1/docs/4.1._Behaviour_-_RTP_Transport_Type.html#separate-source-addresses
 
     const std::string test_sdp = R"(v=0
 o=ali 1122334455 1122334466 IN IP4 dup.example.com
@@ -196,7 +196,7 @@ BST_TEST_CASE(testInterpretationOfSdpFilesSeparateDestinationAddresses)
     using web::json::value;
     using web::json::value_of;
 
-    // See https://github.com/AMWA-TV/nmos-device-connection-management/blob/v1.1.1/docs/4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md#separate-destination-addresses
+    // See https://specs.amwa.tv/is-05/releases/v1.1.1/docs/4.1._Behaviour_-_RTP_Transport_Type.html#separate-destination-addresses
 
     const std::string test_sdp = R"(v=0
 o=ali 1122334455 1122334466 IN IP4 dup.example.com

--- a/Development/nmos/transfer_characteristic.h
+++ b/Development/nmos/transfer_characteristic.h
@@ -6,7 +6,7 @@
 namespace nmos
 {
     // Transfer characteristic (used in video flows)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/flow_video.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
     // and https://github.com/AMWA-TV/nmos-parameter-registers/tree/main/flow-attributes#transfer-characteristic
     DEFINE_STRING_ENUM(transfer_characteristic)
     namespace transfer_characteristics

--- a/Development/nmos/transfer_characteristic.h
+++ b/Development/nmos/transfer_characteristic.h
@@ -6,8 +6,8 @@
 namespace nmos
 {
     // Transfer characteristic (used in video flows)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/flow_video.json
-    // and https://github.com/AMWA-TV/nmos-parameter-registers/tree/main/flow-attributes#transfer-characteristic
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/flow_video.html
+    // and https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#transfer-characteristic
     DEFINE_STRING_ENUM(transfer_characteristic)
     namespace transfer_characteristics
     {

--- a/Development/nmos/transport.h
+++ b/Development/nmos/transport.h
@@ -6,9 +6,9 @@
 namespace nmos
 {
     // Transports (used in senders and receivers)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#transport
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/sender.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_core.json
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.1._APIs_-_Common_Keys.html#transport
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/sender.html
+    // and https://specs.amwa.tv/is-04/releases/v1.2.0/APIs/schemas/with-refs/receiver_core.html
     // and experimentally, for IS-04 v1.3, IS-05 v1.1, IS-07 v1.0
     // also https://github.com/AMWA-TV/nmos-parameter-registers/pull/6
     DEFINE_STRING_ENUM(transport)
@@ -25,7 +25,7 @@ namespace nmos
 
     // "Subclassifications are defined as the portion of the URN which follows the first occurrence of a '.', but prior to any '/' character."
     // "Versions are defined as the portion of the URN which follows the first occurrence of a '/'."
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.2/docs/2.1.%20APIs%20-%20Common%20Keys.md#use-of-urns
+    // See https://specs.amwa.tv/is-04/releases/v1.2.2/docs/2.1._APIs_-_Common_Keys.html#use-of-urns
     inline nmos::transport transport_base(const nmos::transport& transport)
     {
         return nmos::transport{ transport.name.substr(0, transport.name.find_first_of(U("./"))) };

--- a/Development/nmos/transport.h
+++ b/Development/nmos/transport.h
@@ -6,9 +6,9 @@
 namespace nmos
 {
     // Transports (used in senders and receivers)
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.1.%20APIs%20-%20Common%20Keys.md#transport
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/sender.json
-    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/APIs/schemas/receiver_core.json
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#transport
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/sender.json
+    // and https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/APIs/schemas/receiver_core.json
     // and experimentally, for IS-04 v1.3, IS-05 v1.1, IS-07 v1.0
     // also https://github.com/AMWA-TV/nmos-parameter-registers/pull/6
     DEFINE_STRING_ENUM(transport)

--- a/Development/nmos/type.h
+++ b/Development/nmos/type.h
@@ -30,7 +30,7 @@ namespace nmos
 
         // all types ordered so that sub-resource types appear after super-resource types
         // according to the guidelines on referential integrity
-        // see https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.1/docs/4.1.%20Behaviour%20-%20Registration.md#referential-integrity
+        // see https://specs.amwa.tv/is-04/releases/v1.2.1/docs/4.1._Behaviour_-_Registration.html#referential-integrity
         const std::vector<type> all{ nmos::types::node, nmos::types::device, nmos::types::source, nmos::types::flow, nmos::types::sender, nmos::types::receiver, nmos::types::subscription, nmos::types::grain };
 
         // the Channel Mapping API resource types, see nmos/channelmapping_resources.h

--- a/Development/nmos/version.h
+++ b/Development/nmos/version.h
@@ -8,7 +8,7 @@ namespace nmos
     // "Core resources such as Sources, Flows, Nodes etc. include a 'version' attribute.
     // As properties of a given Flow or similar will change over its lifetime, the version
     // identifies the instant at which this change took place."
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/2.1.%20APIs%20-%20Common%20Keys.md#version
+    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#version
 
     inline utility::string_t make_version(tai tai = tai_now())
     {

--- a/Development/nmos/version.h
+++ b/Development/nmos/version.h
@@ -8,7 +8,7 @@ namespace nmos
     // "Core resources such as Sources, Flows, Nodes etc. include a 'version' attribute.
     // As properties of a given Flow or similar will change over its lifetime, the version
     // identifies the instant at which this change took place."
-    // See https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/2.1.%20APIs%20-%20Common%20Keys.md#version
+    // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.1._APIs_-_Common_Keys.html#version
 
     inline utility::string_t make_version(tai tai = tai_now())
     {

--- a/Documents/Tutorial.md
+++ b/Documents/Tutorial.md
@@ -147,7 +147,7 @@ The initial output of each Node instance should appear something like this:
 
 This shows the nmos-cpp-node starting up and advertising its Node API via DNS Service Discovery.
 
-It selects an NMOS Registry to use, and registers itself, according to the NMOS [Discovery: Registered Operation](https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/3.1.%20Discovery%20-%20Registered%20Operation.md) procedure.
+It selects an NMOS Registry to use, and registers itself, according to the IS-04 [Discovery: Registered Operation](https://specs.amwa.tv/is-04/releases/v1.2.0/docs/3.1._Discovery_-_Registered_Operation.html) procedure.
 
 On the other side, this operation should be reflected in the nmos-cpp-registry output something like this:
 

--- a/Documents/Tutorial.md
+++ b/Documents/Tutorial.md
@@ -147,7 +147,7 @@ The initial output of each Node instance should appear something like this:
 
 This shows the nmos-cpp-node starting up and advertising its Node API via DNS Service Discovery.
 
-It selects an NMOS Registry to use, and registers itself, according to the NMOS [Discovery: Registered Operation](https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2/docs/3.1.%20Discovery%20-%20Registered%20Operation.md) procedure.
+It selects an NMOS Registry to use, and registers itself, according to the NMOS [Discovery: Registered Operation](https://github.com/AMWA-TV/nmos-discovery-registration/blob/v1.2.0/docs/3.1.%20Discovery%20-%20Registered%20Operation.md) procedure.
 
 On the other side, this operation should be reflected in the nmos-cpp-registry output something like this:
 


### PR DESCRIPTION
I made the decision to fix the links to still point at GitHub for now, but I hacked a quick script out of a regex search for all the links to check no `404 Not Found` responses.

Switching them over to specs.amwa.tv could be done later, but it might mean losing some of the precision in e.g. links to specific lines of the RAML or JSON Schemas.

The script found some other URL typos as well that I've fixed.