### PR TITLE
Refactor (and a few breaking interface changes) of sdp_utils

### DIFF
--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -1001,7 +1001,13 @@ nmos::connection_sender_transportfile_setter make_node_implementation_transportf
                 throw std::logic_error("matching IS-04 node, source or flow not found");
             }
 
-            // cf. nmos::make_sdp_parameters
+            // the nmos::make_sdp_parameters overload from the IS-04 resources provides a high-level interface
+            // for common "video/raw", "audio/L", "video/smpte291" and "video/SMPTE2022-6" use cases
+            //auto sdp_params = nmos::make_sdp_parameters(node->data, source->data, flow->data, sender.data, { U("PRIMARY"), U("SECONDARY") });
+
+            // nmos::make_{video,audio,data,mux}_sdp_parameters provide a little more flexibility for those four media types
+            // and the combination of nmos::make_{video_raw,audio_L,video_smpte291,video_SMPTE2022_6}_parameters
+            // with the related make_sdp_parameters overloads provides the most flexible and extensible approach
             auto sdp_params = [&]
             {
                 const std::vector<utility::string_t> mids{ U("PRIMARY"), U("SECONDARY") };
@@ -1012,6 +1018,7 @@ nmos::connection_sender_transportfile_setter make_node_implementation_transportf
                 }
                 else if (nmos::formats::audio == format)
                 {
+                    // this example application doesn't actually stream, so just indicate a sensible value for packet time
                     const double packet_time = nmos::fields::channels(source->data).size() > 8 ? 0.125 : 1;
                     return nmos::make_audio_sdp_parameters(node->data, source->data, flow->data, sender.data, nmos::details::payload_type_audio_default, mids, {}, packet_time);
                 }

--- a/Development/nmos/connection_api.cpp
+++ b/Development/nmos/connection_api.cpp
@@ -800,8 +800,15 @@ namespace nmos
         }
     }
 
-    // Validate and parse the specified transport file for the specified receiver
+    // Parse and validate the specified transport file for the specified receiver using the default validator
+    // (this is the default transport file parser)
     web::json::value parse_rtp_transport_file(const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate)
+    {
+        return details::parse_rtp_transport_file(&validate_sdp_parameters, receiver, connection_receiver, transport_file_type, transport_file_data, gate);
+    }
+
+    // Parse and validate the specified transport file for the specified receiver using the specified validator
+    web::json::value details::parse_rtp_transport_file(details::sdp_parameters_validator validate_sdp_parameters, const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate)
     {
         if (transport_file_type != nmos::media_types::application_sdp.name)
         {

--- a/Development/nmos/connection_api.h
+++ b/Development/nmos/connection_api.h
@@ -69,7 +69,19 @@ namespace nmos
 
     // Helper functions for the Connection API callbacks
 
-    // Validate and parse the specified transport file for the specified receiver
+    struct sdp_parameters;
+
+    namespace details
+    {
+        // an sdp_parameters_validator validates the specified SDP parameters for the specified IS-04 receiver
+        // it should throw std::runtime_error to indicate the parameters are not supported by the receiver
+        typedef std::function<void(const web::json::value& receiver, const sdp_parameters& sdp_params)> sdp_parameters_validator;
+
+        // Parse and validate the specified transport file for the specified receiver using the specified validator
+        web::json::value parse_rtp_transport_file(sdp_parameters_validator validate_sdp_parameters, const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate);
+    }
+
+    // Parse and validate the specified transport file for the specified receiver using the default validator
     // (this is the default transport file parser)
     web::json::value parse_rtp_transport_file(const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate);
 

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -7,6 +7,8 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/irange.hpp>
 #include <boost/range/numeric.hpp>
+#include <boost/variant/get.hpp>
+#include <boost/variant/variant.hpp>
 #include "cpprest/basic_utils.h"
 #include "nmos/capabilities.h"
 #include "nmos/clock_ref_type.h"
@@ -177,19 +179,6 @@ namespace nmos
             return sampler->second;
         }
 
-        // Payload identifiers 96-127 are used for payloads defined dynamically during a session
-        // 96 and 97 are suitable for video and audio encodings not covered by the IANA registry
-        // See https://tools.ietf.org/html/rfc3551#section-3
-        // and https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-1
-        const uint64_t payload_type_video_default = 96;
-        const uint64_t payload_type_audio_default = 97;
-        const uint64_t payload_type_data_default = 100;
-        // Payload type 98 is recommended for "High bit rate media transport / 27-MHz Clock"
-        // Payload type 99 is recommended for "High bit rate media transport FEC / 27-MHz Clock"
-        // "Alternatively, payload types may be set by other means in accordance with RFC 3550."
-        // See SMPTE ST 2022-6:2012 Section 6.3 RTP/UDP/IP Header
-        const uint64_t payload_type_mux_default = 98;
-
         // make simple media stream ids based on the sender's number of legs
         std::vector<utility::string_t> make_media_stream_ids(const web::json::value& sender)
         {
@@ -241,7 +230,7 @@ namespace nmos
         params.channel_count = (uint32_t)nmos::fields::channels(source).size();
         params.bit_depth = nmos::fields::bit_depth(flow);
         const auto& sample_rate(flow.at(nmos::fields::sample_rate));
-        params.sample_rate = nmos::rational(nmos::fields::numerator(sample_rate), nmos::fields::denominator(sample_rate));
+        params.sample_rate = uint64_t(double(nmos::fields::numerator(sample_rate)) / double(nmos::fields::denominator(sample_rate)) + 0.5);
 
         // format_specific_parameters
 
@@ -346,9 +335,10 @@ namespace nmos
     }
 
     // Make a json representation of an SDP file, e.g. for sdp::make_session_description, from the specified parameters; explicitly specify whether 'source-filter' attributes are included to override the default behaviour
-    static web::json::value make_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params, const web::json::value& ptime, const web::json::value& rtpmap, const web::json::value& fmtp, bst::optional<bool> source_filters)
+    static web::json::value make_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params, const web::json::value& rtpmap, const web::json::value& fmtp, bst::optional<bool> source_filters)
     {
         using web::json::value;
+        using web::json::value_from_elements;
         using web::json::value_of;
         using web::json::array;
 
@@ -431,9 +421,9 @@ namespace nmos
                 // Media
                 // See https://tools.ietf.org/html/rfc4566#section-5.14
                 { sdp::fields::media, value_of({
-                    { sdp::fields::media_type, sdp_params.media_type.name },
+                    { sdp::fields::media_type, sdp_params.media.media_type.name },
                     { sdp::fields::port, transport_param.at(nmos::fields::destination_port) },
-                    { sdp::fields::protocol, sdp_params.protocol.name },
+                    { sdp::fields::protocol, sdp_params.media.protocol.name },
                     { sdp::fields::formats, value_of({ utility::ostringstreamed(sdp_params.rtpmap.payload_type) }) }
                 }, keep_order) },
 
@@ -448,6 +438,17 @@ namespace nmos
                             : connection_address }
                     }, keep_order)
                 }) },
+
+                // Bandwidth
+                // See https://tools.ietf.org/html/rfc4566#section-5.8
+                { !sdp_params.bandwidth.empty() ? sdp::fields::bandwidth_information.key : U(""), value_from_elements(sdp_params.bandwidth | boost::adaptors::transformed([&](const sdp_parameters::bandwidth_t& bandwidth)
+                    {
+                        return value_of({
+                            { sdp::fields::bandwidth_type, bandwidth.bandwidth_type.name },
+                            { sdp::fields::bandwidth, bandwidth.bandwidth }
+                        }, keep_order);
+                    }))
+                },
 
                 // Attributes
                 // See https://tools.ietf.org/html/rfc4566#section-5.13
@@ -521,12 +522,28 @@ namespace nmos
                 );
             }
 
-            // insert ptime if specified
-            if (!ptime.is_null())
+            if (0 != sdp_params.packet_time)
             {
                 // a=ptime:<packet time>
                 // See https://tools.ietf.org/html/rfc4566#section-6
-                web::json::push_back(media_attributes, ptime);
+                web::json::push_back(
+                    media_attributes, value_of({
+                        { sdp::fields::name, sdp::attributes::ptime },
+                        { sdp::fields::value, sdp_params.packet_time }
+                    }, keep_order)
+                );
+            }
+
+            if (0 != sdp_params.max_packet_time)
+            {
+                // a=maxptime:<packet time>
+                // See https://tools.ietf.org/html/rfc4566#section-6
+                web::json::push_back(
+                    media_attributes, value_of({
+                        { sdp::fields::name, sdp::attributes::maxptime },
+                        { sdp::fields::value, sdp_params.max_packet_time }
+                    }, keep_order)
+                );
             }
 
             // insert rtpmap if specified
@@ -535,6 +552,19 @@ namespace nmos
                 // a=rtpmap:<payload type> <encoding name>/<clock rate>[/<encoding parameters>]
                 // See https://tools.ietf.org/html/rfc4566#section-6
                 web::json::push_back(media_attributes, rtpmap);
+            }
+
+            // insert framerate if specified
+            if (0 != sdp_params.framerate)
+            {
+                // a=framerate:<frame rate>
+                // See https://tools.ietf.org/html/rfc4566#section-6
+                web::json::push_back(
+                    media_attributes, value_of({
+                        { sdp::fields::name, sdp::attributes::framerate },
+                        { sdp::fields::value, sdp_params.framerate }
+                    }, keep_order)
+                );
             }
 
             // insert fmtp if specified
@@ -587,203 +617,135 @@ namespace nmos
         return session_description;
     }
 
-    static web::json::value make_video_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params, bst::optional<bool> source_filters)
+    static web::json::value make_rtpmap(const sdp_parameters& sdp_params)
     {
         using web::json::value_of;
 
         const bool keep_order = true;
 
-        // a=rtpmap:<payload type> <encoding name>/<clock rate>[/<encoding parameters>]
-        // See https://tools.ietf.org/html/rfc4566#section-6
-        const auto rtpmap = value_of({
+        return value_of({
             { sdp::fields::name, sdp::attributes::rtpmap },
-            { sdp::fields::value, web::json::value_of({
+            { sdp::fields::value, value_of({
                 { sdp::fields::payload_type, sdp_params.rtpmap.payload_type },
                 { sdp::fields::encoding_name, sdp_params.rtpmap.encoding_name },
-                { sdp::fields::clock_rate, sdp_params.rtpmap.clock_rate }
+                { sdp::fields::clock_rate, sdp_params.rtpmap.clock_rate },
+                { sdp_params.rtpmap.encoding_parameters > 0 ? sdp::fields::encoding_parameters.key : U(""), sdp_params.rtpmap.encoding_parameters }
             }, keep_order) }
         }, keep_order);
+    }
+
+    static web::json::value make_fmtp(const sdp_parameters& sdp_params)
+    {
+        using web::json::value;
+        using web::json::value_from_elements;
+        using web::json::value_of;
+
+        const bool keep_order = true;
+
+        return sdp_params.fmtp.empty() ? value::null() : value_of({
+            { sdp::fields::name, sdp::attributes::fmtp },
+            { sdp::fields::value, web::json::value_of({
+                { sdp::fields::format, utility::ostringstreamed(sdp_params.rtpmap.payload_type) },
+                { sdp::fields::format_specific_parameters, value_from_elements(sdp_params.fmtp | boost::adaptors::transformed([&](const sdp_parameters::fmtp_t::value_type& param)
+                    {
+                        return sdp::named_value(param.first, param.second, keep_order);
+                    })) }
+            }, keep_order) }
+        }, keep_order);
+    }
+
+    void set_video_raw_parameters(sdp_parameters& sdp_params, const video_raw_parameters& params, uint64_t payload_type)
+    {
+        // a=rtpmap:<payload type> <encoding name>/<clock rate>[/<encoding parameters>]
+        // See https://tools.ietf.org/html/rfc4566#section-6
+        sdp_params.rtpmap = { payload_type, U("raw"), 90000 };
 
         // a=fmtp:<format> <format specific parameters>
         // for simplicity, following the order of parameters given in VSF TR-05:2017
         // See https://tools.ietf.org/html/rfc4566#section-6
         // and http://www.videoservicesforum.org/download/technical_recommendations/VSF_TR-05_2018-06-23.pdf
         // and comments regarding the fmtp attribute parameters in get_session_description_sdp_parameters
-        auto format_specific_parameters = value_of({
-            sdp::named_value(sdp::fields::width, utility::ostringstreamed(sdp_params.video.width)),
-            sdp::named_value(sdp::fields::height, utility::ostringstreamed(sdp_params.video.height)),
-            sdp::named_value(sdp::fields::exactframerate, sdp_params.video.exactframerate.denominator() != 1
-                ? utility::ostringstreamed(sdp_params.video.exactframerate.numerator()) + U("/") + utility::ostringstreamed(sdp_params.video.exactframerate.denominator())
-                : utility::ostringstreamed(sdp_params.video.exactframerate.numerator()))
-        });
-        if (sdp_params.video.interlace) web::json::push_back(format_specific_parameters, sdp::named_value(sdp::fields::interlace));
-        if (sdp_params.video.segmented) web::json::push_back(format_specific_parameters, sdp::named_value(sdp::fields::segmented));
-        web::json::push_back(format_specific_parameters, sdp::named_value(sdp::fields::sampling, sdp_params.video.sampling.name));
-        web::json::push_back(format_specific_parameters, sdp::named_value(sdp::fields::depth, utility::ostringstreamed(sdp_params.video.depth)));
-        web::json::push_back(format_specific_parameters, sdp::named_value(sdp::fields::colorimetry, sdp_params.video.colorimetry.name));
-        if (!sdp_params.video.tcs.name.empty()) web::json::push_back(format_specific_parameters, sdp::named_value(sdp::fields::transfer_characteristic_system, sdp_params.video.tcs.name));
-        web::json::push_back(format_specific_parameters, sdp::named_value(sdp::fields::packing_mode, sdp::packing_modes::general.name)); // or block...
-        web::json::push_back(format_specific_parameters, sdp::named_value(sdp::fields::smpte_standard_number, sdp::smpte_standard_numbers::ST2110_20_2017.name));
-        if (!sdp_params.video.tp.name.empty()) web::json::push_back(format_specific_parameters, sdp::named_value(sdp::fields::type_parameter, sdp_params.video.tp.name));
-
-        const auto fmtp = web::json::value_of({
-            { sdp::fields::name, sdp::attributes::fmtp },
-            { sdp::fields::value, web::json::value_of({
-                { sdp::fields::format, utility::ostringstreamed(sdp_params.rtpmap.payload_type) },
-                { sdp::fields::format_specific_parameters, std::move(format_specific_parameters) }
-            }, keep_order) }
-        }, keep_order);
-
-        return make_session_description(sdp_params, transport_params, {}, rtpmap, fmtp, source_filters);
+        sdp_params.fmtp = {
+            { sdp::fields::width, utility::ostringstreamed(params.width) },
+            { sdp::fields::height, utility::ostringstreamed(params.height) },
+            { sdp::fields::exactframerate, params.exactframerate.denominator() != 1
+                ? utility::ostringstreamed(params.exactframerate.numerator()) + U("/") + utility::ostringstreamed(params.exactframerate.denominator())
+                : utility::ostringstreamed(params.exactframerate.numerator()) }
+        };
+        if (params.interlace) sdp_params.fmtp.push_back({ sdp::fields::interlace, {} });
+        if (params.segmented) sdp_params.fmtp.push_back({ sdp::fields::segmented, {} });
+        sdp_params.fmtp.push_back({ sdp::fields::sampling, params.sampling.name });
+        sdp_params.fmtp.push_back({ sdp::fields::depth, utility::ostringstreamed(params.depth) });
+        sdp_params.fmtp.push_back({ sdp::fields::colorimetry, params.colorimetry.name });
+        if (!params.tcs.name.empty()) sdp_params.fmtp.push_back({ sdp::fields::transfer_characteristic_system, params.tcs.name });
+        sdp_params.fmtp.push_back({ sdp::fields::packing_mode, sdp::packing_modes::general.name }); // or block...
+        sdp_params.fmtp.push_back({ sdp::fields::smpte_standard_number, sdp::smpte_standard_numbers::ST2110_20_2017.name });
+        if (!params.tp.name.empty()) sdp_params.fmtp.push_back({ sdp::fields::type_parameter, params.tp.name });
     }
 
-    static web::json::value make_audio_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params, bst::optional<bool> source_filters)
+    void set_audio_L_parameters(sdp_parameters& sdp_params, const audio_L_parameters& params, uint64_t payload_type)
     {
-        using web::json::value;
-        using web::json::value_of;
-
-        const bool keep_order = true;
-
         // a=ptime:<packet time>
         // See https://tools.ietf.org/html/rfc4566#section-6
-        const auto ptime = value_of({
-            { sdp::fields::name, sdp::attributes::ptime },
-            { sdp::fields::value, sdp_params.audio.packet_time }
-        }, keep_order);
+        sdp_params.packet_time = params.packet_time;
 
         // a=rtpmap:<payload type> <encoding name>/<clock rate>[/<encoding parameters>]
         // See https://tools.ietf.org/html/rfc4566#section-6
-        const auto rtpmap = value_of({
-            { sdp::fields::name, sdp::attributes::rtpmap },
-            { sdp::fields::value, value_of({
-                { sdp::fields::payload_type, sdp_params.rtpmap.payload_type },
-                { sdp::fields::encoding_name, sdp_params.rtpmap.encoding_name },
-                { sdp::fields::clock_rate, sdp_params.rtpmap.clock_rate },
-                { sdp::fields::encoding_parameters, sdp_params.audio.channel_count }
-            }, keep_order) }
-        }, keep_order);
+        sdp_params.rtpmap = { payload_type, U("L") + utility::ostringstreamed(params.bit_depth), params.sample_rate, params.channel_count };
 
         // a=fmtp:<format> <format specific parameters>
         // See https://tools.ietf.org/html/rfc4566#section-6
-        const auto format_specific_parameters = sdp_params.audio.channel_order.empty() ? value::array() : value_of({
-            sdp::named_value(sdp::fields::channel_order, sdp_params.audio.channel_order)
-        });
-        const auto fmtp = value_of({
-            { sdp::fields::name, sdp::attributes::fmtp },
-            { sdp::fields::value, value_of({
-                { sdp::fields::format, utility::ostringstreamed(sdp_params.rtpmap.payload_type) },
-                { sdp::fields::format_specific_parameters, std::move(format_specific_parameters) }
-            }, keep_order) }
-        }, keep_order);
-
-        return make_session_description(sdp_params, transport_params, ptime, rtpmap, fmtp, source_filters);
+        sdp_params.fmtp = {};
+        if (!params.channel_order.empty()) sdp_params.fmtp.push_back({ sdp::fields::channel_order, params.channel_order });
     }
 
-    static web::json::value make_data_format_specific_parameters(const sdp_parameters::data_t& data_params)
+    void set_video_smpte291_parameters(sdp_parameters& sdp_params, const video_smpte291_parameters& params, uint64_t payload_type)
     {
-        auto result = web::json::value_from_elements(data_params.did_sdids | boost::adaptors::transformed([](const nmos::did_sdid& did_sdid)
+        // a=rtpmap:<payload type> <encoding name>/<clock rate>[/<encoding parameters>]
+        // See https://tools.ietf.org/html/rfc4566#section-6
+        sdp_params.rtpmap = { payload_type, U("smpte291"), 90000 };
+
+        // a=fmtp:<format> <format specific parameters>
+        // See https://tools.ietf.org/html/rfc4566#section-6
+        sdp_params.fmtp = boost::copy_range<sdp_parameters::fmtp_t>(params.did_sdids | boost::adaptors::transformed([](const nmos::did_sdid& did_sdid)
         {
-            return sdp::named_value(sdp::fields::DID_SDID, make_fmtp_did_sdid(did_sdid));
+            return sdp_parameters::fmtp_t::value_type{ sdp::fields::DID_SDID, make_fmtp_did_sdid(did_sdid) };
         }));
-
-        if (0 != data_params.vpid_code)
-        {
-            web::json::push_back(result, sdp::named_value(sdp::fields::VPID_Code, utility::ostringstreamed(data_params.vpid_code)));
-        }
-
-        return result;
+        if (0 != params.vpid_code) sdp_params.fmtp.push_back({ sdp::fields::VPID_Code, utility::ostringstreamed(params.vpid_code) });
     }
 
-    static web::json::value make_data_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params, bst::optional<bool> source_filters)
+    void set_video_SMPTE2022_6_parameters(sdp_parameters& sdp_params, const video_SMPTE2022_6_parameters& params, uint64_t payload_type)
     {
-        using web::json::value;
-        using web::json::value_of;
-
-        const bool keep_order = true;
-
         // a=rtpmap:<payload type> <encoding name>/<clock rate>[/<encoding parameters>]
         // See https://tools.ietf.org/html/rfc4566#section-6
-        const auto rtpmap = value_of({
-            { sdp::fields::name, sdp::attributes::rtpmap },
-            { sdp::fields::value, value_of({
-                { sdp::fields::payload_type, sdp_params.rtpmap.payload_type },
-                { sdp::fields::encoding_name, sdp_params.rtpmap.encoding_name },
-                { sdp::fields::clock_rate, sdp_params.rtpmap.clock_rate }
-            }, keep_order) }
-        }, keep_order);
+        sdp_params.rtpmap = { payload_type, U("SMPTE2022-6"), 27000000 };
 
         // a=fmtp:<format> <format specific parameters>
         // See https://tools.ietf.org/html/rfc4566#section-6
-        const auto fmtp = sdp_params.data.did_sdids.empty() && 0 == sdp_params.data.vpid_code ? value::null() : value_of({
-            { sdp::fields::name, sdp::attributes::fmtp },
-            { sdp::fields::value, value_of({
-                { sdp::fields::format, utility::ostringstreamed(sdp_params.rtpmap.payload_type) },
-                { sdp::fields::format_specific_parameters, make_data_format_specific_parameters(sdp_params.data) }
-            }, keep_order) }
-        }, keep_order);
-
-        return make_session_description(sdp_params, transport_params, {}, rtpmap, fmtp, source_filters);
-    }
-
-    static web::json::value make_mux_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params, bst::optional<bool> source_filters)
-    {
-        using web::json::value;
-        using web::json::value_of;
-
-        const bool keep_order = true;
-
-        // a=rtpmap:<payload type> <encoding name>/<clock rate>[/<encoding parameters>]
-        // See https://tools.ietf.org/html/rfc4566#section-6
-        const auto rtpmap = value_of({
-            { sdp::fields::name, sdp::attributes::rtpmap },
-            { sdp::fields::value, value_of({
-                { sdp::fields::payload_type, sdp_params.rtpmap.payload_type },
-                { sdp::fields::encoding_name, sdp_params.rtpmap.encoding_name },
-                { sdp::fields::clock_rate, sdp_params.rtpmap.clock_rate }
-            }, keep_order) }
-        }, keep_order);
-
-        auto format_specific_parameters = value::array();
-        if (!sdp_params.mux.tp.name.empty()) web::json::push_back(format_specific_parameters, sdp::named_value(sdp::fields::type_parameter, sdp_params.mux.tp.name));
-
-        // a=fmtp:<format> <format specific parameters>
-        // See https://tools.ietf.org/html/rfc4566#section-6
-        const auto fmtp = value_of({
-            { sdp::fields::name, sdp::attributes::fmtp },
-            { sdp::fields::value, value_of({
-                { sdp::fields::format, utility::ostringstreamed(sdp_params.rtpmap.payload_type) },
-                { sdp::fields::format_specific_parameters, std::move(format_specific_parameters) }
-            }, keep_order) }
-        }, keep_order);
-
-        return make_session_description(sdp_params, transport_params, {}, rtpmap, fmtp, source_filters);
+        sdp_params.fmtp = {};
+        if (!params.tp.name.empty()) sdp_params.fmtp.push_back({ sdp::fields::type_parameter, params.tp.name });
     }
 
     namespace details
     {
         nmos::format get_format(const sdp_parameters& sdp_params)
         {
-            if (sdp::media_types::video == sdp_params.media_type && U("raw") == sdp_params.rtpmap.encoding_name) return nmos::formats::video;
-            if (sdp::media_types::audio == sdp_params.media_type) return nmos::formats::audio;
-            if (sdp::media_types::video == sdp_params.media_type && U("smpte291") == sdp_params.rtpmap.encoding_name) return nmos::formats::data;
-            if (sdp::media_types::video == sdp_params.media_type && U("SMPTE2022-6") == sdp_params.rtpmap.encoding_name) return nmos::formats::mux;
-            return{};
+            if (sdp::media_types::video == sdp_params.media.media_type && U("raw") == sdp_params.rtpmap.encoding_name) return nmos::formats::video;
+            if (sdp::media_types::audio == sdp_params.media.media_type && U("L") == sdp_params.rtpmap.encoding_name.substr(0, 1)) return nmos::formats::audio;
+            if (sdp::media_types::video == sdp_params.media.media_type && U("smpte291") == sdp_params.rtpmap.encoding_name) return nmos::formats::data;
+            if (sdp::media_types::video == sdp_params.media.media_type && U("SMPTE2022-6") == sdp_params.rtpmap.encoding_name) return nmos::formats::mux;
+            return {};
         }
 
         nmos::media_type get_media_type(const sdp_parameters& sdp_params)
         {
-            return nmos::media_type{ sdp_params.media_type.name + U("/") + sdp_params.rtpmap.encoding_name };
+            return nmos::media_type{ sdp_params.media.media_type.name + U("/") + sdp_params.rtpmap.encoding_name };
         }
     }
 
     web::json::value make_session_description(const sdp_parameters& sdp_params, const web::json::value& transport_params, bst::optional<bool> source_filters)
     {
-        const auto format = details::get_format(sdp_params);
-        if (nmos::formats::video == format) return make_video_session_description(sdp_params, transport_params, source_filters);
-        if (nmos::formats::audio == format) return make_audio_session_description(sdp_params, transport_params, source_filters);
-        if (nmos::formats::data == format)  return make_data_session_description(sdp_params, transport_params, source_filters);
-        if (nmos::formats::mux == format)  return make_mux_session_description(sdp_params, transport_params, source_filters);
-        throw details::sdp_creation_error("unsupported ST2110 media");
+        return make_session_description(sdp_params, transport_params, make_rtpmap(sdp_params), make_fmtp(sdp_params), source_filters);
     }
 
     namespace details
@@ -1102,11 +1064,21 @@ namespace nmos
             }
         }
 
+        // Bandwidth
+        // See https://tools.ietf.org/html/rfc4566#section-5.8
+        {
+            const auto& media_bandwidth_information = sdp::fields::bandwidth_information(media_description);
+            sdp_params.bandwidth = boost::copy_range<std::vector<sdp_parameters::bandwidth_t>>(media_bandwidth_information.as_array() | boost::adaptors::transformed([](const web::json::value& bandwidth)
+            {
+                return sdp_parameters::bandwidth_t{ sdp::bandwidth_type{ sdp::fields::bandwidth_type(bandwidth) }, sdp::fields::bandwidth(bandwidth) };
+            }));
+        }
+
         // Media
         // See https://tools.ietf.org/html/rfc4566#section-5.14
         const auto& media = sdp::fields::media(media_description);
-        sdp_params.media_type = sdp::media_type{ sdp::fields::media_type(media) };
-        sdp_params.protocol = sdp::protocol{ sdp::fields::protocol(media) };
+        sdp_params.media.media_type = sdp::media_type{ sdp::fields::media_type(media) };
+        sdp_params.media.protocol = sdp::protocol{ sdp::fields::protocol(media) };
 
         // media description attributes
         const auto& media_attributes = sdp::fields::attributes(media_description).as_array();
@@ -1142,170 +1114,210 @@ namespace nmos
         sdp_params.rtpmap.encoding_name = sdp::fields::encoding_name(rtpmap_value);
         sdp_params.rtpmap.payload_type = sdp::fields::payload_type(rtpmap_value);
         sdp_params.rtpmap.clock_rate = sdp::fields::clock_rate(rtpmap_value);
-
-        const auto format = details::get_format(sdp_params);
-        const auto is_video_sdp = nmos::formats::video == format;
-        const auto is_audio_sdp = nmos::formats::audio == format;
-        const auto is_data_sdp = nmos::formats::data == format;
-        const auto is_mux_sdp = nmos::formats::mux == format;
-
-        if (is_audio_sdp)
-        {
-            const auto& encoding_name = sdp::fields::encoding_name(rtpmap_value);
-            sdp_params.audio.bit_depth = !encoding_name.empty() && U('L') == encoding_name.front() ? utility::istringstreamed<uint32_t>(encoding_name.substr(1)) : 0;
-
-            sdp_params.audio.sample_rate = nmos::rational{ (nmos::rational::int_type)sdp::fields::clock_rate(rtpmap_value) };
-            sdp_params.audio.channel_count = (uint32_t)sdp::fields::encoding_parameters(rtpmap_value);
-        }
+        sdp_params.rtpmap.encoding_parameters = sdp::fields::encoding_parameters(rtpmap_value);
 
         // ptime attribute
         // See https://tools.ietf.org/html/rfc4566#section-6
         {
             auto ptime = sdp::find_name(media_attributes, sdp::attributes::ptime);
-            if (is_audio_sdp)
+            if (media_attributes.end() != ptime)
             {
-                if (media_attributes.end() == ptime) throw details::sdp_processing_error("missing attribute: ptime");
-                sdp_params.audio.packet_time = sdp::fields::value(*ptime).as_double();
+                sdp_params.packet_time = sdp::fields::value(*ptime).as_double();
+            }
+        }
+
+        // maxptime attribute
+        // See https://tools.ietf.org/html/rfc4566#section-6
+        {
+            auto maxptime = sdp::find_name(media_attributes, sdp::attributes::maxptime);
+            if (media_attributes.end() != maxptime)
+            {
+                sdp_params.max_packet_time = sdp::fields::value(*maxptime).as_double();
+            }
+        }
+
+        // framerate attribute
+        // See https://tools.ietf.org/html/rfc4566#section-6
+        {
+            auto framerate = sdp::find_name(media_attributes, sdp::attributes::framerate);
+            if (media_attributes.end() != framerate)
+            {
+                sdp_params.framerate = sdp::fields::value(*framerate).as_double();
             }
         }
 
         // fmtp attribute
         // See https://tools.ietf.org/html/rfc4566#section-6
-        auto fmtp = sdp::find_name(media_attributes, sdp::attributes::fmtp);
-        if (is_video_sdp)
         {
-            if (media_attributes.end() == fmtp) throw details::sdp_processing_error("missing attribute: fmtp");
-            const auto& fmtp_value = sdp::fields::value(*fmtp);
-            const auto& format_specific_parameters = sdp::fields::format_specific_parameters(fmtp_value);
-
-            // See SMPTE ST 2110-20:2017 Section 7.2 Required Media Type Parameters
-            // and Section 7.3 Media Type Parameters with default values
-
-            const auto width = sdp::find_name(format_specific_parameters, sdp::fields::width);
-            if (format_specific_parameters.end() == width) throw details::sdp_processing_error("missing format parameter: width");
-            sdp_params.video.width = utility::istringstreamed<uint32_t>(sdp::fields::value(*width).as_string());
-
-            const auto height = sdp::find_name(format_specific_parameters, sdp::fields::height);
-            if (format_specific_parameters.end() == height) throw details::sdp_processing_error("missing format parameter: height");
-            sdp_params.video.height = utility::istringstreamed<uint32_t>(sdp::fields::value(*height).as_string());
-
-            auto parse_rational = [](const utility::string_t& rational_string)
+            auto fmtp = sdp::find_name(media_attributes, sdp::attributes::fmtp);
+            if (media_attributes.end() != fmtp)
             {
-                const auto slash = rational_string.find(U('/'));
-                return nmos::rational(utility::istringstreamed<uint64_t>(rational_string.substr(0, slash)), utility::string_t::npos != slash ? utility::istringstreamed<uint64_t>(rational_string.substr(slash + 1)) : 1);
-            };
-            const auto exactframerate = sdp::find_name(format_specific_parameters, sdp::fields::exactframerate);
-            if (format_specific_parameters.end() == exactframerate) throw details::sdp_processing_error("missing format parameter: exactframerate");
-            sdp_params.video.exactframerate = parse_rational(sdp::fields::value(*exactframerate).as_string());
-
-            // optional
-            const auto interlace = sdp::find_name(format_specific_parameters, sdp::fields::interlace);
-            sdp_params.video.interlace = format_specific_parameters.end() != interlace;
-
-            // optional
-            const auto segmented = sdp::find_name(format_specific_parameters, sdp::fields::segmented);
-            sdp_params.video.segmented = format_specific_parameters.end() != segmented;
-
-            const auto sampling = sdp::find_name(format_specific_parameters, sdp::fields::sampling);
-            if (format_specific_parameters.end() == sampling) throw details::sdp_processing_error("missing format parameter: sampling");
-            sdp_params.video.sampling = sdp::sampling{ sdp::fields::value(*sampling).as_string() };
-
-            const auto depth = sdp::find_name(format_specific_parameters, sdp::fields::depth);
-            if (format_specific_parameters.end() == depth) throw details::sdp_processing_error("missing format parameter: depth");
-            sdp_params.video.depth = utility::istringstreamed<uint32_t>(sdp::fields::value(*depth).as_string());
-
-            // optional
-            const auto tcs = sdp::find_name(format_specific_parameters, sdp::fields::transfer_characteristic_system);
-            if (format_specific_parameters.end() != tcs)
-            {
-                sdp_params.video.tcs = sdp::transfer_characteristic_system{ sdp::fields::value(*tcs).as_string() };
+                const auto& format_specific_parameters = sdp::fields::format_specific_parameters(sdp::fields::value(*fmtp));
+                sdp_params.fmtp = boost::copy_range<sdp_parameters::fmtp_t>(format_specific_parameters | boost::adaptors::transformed([&](const value& param)
+                {
+                    const auto& name = sdp::fields::name(param);
+                    const auto& value_or_null = sdp::fields::value(param);
+                    return sdp_parameters::fmtp_t::value_type{ name, !value_or_null.is_null() ? value_or_null.as_string() : U("") };
+                }));
             }
-            // else sdp_params.video.tcs = sdp::transfer_characteristic_systems::SDR;
-            // but better to let the caller distinguish that it's been defaulted?
-
-            const auto colorimetry = sdp::find_name(format_specific_parameters, sdp::fields::colorimetry);
-            if (format_specific_parameters.end() == colorimetry) throw details::sdp_processing_error("missing format parameter: colorimetry");
-            sdp_params.video.colorimetry = sdp::colorimetry{ sdp::fields::value(*colorimetry).as_string() };
-
-            // don't examine required parameters "PM" (packing mode), "SSN" (SMPTE standard number)
-            // don't examine optional parameters "RANGE", "MAXUDP", "PAR"
-
-            // "Senders and Receivers compliant to [ST 2110-20] shall comply with the provisions of SMPTE ST 2110-21."
-            // See SMPTE ST 2110-20:2017 Section 6.1.1
-
-            // See SMPTE ST 2110-21:2017 Section 8.1 Required Parameters
-            // and Section 8.2 Optional Parameters
-
-            // hmm, "TP" (type parameter) is required, but currently omitted by several vendors, so allow that for now...
-            const auto tp = sdp::find_name(format_specific_parameters, sdp::fields::type_parameter);
-            if (format_specific_parameters.end() != tp)
-            {
-                sdp_params.video.tp = sdp::type_parameter{ sdp::fields::value(*tp).as_string() };
-            }
-            // else sdp_params.video.tp = {};
-
-            // don't examine optional parameters "TROFF", "CMAX"
-        }
-        else if (is_audio_sdp && media_attributes.end() != fmtp)
-        {
-            const auto& fmtp_value = sdp::fields::value(*fmtp);
-            const auto& format_specific_parameters = sdp::fields::format_specific_parameters(fmtp_value);
-
-            // optional
-            const auto channel_order = sdp::find_name(format_specific_parameters, sdp::fields::channel_order);
-            if (format_specific_parameters.end() != channel_order)
-            {
-                sdp_params.audio.channel_order = sdp::fields::value(*channel_order).as_string();
-            }
-        }
-        else if (is_data_sdp && media_attributes.end() != fmtp)
-        {
-            const auto& fmtp_value = sdp::fields::value(*fmtp);
-            const auto& format_specific_parameters = sdp::fields::format_specific_parameters(fmtp_value);
-
-            // "The SDP object shall be constructed as described in IETF RFC 8331"
-            // See SMPTE ST 2110-40:2018 Section 6
-            // and https://tools.ietf.org/html/rfc8331
-
-            // optional
-            sdp_params.data.did_sdids = boost::copy_range<std::vector<nmos::did_sdid>>(format_specific_parameters | boost::adaptors::filtered([](const web::json::value& nv)
-            {
-                return sdp::fields::DID_SDID.key == sdp::fields::name(nv);
-            }) | boost::adaptors::transformed([](const web::json::value& did_sdid)
-            {
-                return parse_fmtp_did_sdid(sdp::fields::value(did_sdid).as_string());
-            }));
-
-            // optional
-            const auto vpid_code = sdp::find_name(format_specific_parameters, sdp::fields::VPID_Code);
-            if (format_specific_parameters.end() != vpid_code)
-            {
-                sdp_params.data.vpid_code = (nmos::vpid_code)utility::istringstreamed<uint32_t>(sdp::fields::value(*vpid_code).as_string());
-            }
-        }
-        else if (is_mux_sdp && media_attributes.end() != fmtp)
-        {
-            const auto& fmtp_value = sdp::fields::value(*fmtp);
-            const auto& format_specific_parameters = sdp::fields::format_specific_parameters(fmtp_value);
-
-            // "Senders shall signal Media Type Parameters TP and TROFF as specified in ST 2110-21"
-            // See SMPTE ST 2022-8:2019 Section 6
-
-            // See SMPTE ST 2110-21:2017 Section 8.1 Required Parameters
-            // and Section 8.2 Optional Parameters
-
-            // "TP" (type parameter) is required, but allow it to be omitted for now...
-            const auto tp = sdp::find_name(format_specific_parameters, sdp::fields::type_parameter);
-            if (format_specific_parameters.end() != tp)
-            {
-                sdp_params.mux.tp = sdp::type_parameter{ sdp::fields::value(*tp).as_string() };
-            }
-            // else sdp_params.mux.tp = {};
-
-            // don't examine optional parameter "TROFF"
         }
 
         return sdp_params;
+    }
+
+    static sdp_parameters::fmtp_t::const_iterator find_fmtp(const sdp_parameters::fmtp_t& fmtp, const utility::string_t& param_name)
+    {
+        return std::find_if(fmtp.begin(), fmtp.end(), [&](const sdp_parameters::fmtp_t::value_type& param)
+        {
+            return param.first == param_name;
+        });
+    }
+
+    video_raw_parameters get_video_raw_parameters(const sdp_parameters& sdp_params)
+    {
+        video_raw_parameters params;
+
+        if (sdp_params.fmtp.empty()) throw details::sdp_processing_error("missing attribute: fmtp");
+
+        // See SMPTE ST 2110-20:2017 Section 7.2 Required Media Type Parameters
+        // and Section 7.3 Media Type Parameters with default values
+
+        const auto width = find_fmtp(sdp_params.fmtp, sdp::fields::width);
+        if (sdp_params.fmtp.end() == width) throw details::sdp_processing_error("missing format parameter: width");
+        params.width = utility::istringstreamed<uint32_t>(width->second);
+
+        const auto height = find_fmtp(sdp_params.fmtp, sdp::fields::height);
+        if (sdp_params.fmtp.end() == height) throw details::sdp_processing_error("missing format parameter: height");
+        params.height = utility::istringstreamed<uint32_t>(height->second);
+
+        auto parse_rational = [](const utility::string_t& rational_string)
+        {
+            const auto slash = rational_string.find(U('/'));
+            return nmos::rational(utility::istringstreamed<uint64_t>(rational_string.substr(0, slash)), utility::string_t::npos != slash ? utility::istringstreamed<uint64_t>(rational_string.substr(slash + 1)) : 1);
+        };
+        const auto exactframerate = find_fmtp(sdp_params.fmtp, sdp::fields::exactframerate);
+        if (sdp_params.fmtp.end() == exactframerate) throw details::sdp_processing_error("missing format parameter: exactframerate");
+        params.exactframerate = parse_rational(exactframerate->second);
+
+        // optional
+        const auto interlace = find_fmtp(sdp_params.fmtp, sdp::fields::interlace);
+        params.interlace = sdp_params.fmtp.end() != interlace;
+
+        // optional
+        const auto segmented = find_fmtp(sdp_params.fmtp, sdp::fields::segmented);
+        params.segmented = sdp_params.fmtp.end() != segmented;
+
+        const auto sampling = find_fmtp(sdp_params.fmtp, sdp::fields::sampling);
+        if (sdp_params.fmtp.end() == sampling) throw details::sdp_processing_error("missing format parameter: sampling");
+        params.sampling = sdp::sampling{ sampling->second };
+
+        const auto depth = find_fmtp(sdp_params.fmtp, sdp::fields::depth);
+        if (sdp_params.fmtp.end() == depth) throw details::sdp_processing_error("missing format parameter: depth");
+        params.depth = utility::istringstreamed<uint32_t>(depth->second);
+
+        // optional
+        const auto tcs = find_fmtp(sdp_params.fmtp, sdp::fields::transfer_characteristic_system);
+        if (sdp_params.fmtp.end() != tcs)
+        {
+            params.tcs = sdp::transfer_characteristic_system{ tcs->second };
+        }
+        // else params.tcs = sdp::transfer_characteristic_systems::SDR;
+        // but better to let the caller distinguish that it's been defaulted?
+
+        const auto colorimetry = find_fmtp(sdp_params.fmtp, sdp::fields::colorimetry);
+        if (sdp_params.fmtp.end() == colorimetry) throw details::sdp_processing_error("missing format parameter: colorimetry");
+        params.colorimetry = sdp::colorimetry{ colorimetry->second };
+
+        // don't examine required parameters "PM" (packing mode), "SSN" (SMPTE standard number)
+        // don't examine optional parameters "RANGE", "MAXUDP", "PAR"
+
+        // "Senders and Receivers compliant to [ST 2110-20] shall comply with the provisions of SMPTE ST 2110-21."
+        // See SMPTE ST 2110-20:2017 Section 6.1.1
+
+        // See SMPTE ST 2110-21:2017 Section 8.1 Required Parameters
+        // and Section 8.2 Optional Parameters
+
+        // hmm, "TP" (type parameter) is required, but currently omitted by several vendors, so allow that for now...
+        const auto tp = find_fmtp(sdp_params.fmtp, sdp::fields::type_parameter);
+        if (sdp_params.fmtp.end() != tp)
+        {
+            params.tp = sdp::type_parameter{ tp->second };
+        }
+        // else params.tp = {};
+
+        // don't examine optional parameters "TROFF", "CMAX"
+
+        return params;
+    }
+
+    audio_L_parameters get_audio_L_parameters(const sdp_parameters& sdp_params)
+    {
+        audio_L_parameters params;
+
+        const auto& encoding_name = sdp_params.rtpmap.encoding_name;
+        params.bit_depth = !encoding_name.empty() && U('L') == encoding_name.front() ? utility::istringstreamed<uint32_t>(encoding_name.substr(1)) : 0;
+
+        params.sample_rate = sdp_params.rtpmap.clock_rate;
+        params.channel_count = (uint32_t)sdp_params.rtpmap.encoding_parameters;
+
+        // optional
+        const auto channel_order = find_fmtp(sdp_params.fmtp, sdp::fields::channel_order);
+        if (sdp_params.fmtp.end() != channel_order)
+        {
+            params.channel_order = channel_order->second;
+        }
+
+        return params;
+    }
+
+    video_smpte291_parameters get_video_smpte291_parameters(const sdp_parameters& sdp_params)
+    {
+        video_smpte291_parameters params;
+
+        // "The SDP object shall be constructed as described in IETF RFC 8331"
+        // See SMPTE ST 2110-40:2018 Section 6
+        // and https://tools.ietf.org/html/rfc8331
+
+        // optional
+        params.did_sdids = boost::copy_range<std::vector<nmos::did_sdid>>(sdp_params.fmtp | boost::adaptors::filtered([](const sdp_parameters::fmtp_t::value_type& param)
+        {
+            return sdp::fields::DID_SDID.key == param.first;
+        }) | boost::adaptors::transformed([](const sdp_parameters::fmtp_t::value_type& did_sdid)
+        {
+            return parse_fmtp_did_sdid(did_sdid.second);
+        }));
+
+        // optional
+        const auto vpid_code = find_fmtp(sdp_params.fmtp, sdp::fields::VPID_Code);
+        if (sdp_params.fmtp.end() != vpid_code)
+        {
+            params.vpid_code = (nmos::vpid_code)utility::istringstreamed<uint32_t>(vpid_code->second);
+        }
+
+        return params;
+    }
+
+    video_SMPTE2022_6_parameters get_video_SMPTE2022_6_parameters(const sdp_parameters& sdp_params)
+    {
+        video_SMPTE2022_6_parameters params;
+
+        // "Senders shall signal Media Type Parameters TP and TROFF as specified in ST 2110-21"
+        // See SMPTE ST 2022-8:2019 Section 6
+
+        // See SMPTE ST 2110-21:2017 Section 8.1 Required Parameters
+        // and Section 8.2 Optional Parameters
+
+        // "TP" (type parameter) is required, but allow it to be omitted for now...
+        const auto tp = find_fmtp(sdp_params.fmtp, sdp::fields::type_parameter);
+        if (sdp_params.fmtp.end() != tp)
+        {
+            params.tp = sdp::type_parameter{ tp->second };
+        }
+        // else params.tp = {};
+
+        // don't examine optional parameter "TROFF"
+
+        return params;
     }
 
     // Get SDP parameters from the json representation of an SDP file, e.g. from sdp::parse_session_description
@@ -1323,7 +1335,26 @@ namespace nmos
             || nmos::match_string_constraint(nmos::interlace_modes::interlaced_bff.name, constraint_set);
     }
 
-    bool match_sdp_parameters_constraint_set(const sdp_parameters& sdp_params, const web::json::value& constraint_set)
+    namespace details
+    {
+        typedef boost::variant<
+            video_raw_parameters,
+            audio_L_parameters,
+            video_smpte291_parameters,
+            video_SMPTE2022_6_parameters
+        > format_parameters;
+
+        format_parameters get_format_parameters(const sdp_parameters& sdp_params)
+        {
+            if (sdp::media_types::video == sdp_params.media.media_type && U("raw") == sdp_params.rtpmap.encoding_name) return get_video_raw_parameters(sdp_params);
+            if (sdp::media_types::audio == sdp_params.media.media_type && U("L") == sdp_params.rtpmap.encoding_name.substr(0, 1)) return get_audio_L_parameters(sdp_params);
+            if (sdp::media_types::video == sdp_params.media.media_type && U("smpte291") == sdp_params.rtpmap.encoding_name) return get_video_smpte291_parameters(sdp_params);
+            if (sdp::media_types::video == sdp_params.media.media_type && U("SMPTE2022-6") == sdp_params.rtpmap.encoding_name) return get_video_SMPTE2022_6_parameters(sdp_params);
+            throw sdp_processing_error("unsupported media type/encoding name");
+        }
+    }
+
+    static bool match_sdp_parameters_constraint_set(const sdp_parameters& sdp_params, const details::format_parameters& format_params, const web::json::value& constraint_set)
     {
         using web::json::value;
 
@@ -1331,41 +1362,50 @@ namespace nmos
 
         // NMOS Parameter Registers - Capabilities register
         // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/
-        static const std::map<utility::string_t, std::function<bool(const sdp_parameters& sdp, const value& con)>> match_constraints
+
+        // for a little brevity, cf. sdp_parameters member types
+        typedef video_raw_parameters video_t;
+        typedef audio_L_parameters audio_t;
+        typedef video_smpte291_parameters data_t;
+        typedef video_SMPTE2022_6_parameters mux_t;
+
+        static const std::map<utility::string_t, std::function<bool(const sdp_parameters& sdp, const details::format_parameters& format, const value& con)>> match_constraints
         {
             // General Constraints
 
-            { nmos::caps::format::media_type, [](const sdp_parameters& sdp, const value& con) { return nmos::match_string_constraint(sdp.media_type.name, con); } },
-            { nmos::caps::format::grain_rate, [](const sdp_parameters& sdp, const value& con) { return nmos::rational{} == sdp.video.exactframerate || nmos::match_rational_constraint(sdp.video.exactframerate, con); } },
+            { nmos::caps::format::media_type, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { return nmos::match_string_constraint(sdp.media.media_type.name, con); } },
+            // hm, how best to match (rational) nmos::caps::format::grain_rate against (double) framerate e.g. for video/SMPTE2022-6?
+            // is 23.976 a match for 24000/1001? how about 23.98, or 23.9? or even 23?!
+            { nmos::caps::format::grain_rate, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto video = boost::get<video_t>(&format); return !video || nmos::rational{} == video->exactframerate || nmos::match_rational_constraint(video->exactframerate, con); } },
 
             // Video Constraints
 
-            { nmos::caps::format::frame_height, [](const sdp_parameters& sdp, const value& con) { return nmos::match_integer_constraint(sdp.video.height, con); } },
-            { nmos::caps::format::frame_width, [](const sdp_parameters& sdp, const value& con) { return nmos::match_integer_constraint(sdp.video.width, con); } },
-            { nmos::caps::format::color_sampling, [](const sdp_parameters& sdp, const value& con) { return nmos::match_string_constraint(sdp.video.sampling.name, con); } },
-            { nmos::caps::format::interlace_mode, [](const sdp_parameters& sdp, const value& con) { return nmos::match_interlace_mode_constraint(sdp.video.interlace, sdp.video.segmented, con); } },
-            { nmos::caps::format::colorspace, [](const sdp_parameters& sdp, const value& con) { return nmos::match_string_constraint(sdp.video.colorimetry.name, con); } },
-            { nmos::caps::format::transfer_characteristic, [](const sdp_parameters& sdp, const value& con) { return nmos::match_string_constraint(sdp.video.tcs.name, con); } },
-            { nmos::caps::format::component_depth, [](const sdp_parameters& sdp, const value& con) { return nmos::match_integer_constraint(sdp.video.depth, con); } },
+            { nmos::caps::format::frame_height, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto video = boost::get<video_t>(&format); return video && nmos::match_integer_constraint(video->height, con); } },
+            { nmos::caps::format::frame_width, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto video = boost::get<video_t>(&format); return video && nmos::match_integer_constraint(video->width, con); } },
+            { nmos::caps::format::color_sampling, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto video = boost::get<video_t>(&format); return video && nmos::match_string_constraint(video->sampling.name, con); } },
+            { nmos::caps::format::interlace_mode, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto video = boost::get<video_t>(&format); return video && nmos::match_interlace_mode_constraint(video->interlace, video->segmented, con); } },
+            { nmos::caps::format::colorspace, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto video = boost::get<video_t>(&format); return video && nmos::match_string_constraint(video->colorimetry.name, con); } },
+            { nmos::caps::format::transfer_characteristic, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto video = boost::get<video_t>(&format); return video && nmos::match_string_constraint(video->tcs.name, con); } },
+            { nmos::caps::format::component_depth, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto video = boost::get<video_t>(&format); return video && nmos::match_integer_constraint(video->depth, con); } },
 
             // Audio Constraints
 
-            { nmos::caps::format::channel_count, [](const sdp_parameters& sdp, const value& con) { return nmos::match_integer_constraint(sdp.audio.channel_count, con); } },
-            { nmos::caps::format::sample_rate, [](const sdp_parameters& sdp, const value& con) { return nmos::match_rational_constraint(sdp.audio.sample_rate, con); } },
-            { nmos::caps::format::sample_depth, [](const sdp_parameters& sdp, const value& con) { return nmos::match_integer_constraint(sdp.audio.bit_depth, con); } },
+            { nmos::caps::format::channel_count, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto audio = boost::get<audio_t>(&format); return audio && nmos::match_integer_constraint(audio->channel_count, con); } },
+            { nmos::caps::format::sample_rate, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto audio = boost::get<audio_t>(&format); return audio && nmos::match_rational_constraint(audio->sample_rate, con); } },
+            { nmos::caps::format::sample_depth, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto audio = boost::get<audio_t>(&format); return audio && nmos::match_integer_constraint(audio->bit_depth, con); } },
 
             // Transport Constraints
 
-            { nmos::caps::transport::packet_time, [](const sdp_parameters& sdp, const value& con) { return nmos::match_number_constraint(sdp.audio.packet_time, con); } },
-            // hm, nmos::caps::transport::max_packet_time
-            { nmos::caps::transport::st2110_21_sender_type, [](const sdp_parameters& sdp, const value& con) { return nmos::match_string_constraint(sdp.video.tp.name, con) || nmos::match_string_constraint(sdp.mux.tp.name, con); } }
+            { nmos::caps::transport::packet_time, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { return nmos::match_number_constraint(sdp.packet_time, con); } },
+            { nmos::caps::transport::max_packet_time, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { return nmos::match_number_constraint(sdp.max_packet_time, con); } },
+            { nmos::caps::transport::st2110_21_sender_type, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { if (auto video = boost::get<video_t>(&format)) return nmos::match_string_constraint(video->tp.name, con); else if (auto mux = boost::get<mux_t>(&format)) return nmos::match_string_constraint(mux->tp.name, con); else return false; } }
         };
 
         const auto& constraints = constraint_set.as_object();
         return constraints.end() == std::find_if(constraints.begin(), constraints.end(), [&](const std::pair<utility::string_t, value>& constraint)
         {
             const auto& found = match_constraints.find(constraint.first);
-            return match_constraints.end() != found && !found->second(sdp_params, constraint.second);
+            return match_constraints.end() != found && !found->second(sdp_params, format_params, constraint.second);
         });
     }
 
@@ -1387,8 +1427,9 @@ namespace nmos
         const auto& constraint_sets_or_null = nmos::fields::constraint_sets(caps);
         if (!constraint_sets_or_null.is_null())
         {
+            const auto format_params = details::get_format_parameters(sdp_params);
             const auto& constraint_sets = constraint_sets_or_null.as_array();
-            const auto found = std::find_if(constraint_sets.begin(), constraint_sets.end(), std::bind(match_sdp_parameters_constraint_set, std::ref(sdp_params), std::placeholders::_1));
+            const auto found = std::find_if(constraint_sets.begin(), constraint_sets.end(), [&](const web::json::value& constraint_set) { return match_sdp_parameters_constraint_set(sdp_params, format_params, constraint_set); });
             if (constraint_sets.end() == found) throw details::sdp_processing_error("unsupported transport or format-specific parameters");
         }
     }

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -421,9 +421,9 @@ namespace nmos
                 // Media
                 // See https://tools.ietf.org/html/rfc4566#section-5.14
                 { sdp::fields::media, value_of({
-                    { sdp::fields::media_type, sdp_params.media.media_type.name },
+                    { sdp::fields::media_type, sdp_params.media_type.name },
                     { sdp::fields::port, transport_param.at(nmos::fields::destination_port) },
-                    { sdp::fields::protocol, sdp_params.media.protocol.name },
+                    { sdp::fields::protocol, sdp_params.protocol.name },
                     { sdp::fields::formats, value_of({ utility::ostringstreamed(sdp_params.rtpmap.payload_type) }) }
                 }, keep_order) },
 
@@ -738,16 +738,16 @@ namespace nmos
     {
         nmos::format get_format(const sdp_parameters& sdp_params)
         {
-            if (sdp::media_types::video == sdp_params.media.media_type && U("raw") == sdp_params.rtpmap.encoding_name) return nmos::formats::video;
-            if (sdp::media_types::audio == sdp_params.media.media_type && U("L") == sdp_params.rtpmap.encoding_name.substr(0, 1)) return nmos::formats::audio;
-            if (sdp::media_types::video == sdp_params.media.media_type && U("smpte291") == sdp_params.rtpmap.encoding_name) return nmos::formats::data;
-            if (sdp::media_types::video == sdp_params.media.media_type && U("SMPTE2022-6") == sdp_params.rtpmap.encoding_name) return nmos::formats::mux;
+            if (sdp::media_types::video == sdp_params.media_type && U("raw") == sdp_params.rtpmap.encoding_name) return nmos::formats::video;
+            if (sdp::media_types::audio == sdp_params.media_type && U("L") == sdp_params.rtpmap.encoding_name.substr(0, 1)) return nmos::formats::audio;
+            if (sdp::media_types::video == sdp_params.media_type && U("smpte291") == sdp_params.rtpmap.encoding_name) return nmos::formats::data;
+            if (sdp::media_types::video == sdp_params.media_type && U("SMPTE2022-6") == sdp_params.rtpmap.encoding_name) return nmos::formats::mux;
             return {};
         }
 
         nmos::media_type get_media_type(const sdp_parameters& sdp_params)
         {
-            return nmos::media_type{ sdp_params.media.media_type.name + U("/") + sdp_params.rtpmap.encoding_name };
+            return nmos::media_type{ sdp_params.media_type.name + U("/") + sdp_params.rtpmap.encoding_name };
         }
     }
 
@@ -1085,8 +1085,8 @@ namespace nmos
         // Media
         // See https://tools.ietf.org/html/rfc4566#section-5.14
         const auto& media = sdp::fields::media(media_description);
-        sdp_params.media.media_type = sdp::media_type{ sdp::fields::media_type(media) };
-        sdp_params.media.protocol = sdp::protocol{ sdp::fields::protocol(media) };
+        sdp_params.media_type = sdp::media_type{ sdp::fields::media_type(media) };
+        sdp_params.protocol = sdp::protocol{ sdp::fields::protocol(media) };
 
         // media description attributes
         const auto& media_attributes = sdp::fields::attributes(media_description).as_array();
@@ -1358,10 +1358,10 @@ namespace nmos
 
         format_parameters get_format_parameters(const sdp_parameters& sdp_params)
         {
-            if (sdp::media_types::video == sdp_params.media.media_type && U("raw") == sdp_params.rtpmap.encoding_name) return get_video_raw_parameters(sdp_params);
-            if (sdp::media_types::audio == sdp_params.media.media_type && U("L") == sdp_params.rtpmap.encoding_name.substr(0, 1)) return get_audio_L_parameters(sdp_params);
-            if (sdp::media_types::video == sdp_params.media.media_type && U("smpte291") == sdp_params.rtpmap.encoding_name) return get_video_smpte291_parameters(sdp_params);
-            if (sdp::media_types::video == sdp_params.media.media_type && U("SMPTE2022-6") == sdp_params.rtpmap.encoding_name) return get_video_SMPTE2022_6_parameters(sdp_params);
+            if (sdp::media_types::video == sdp_params.media_type && U("raw") == sdp_params.rtpmap.encoding_name) return get_video_raw_parameters(sdp_params);
+            if (sdp::media_types::audio == sdp_params.media_type && U("L") == sdp_params.rtpmap.encoding_name.substr(0, 1)) return get_audio_L_parameters(sdp_params);
+            if (sdp::media_types::video == sdp_params.media_type && U("smpte291") == sdp_params.rtpmap.encoding_name) return get_video_smpte291_parameters(sdp_params);
+            if (sdp::media_types::video == sdp_params.media_type && U("SMPTE2022-6") == sdp_params.rtpmap.encoding_name) return get_video_SMPTE2022_6_parameters(sdp_params);
             throw sdp_processing_error("unsupported media type/encoding name");
         }
     }
@@ -1385,7 +1385,7 @@ namespace nmos
         {
             // General Constraints
 
-            { nmos::caps::format::media_type, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { return nmos::match_string_constraint(sdp.media.media_type.name, con); } },
+            { nmos::caps::format::media_type, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { return nmos::match_string_constraint(sdp.media_type.name, con); } },
             // hm, how best to match (rational) nmos::caps::format::grain_rate against (double) framerate e.g. for video/SMPTE2022-6?
             // is 23.976 a match for 24000/1001? how about 23.98, or 23.9? or even 23?!
             { nmos::caps::format::grain_rate, [](const sdp_parameters& sdp, const details::format_parameters& format, const value& con) { auto video = boost::get<video_t>(&format); return !video || nmos::rational{} == video->exactframerate || nmos::match_rational_constraint(video->exactframerate, con); } },

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -39,6 +39,7 @@ namespace nmos
             return{ ip_address.is_v4() ? sdp::address_types::IP4 : sdp::address_types::IP6, ip_address.is_multicast() };
         }
 
+        // Construct ts-refclk attributes for each leg based on the IS-04 resources
         std::vector<sdp_parameters::ts_refclk_t> make_ts_refclk(const web::json::value& node, const web::json::value& source, const web::json::value& sender, bst::optional<int> ptp_domain)
         {
             const auto& clock_name = nmos::fields::clock_name(source);
@@ -179,7 +180,7 @@ namespace nmos
             return sampler->second;
         }
 
-        // make simple media stream ids based on the sender's number of legs
+        // Construct simple media stream ids based on the sender's number of legs
         std::vector<utility::string_t> make_media_stream_ids(const web::json::value& sender)
         {
             const auto legs = nmos::fields::interface_bindings(sender).size();

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -17,24 +17,6 @@ namespace nmos
 
     web::json::value make_components(const sdp::sampling& sampling, uint32_t width, uint32_t height, uint32_t depth);
 
-    namespace details
-    {
-        sdp::sampling make_sampling(const web::json::array& components);
-
-        // Payload identifiers 96-127 are used for payloads defined dynamically during a session
-        // 96 and 97 are suitable for video and audio encodings not covered by the IANA registry
-        // See https://tools.ietf.org/html/rfc3551#section-3
-        // and https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-1
-        const uint64_t payload_type_video_default = 96;
-        const uint64_t payload_type_audio_default = 97;
-        const uint64_t payload_type_data_default = 100;
-        // Payload type 98 is recommended for "High bit rate media transport / 27-MHz Clock"
-        // Payload type 99 is recommended for "High bit rate media transport FEC / 27-MHz Clock"
-        // "Alternatively, payload types may be set by other means in accordance with RFC 3550."
-        // See SMPTE ST 2022-6:2012 Section 6.3 RTP/UDP/IP Header
-        const uint64_t payload_type_mux_default = 98;
-    }
-
     // Construct SDP parameters from the IS-04 resources, using default values for unspecified items
     sdp_parameters make_sdp_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, const std::vector<utility::string_t>& media_stream_ids, bst::optional<int> ptp_domain);
 
@@ -451,6 +433,32 @@ namespace nmos
     inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
         : sdp_parameters(make_sdp_parameters(session_name, mux, payload_type, media_stream_ids, ts_refclk))
     {}
+
+    // Helper functions for implementing format-specific make_<media type/sub-type>_sdp_parameters functions
+    namespace details
+    {
+        // Construct ts-refclk attributes for each leg based on the IS-04 resources
+        std::vector<sdp_parameters::ts_refclk_t> make_ts_refclk(const web::json::value& node, const web::json::value& source, const web::json::value& sender, bst::optional<int> ptp_domain);
+
+        // Construct simple media stream ids based on the sender's number of legs
+        std::vector<utility::string_t> make_media_stream_ids(const web::json::value& sender);
+
+        // cf. nmos::make_components
+        sdp::sampling make_sampling(const web::json::array& components);
+
+        // Payload identifiers 96-127 are used for payloads defined dynamically during a session
+        // 96 and 97 are suitable for video and audio encodings not covered by the IANA registry
+        // See https://tools.ietf.org/html/rfc3551#section-3
+        // and https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-1
+        const uint64_t payload_type_video_default = 96;
+        const uint64_t payload_type_audio_default = 97;
+        const uint64_t payload_type_data_default = 100;
+        // Payload type 98 is recommended for "High bit rate media transport / 27-MHz Clock"
+        // Payload type 99 is recommended for "High bit rate media transport FEC / 27-MHz Clock"
+        // "Alternatively, payload types may be set by other means in accordance with RFC 3550."
+        // See SMPTE ST 2022-6:2012 Section 6.3 RTP/UDP/IP Header
+        const uint64_t payload_type_mux_default = 98;
+    }
 }
 
 #endif

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -438,7 +438,7 @@ namespace nmos
         : sdp_parameters(make_sdp_parameters(session_name, mux, payload_type, media_stream_ids, ts_refclk))
     {}
 
-    // Helper functions for implementing format-specific make_<media type/sub-type>_sdp_parameters functions
+    // Helper functions for implementing format-specific make_<media type/subtype>_sdp_parameters functions
     namespace details
     {
         // Construct ts-refclk attributes for each leg based on the IS-04 resources

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -139,15 +139,8 @@ namespace nmos
 
         // Media ("m=")
         // See https://tools.ietf.org/html/rfc4566#section-5.14
-        struct media_t
-        {
-            sdp::media_type media_type;
-            sdp::protocol protocol;
-            // formats are specified by the RTP payload mapping
-
-            media_t() {}
-            media_t(const sdp::media_type& media_type, const sdp::protocol& protocol) : media_type(media_type), protocol(protocol) {}
-        } media;
+        sdp::media_type media_type;
+        sdp::protocol protocol;
 
         // Bandwidth ("b=") (e.g. for "video/jxsv")
         // See https://tools.ietf.org/html/rfc4566#section-5.8
@@ -266,7 +259,8 @@ namespace nmos
             , connection_data(32)
             , timing()
             , group(!media_stream_ids.empty() ? group_t{ sdp::group_semantics::duplication, media_stream_ids } : group_t{})
-            , media(media_type, sdp::protocols::RTP_AVP)
+            , media_type(media_type)
+            , protocol(sdp::protocols::RTP_AVP)
             , bandwidth(0 != bandwidth ? std::vector<bandwidth_t>{ bandwidth_t{ sdp::bandwidth_types::application_specific, bandwidth } } : std::vector<bandwidth_t>{})
             , packet_time(packet_time)
             , max_packet_time(max_packet_time)

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -277,16 +277,16 @@ namespace nmos
         typedef video_smpte291_parameters data_t;
         typedef video_SMPTE2022_6_parameters mux_t;
 
-        // deprecated, use make_video_raw_sdp_parameters
+        // deprecated, use make_video_raw_sdp_parameters or equivalent overload of make_sdp_parameters
         sdp_parameters(const utility::string_t& session_name, const video_t& video, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
 
-        // deprecated, use make_audio_L_sdp_parameters
+        // deprecated, use make_audio_L_sdp_parameters or equivalent overload of make_sdp_parameters
         sdp_parameters(const utility::string_t& session_name, const audio_t& audio, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
 
-        // deprecated, use make_video_smpte291_sdp_parameters
+        // deprecated, use make_video_smpte291_sdp_parameters or equivalent overload of make_sdp_parameters
         sdp_parameters(const utility::string_t& session_name, const data_t& data, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
 
-        // deprecated, use make_video_SMPTE2022_6_sdp_parameters
+        // deprecated, use make_video_SMPTE2022_6_sdp_parameters or equivalent overload of make_sdp_parameters
         sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
     };
 
@@ -383,44 +383,73 @@ namespace nmos
         {}
     };
 
+    // Construct additional "video/raw" parameters from the IS-04 resources, using default values for unspecified items
+    video_raw_parameters make_video_raw_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, bst::optional<sdp::type_parameter> tp);
     // Construct SDP parameters for "video/raw", with sensible defaults for unspecified fields
     sdp_parameters make_video_raw_sdp_parameters(const utility::string_t& session_name, const video_raw_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
     // Get additional "video/raw" parameters from the SDP parameters
     video_raw_parameters get_video_raw_parameters(const sdp_parameters& sdp_params);
 
+    // Construct additional "audio/L" parameters from the IS-04 resources, using default values for unspecified items
+    audio_L_parameters make_audio_L_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, bst::optional<double> packet_time);
     // Construct SDP parameters for "audio/L", with sensible defaults for unspecified fields
     sdp_parameters make_audio_L_sdp_parameters(const utility::string_t& session_name, const audio_L_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
     // Get additional "audio/L" parameters from the SDP parameters
     audio_L_parameters get_audio_L_parameters(const sdp_parameters& sdp_params);
 
+    // Construct additional "video/smpte291" parameters from the IS-04 resources, using default values for unspecified items
+    video_smpte291_parameters make_video_smpte291_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, bst::optional<nmos::vpid_code> vpid_code);
     // Construct SDP parameters for "video/smpte291", with sensible defaults for unspecified fields
     sdp_parameters make_video_smpte291_sdp_parameters(const utility::string_t& session_name, const video_smpte291_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
     // Get additional "video/smpte291" parameters from the SDP parameters
     video_smpte291_parameters get_video_smpte291_parameters(const sdp_parameters& sdp_params);
 
+    // Construct additional "video/SMPTE2022-6" parameters from the IS-04 resources, using default values for unspecified items
+    video_SMPTE2022_6_parameters make_video_SMPTE2022_6_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, bst::optional<sdp::type_parameter> tp);
     // Construct SDP parameters for "video/SMPTE2022-6", with sensible defaults for unspecified fields
     sdp_parameters make_video_SMPTE2022_6_sdp_parameters(const utility::string_t& session_name, const video_SMPTE2022_6_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
     // Get additional "video/SMPTE2022-6" parameters from the SDP parameters
     video_SMPTE2022_6_parameters get_video_SMPTE2022_6_parameters(const sdp_parameters& sdp_params);
 
-    // deprecated, use make_video_raw_sdp_parameters
+    // Construct SDP parameters for "video/raw", with sensible defaults for unspecified fields
+    inline sdp_parameters make_sdp_parameters(const utility::string_t& session_name, const video_raw_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {})
+    {
+        return make_video_raw_sdp_parameters(session_name, params, payload_type, media_stream_ids, ts_refclk);
+    }
+    // Construct SDP parameters for "audio/L", with sensible defaults for unspecified fields
+    inline sdp_parameters make_sdp_parameters(const utility::string_t& session_name, const audio_L_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {})
+    {
+        return make_audio_L_sdp_parameters(session_name, params, payload_type, media_stream_ids, ts_refclk);
+    }
+    // Construct SDP parameters for "video/smpte291", with sensible defaults for unspecified fields
+    inline sdp_parameters make_sdp_parameters(const utility::string_t& session_name, const video_smpte291_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {})
+    {
+        return make_video_smpte291_sdp_parameters(session_name, params, payload_type, media_stream_ids, ts_refclk);
+    }
+    // Construct SDP parameters for "video/SMPTE2022-6", with sensible defaults for unspecified fields
+    inline sdp_parameters make_sdp_parameters(const utility::string_t& session_name, const video_SMPTE2022_6_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {})
+    {
+        return make_video_SMPTE2022_6_sdp_parameters(session_name, params, payload_type, media_stream_ids, ts_refclk);
+    }
+
+    // deprecated, use make_video_raw_sdp_parameters or equivalent overload of make_sdp_parameters
     inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const video_t& video, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
-        : sdp_parameters(make_video_raw_sdp_parameters(session_name, video, payload_type, media_stream_ids, ts_refclk))
+        : sdp_parameters(make_sdp_parameters(session_name, video, payload_type, media_stream_ids, ts_refclk))
     {}
 
-    // deprecated, use make_audio_L_sdp_parameters
+    // deprecated, use make_audio_L_sdp_parameters or equivalent overload of make_sdp_parameters
     inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const audio_t& audio, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
-        : sdp_parameters(make_audio_L_sdp_parameters(session_name, audio, payload_type, media_stream_ids, ts_refclk))
+        : sdp_parameters(make_sdp_parameters(session_name, audio, payload_type, media_stream_ids, ts_refclk))
     {}
 
-    // deprecated, use make_video_smpte291_sdp_parameters
+    // deprecated, use make_video_smpte291_sdp_parameters or equivalent overload of make_sdp_parameters
     inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const data_t& data, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
-        : sdp_parameters(make_video_smpte291_sdp_parameters(session_name, data, payload_type, media_stream_ids, ts_refclk))
+        : sdp_parameters(make_sdp_parameters(session_name, data, payload_type, media_stream_ids, ts_refclk))
     {}
 
-    // deprecated, use make_video_SMPTE2022_6_sdp_parameters
+    // deprecated, use make_video_SMPTE2022_6_sdp_parameters or equivalent overload of make_sdp_parameters
     inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
-        : sdp_parameters(make_video_SMPTE2022_6_sdp_parameters(session_name, mux, payload_type, media_stream_ids, ts_refclk))
+        : sdp_parameters(make_sdp_parameters(session_name, mux, payload_type, media_stream_ids, ts_refclk))
     {}
 }
 

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -11,7 +11,9 @@
 
 namespace nmos
 {
-    struct sdp_parameters;
+    struct media_type;
+
+    struct sdp_parameters; // defined below
 
     // Sender helper functions
 
@@ -270,6 +272,9 @@ namespace nmos
         // deprecated, use make_video_SMPTE2022_6_sdp_parameters or equivalent overload of make_sdp_parameters
         sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
     };
+
+    // "<sdp_params.media_type>/<sdp_params.rtpmap.encoding_name>"
+    media_type get_media_type(const sdp_parameters& sdp_params);
 
     // Format-specific types and functions
 

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -20,6 +20,19 @@ namespace nmos
     namespace details
     {
         sdp::sampling make_sampling(const web::json::array& components);
+
+        // Payload identifiers 96-127 are used for payloads defined dynamically during a session
+        // 96 and 97 are suitable for video and audio encodings not covered by the IANA registry
+        // See https://tools.ietf.org/html/rfc3551#section-3
+        // and https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-1
+        const uint64_t payload_type_video_default = 96;
+        const uint64_t payload_type_audio_default = 97;
+        const uint64_t payload_type_data_default = 100;
+        // Payload type 98 is recommended for "High bit rate media transport / 27-MHz Clock"
+        // Payload type 99 is recommended for "High bit rate media transport FEC / 27-MHz Clock"
+        // "Alternatively, payload types may be set by other means in accordance with RFC 3550."
+        // See SMPTE ST 2022-6:2012 Section 6.3 RTP/UDP/IP Header
+        const uint64_t payload_type_mux_default = 98;
     }
 
     // Construct SDP parameters from the IS-04 resources, using default values for unspecified items
@@ -52,8 +65,22 @@ namespace nmos
 
     void validate_sdp_parameters(const web::json::value& receiver, const sdp_parameters& sdp_params);
 
+    // Format-specific types
+
+    struct video_raw_parameters;
+    struct audio_L_parameters;
+    struct video_smpte291_parameters;
+    struct video_SMPTE2022_6_parameters;
+
+    // sdp_parameters represents the additional (non-transport) SDP parameters.
+    // It does not cover the case of multiple media types in a single SDP file because NMOS associates an SDP file
+    // with each RTP sender and receiver.
+    // When redundancy is being used, the media description and media-level attributes for each stream are assumed
+    // to be identical except for the values corresponding to the IS-05 transport parameters for each leg.
     struct sdp_parameters
     {
+        // Origin ("o=")
+        // See https://tools.ietf.org/html/rfc4566#section-5.2
         struct origin_t
         {
             utility::string_t user_name;
@@ -73,16 +100,23 @@ namespace nmos
             {}
         } origin;
 
+        // Session Name ("s=")
+        // See https://tools.ietf.org/html/rfc4566#section-5.3
         utility::string_t session_name;
 
+        // Connection Data ("c=")
+        // See https://tools.ietf.org/html/rfc4566#section-5.7
         struct connection_data_t
         {
+            // most fields in the "c=" line have corresponding values in the IS-05 transport parameters
             uint32_t ttl;
 
             connection_data_t() : ttl() {}
             connection_data_t(uint32_t ttl) : ttl(ttl) {}
         } connection_data;
 
+        // Timing ("t=")
+        // See https://tools.ietf.org/html/rfc4566#section-5.9
         struct timing_t
         {
             uint64_t start_time;
@@ -91,6 +125,8 @@ namespace nmos
             timing_t(uint64_t start_time, uint64_t stop_time) : start_time(start_time), stop_time(stop_time) {}
         } timing;
 
+        // Grouping Framework ("a=mid:" and "a=group:")
+        // See https://tools.ietf.org/html/rfc5888
         struct group_t
         {
             sdp::group_semantics_type semantics;
@@ -101,109 +137,74 @@ namespace nmos
             group_t(const sdp::group_semantics_type& semantics, const std::vector<utility::string_t>& media_stream_ids) : semantics(semantics), media_stream_ids(media_stream_ids) {}
         } group;
 
-        sdp::media_type media_type;
-        sdp::protocol protocol;
+        // Media ("m=")
+        // See https://tools.ietf.org/html/rfc4566#section-5.14
+        struct media_t
+        {
+            sdp::media_type media_type;
+            sdp::protocol protocol;
+            // formats are specified by the RTP payload mapping
 
+            media_t() {}
+            media_t(const sdp::media_type& media_type, const sdp::protocol& protocol) : media_type(media_type), protocol(protocol) {}
+        } media;
+
+        // Bandwidth ("b=") (e.g. for "video/jxsv")
+        // See https://tools.ietf.org/html/rfc4566#section-5.8
+        struct bandwidth_t
+        {
+            sdp::bandwidth_type bandwidth_type;
+            uint64_t bandwidth;
+
+            bandwidth_t() : bandwidth() {}
+            bandwidth_t(const sdp::bandwidth_type& bandwidth_type, uint64_t bandwidth) : bandwidth_type(bandwidth_type), bandwidth(bandwidth) {}
+        };
+        std::vector<bandwidth_t> bandwidth;
+
+        // Packet Time ("a=ptime:") (e.g. for "audio/L16")
+        // See https://tools.ietf.org/html/rfc4566#section-6
+        double packet_time;
+
+        // Maximum Packet Time ("a=maxptime:") (e.g. for "audio/L16")
+        // See https://tools.ietf.org/html/rfc4566#section-6
+        double max_packet_time;
+
+        // RTP Payload Mapping ("a=rtpmap:")
+        // See https://tools.ietf.org/html/rfc4566#section-6
         struct rtpmap_t
         {
             uint64_t payload_type;
-            // encoding-name is "raw" for video, "L24" or "L16" for audio, "smpte291" for data, "SMPTE2022-6" for mux
+            // encoding-name is the media subtype
+            // e.g. "raw" for video, "L24" or "L16" for audio, "smpte291" for data, "SMPTE2022-6" for mux
             utility::string_t encoding_name;
             uint64_t clock_rate;
+            // encoding-parameters optionally indicates channel count for audio
+            uint64_t encoding_parameters;
 
-            rtpmap_t() : payload_type(), clock_rate() {}
-            rtpmap_t(uint64_t payload_type, const utility::string_t& encoding_name, uint64_t clock_rate)
+            rtpmap_t() : payload_type(), clock_rate(), encoding_parameters() {}
+            rtpmap_t(uint64_t payload_type, const utility::string_t& encoding_name, uint64_t clock_rate, uint64_t encoding_parameters = {})
                 : payload_type(payload_type)
                 , encoding_name(encoding_name)
                 , clock_rate(clock_rate)
+                , encoding_parameters(encoding_parameters)
             {}
         } rtpmap;
 
-        // additional "video/raw" parameters (video only)
-        struct video_t
-        {
-            // fmtp indicates format
-            uint32_t width;
-            uint32_t height;
-            nmos::rational exactframerate;
-            bool interlace;
-            bool segmented;
-            sdp::sampling sampling;
-            uint32_t depth;
-            sdp::transfer_characteristic_system tcs; // nmos::transfer_characteristic is a subset
-            sdp::colorimetry colorimetry; // nmos::colorspace is a subset
-            sdp::type_parameter tp;
+        // Frame Rate ("a=framerate:") (e.g. for "video/SMPTE2022-6")
+        // See https://tools.ietf.org/html/rfc4566#section-6
+        double framerate;
 
-            video_t() : width(), height(), interlace(), segmented(), depth() {}
-            video_t(uint32_t width, uint32_t height, const nmos::rational& exactframerate, bool interlace, bool segmented, const sdp::sampling& sampling, uint32_t depth, const sdp::transfer_characteristic_system& tcs, const sdp::colorimetry& colorimetry, const sdp::type_parameter& tp)
-                : width(width)
-                , height(height)
-                , exactframerate(exactframerate)
-                , interlace(interlace)
-                , segmented(segmented)
-                , sampling(sampling)
-                , depth(depth)
-                , tcs(tcs)
-                , colorimetry(colorimetry)
-                , tp(tp)
-            {}
-        } video;
+        // Format-specific Parameters ("a=fmtp:")
+        // The payload type is specified by the RTP payload mapping
+        // See https://tools.ietf.org/html/rfc4566#section-6
+        typedef std::vector<std::pair<utility::string_t, utility::string_t>> fmtp_t;
+        fmtp_t fmtp;
 
-        // additional "audio/L" parameters (audio only)
-        struct audio_t
-        {
-            // rtpmap encoding-parameters indicates channel_count
-            uint32_t channel_count;
-            // rtpmap encoding-name (e.g. "L24") indicates bit_depth
-            uint32_t bit_depth;
-            // rtpmap clock-rate indicates sample_rate
-            nmos::rational sample_rate;
-
-            // fmtp indicates channel-order (e.g. "SMPTE2110.(ST)")
-            utility::string_t channel_order;
-
-            // ptime
-            double packet_time;
-
-            audio_t() : channel_count(), bit_depth(), packet_time() {}
-            audio_t(uint32_t channel_count, uint32_t bit_depth, const nmos::rational& sample_rate, const utility::string_t& channel_order, double packet_time)
-                : channel_count(channel_count)
-                , bit_depth(bit_depth)
-                , sample_rate(sample_rate)
-                , channel_order(channel_order)
-                , packet_time(packet_time)
-            {}
-        } audio;
-
-        // additional "video/smpte291" data parameters (data only)
-        // see SMPTE ST 2110-40:2018
-        // and https://www.iana.org/assignments/media-types/video/smpte291
-        // and https://tools.ietf.org/html/rfc8331
-        struct data_t
-        {
-            // fmtp optionally indicates multiple DID_SDID parameters
-            std::vector<nmos::did_sdid> did_sdids;
-            // fmtp optionally indicates VPID Code of the source interface
-            nmos::vpid_code vpid_code;
-
-            data_t(const std::vector<nmos::did_sdid>& did_sdids = {}, nmos::vpid_code vpid_code = {})
-                : did_sdids(did_sdids)
-                , vpid_code(vpid_code)
-            {}
-        } data;
-
-        // additional "video/SMPTE2022-6" parameters (mux only)
-        // see SMPTE ST 2022-8:2019
-        struct mux_t
-        {
-            sdp::type_parameter tp;
-
-            mux_t() {}
-            mux_t(const sdp::type_parameter& tp)
-                : tp(tp)
-            {}
-        } mux;
-
+        // For now, only the default payload format is covered.
+        //std::vector<std::pair<rtpmap_t, fmtp_t>> alternative_rtpmap_fmtp;
+        
+        // Timestamp Reference Clock Source Signalling ("a=ts-refclk:")
+        // See https://tools.ietf.org/html/rfc7273#section-4
         struct ts_refclk_t
         {
             sdp::ts_refclk_source clock_source;
@@ -240,8 +241,10 @@ namespace nmos
                 , mac_address(mac_address)
             {}
         };
-        std::vector<sdp_parameters::ts_refclk_t> ts_refclk;
+        std::vector<sdp_parameters::ts_refclk_t> ts_refclk; // hm, this is one for each leg
 
+        // Media Clock Source Signalling
+        // See https://tools.ietf.org/html/rfc7273#section-5
         struct mediaclk_t
         {
             sdp::mediaclk_source clock_source;
@@ -255,80 +258,177 @@ namespace nmos
         } mediaclk;
 
         // construct null SDP parameters
-        sdp_parameters() {}
+        sdp_parameters() : packet_time(), max_packet_time(), framerate() {}
 
-        // construct "video/raw" SDP parameters with sensible defaults for unspecified fields
-        sdp_parameters(const utility::string_t& session_name, const video_t& video, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {})
+        // construct SDP parameters with sensible defaults for unspecified fields
+        sdp_parameters(const utility::string_t& session_name, const sdp::media_type& media_type, const rtpmap_t& rtpmap, const fmtp_t& fmtp = {}, uint64_t bandwidth = {}, double packet_time = {}, double max_packet_time = {}, double framerate = {}, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {})
             : origin(U("-"), sdp::ntp_now() >> 32)
             , session_name(session_name)
             , connection_data(32)
             , timing()
             , group(!media_stream_ids.empty() ? group_t{ sdp::group_semantics::duplication, media_stream_ids } : group_t{})
-            , media_type(sdp::media_types::video)
-            , protocol(sdp::protocols::RTP_AVP)
-            , rtpmap(payload_type, U("raw"), 90000)
-            , video(video)
-            , audio()
-            , data()
-            , mux()
+            , media(media_type, sdp::protocols::RTP_AVP)
+            , bandwidth(0 != bandwidth ? std::vector<bandwidth_t>{ bandwidth_t{ sdp::bandwidth_types::application_specific, bandwidth } } : std::vector<bandwidth_t>{})
+            , packet_time(packet_time)
+            , max_packet_time(max_packet_time)
+            , rtpmap(rtpmap)
+            , framerate(framerate)
+            , fmtp(fmtp)
             , ts_refclk(ts_refclk)
             , mediaclk(sdp::mediaclk_sources::direct, U("0"))
         {}
 
-        // construct "audio/L" SDP parameters with sensible defaults for unspecified fields
-        sdp_parameters(const utility::string_t& session_name, const audio_t& audio, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {})
-            : origin(U("-"), sdp::ntp_now() >> 32)
-            , session_name(session_name)
-            , connection_data(32)
-            , timing()
-            , group(!media_stream_ids.empty() ? group_t{ sdp::group_semantics::duplication, media_stream_ids } : group_t{})
-            , media_type(sdp::media_types::audio)
-            , protocol(sdp::protocols::RTP_AVP)
-            , rtpmap(payload_type, U("L") + utility::ostringstreamed(audio.bit_depth), uint64_t(double(audio.sample_rate.numerator()) / double(audio.sample_rate.denominator()) + 0.5))
-            , video()
-            , audio(audio)
-            , data()
-            , mux()
-            , ts_refclk(ts_refclk)
-            , mediaclk(sdp::mediaclk_sources::direct, U("0"))
-        {}
+        // deprecated, provided to slightly simplify updating code to use fmtp
+        typedef video_raw_parameters video_t;
+        typedef audio_L_parameters audio_t;
+        typedef video_smpte291_parameters data_t;
+        typedef video_SMPTE2022_6_parameters mux_t;
 
-        // construct "video/smpte291" SDP parameters with sensible defaults for unspecified fields
-        sdp_parameters(const utility::string_t& session_name, const data_t& data, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {})
-            : origin(U("-"), sdp::ntp_now() >> 32)
-            , session_name(session_name)
-            , connection_data(32)
-            , timing()
-            , group(!media_stream_ids.empty() ? group_t{ sdp::group_semantics::duplication, media_stream_ids } : group_t{})
-            , media_type(sdp::media_types::video)
-            , protocol(sdp::protocols::RTP_AVP)
-            , rtpmap(payload_type, U("smpte291"), 90000)
-            , video()
-            , audio()
-            , data(data)
-            , mux()
-            , ts_refclk(ts_refclk)
-            , mediaclk(sdp::mediaclk_sources::direct, U("0"))
-        {}
+        // deprecated, construct "video/raw" SDP parameters with sensible defaults for unspecified fields
+        sdp_parameters(const utility::string_t& session_name, const video_t& video, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
 
-        // construct "video/SMPTE2022-6" SDP parameters with sensible defaults for unspecified fields
-        sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {})
-            : origin(U("-"), sdp::ntp_now() >> 32)
-            , session_name(session_name)
-            , connection_data(32)
-            , timing()
-            , group(!media_stream_ids.empty() ? group_t{ sdp::group_semantics::duplication, media_stream_ids } : group_t{})
-            , media_type(sdp::media_types::video)
-            , protocol(sdp::protocols::RTP_AVP)
-            , rtpmap(payload_type, U("SMPTE2022-6"), 27000000)
-            , video()
-            , audio()
-            , data()
-            , mux(mux)
-            , ts_refclk(ts_refclk)
-            , mediaclk(sdp::mediaclk_sources::direct, U("0"))
+        // deprecated, construct "audio/L" SDP parameters with sensible defaults for unspecified fields
+        sdp_parameters(const utility::string_t& session_name, const audio_t& audio, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
+
+        // deprecated, construct "video/smpte291" SDP parameters with sensible defaults for unspecified fields
+        sdp_parameters(const utility::string_t& session_name, const data_t& data, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
+
+        // deprecated, construct "video/SMPTE2022-6" SDP parameters with sensible defaults for unspecified fields
+        sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
+    };
+
+    // Format-specific types and functions
+
+    // Additional "video/raw" parameters
+    // See SMPTE ST 2110-20:2017
+    // and https://www.iana.org/assignments/media-types/video/raw
+    struct video_raw_parameters
+    {
+        // fmtp indicates format
+        uint32_t width;
+        uint32_t height;
+        nmos::rational exactframerate;
+        bool interlace;
+        bool segmented;
+        sdp::sampling sampling;
+        uint32_t depth;
+        sdp::transfer_characteristic_system tcs; // nmos::transfer_characteristic is a subset
+        sdp::colorimetry colorimetry; // nmos::colorspace is a subset
+        sdp::type_parameter tp;
+
+        video_raw_parameters() : width(), height(), interlace(), segmented(), depth() {}
+        video_raw_parameters(uint32_t width, uint32_t height, const nmos::rational& exactframerate, bool interlace, bool segmented, const sdp::sampling& sampling, uint32_t depth, const sdp::transfer_characteristic_system& tcs, const sdp::colorimetry& colorimetry, const sdp::type_parameter& tp)
+            : width(width)
+            , height(height)
+            , exactframerate(exactframerate)
+            , interlace(interlace)
+            , segmented(segmented)
+            , sampling(sampling)
+            , depth(depth)
+            , tcs(tcs)
+            , colorimetry(colorimetry)
+            , tp(tp)
         {}
     };
+
+    // Additional "audio/L" parameters
+    // See SMPTE ST 2110-30:2017
+    // and https://www.iana.org/assignments/media-types/audio/L24
+    // and https://www.iana.org/assignments/media-types/audio/L16
+    // and https://www.iana.org/assignments/media-types/audio/L8
+    struct audio_L_parameters
+    {
+        // rtpmap encoding-parameters indicates channel_count
+        uint32_t channel_count;
+        // rtpmap encoding-name (e.g. "L24") indicates bit_depth
+        uint32_t bit_depth;
+        // rtpmap clock-rate indicates sample_rate
+        uint64_t sample_rate;
+
+        // fmtp indicates channel-order (e.g. "SMPTE2110.(ST)")
+        utility::string_t channel_order;
+
+        // ptime
+        double packet_time;
+
+        audio_L_parameters() : channel_count(), bit_depth(), sample_rate(), packet_time() {}
+        audio_L_parameters(uint32_t channel_count, uint32_t bit_depth, uint64_t sample_rate, const utility::string_t& channel_order, double packet_time)
+            : channel_count(channel_count)
+            , bit_depth(bit_depth)
+            , sample_rate(sample_rate)
+            , channel_order(channel_order)
+            , packet_time(packet_time)
+        {}
+    };
+
+    // Additional "video/smpte291" data payload parameters
+    // See SMPTE ST 2110-40:2018
+    // and https://www.iana.org/assignments/media-types/video/smpte291
+    // and https://tools.ietf.org/html/rfc8331
+    struct video_smpte291_parameters
+    {
+        // fmtp optionally indicates multiple DID_SDID parameters
+        std::vector<nmos::did_sdid> did_sdids;
+        // fmtp optionally indicates VPID Code of the source interface
+        nmos::vpid_code vpid_code;
+
+        video_smpte291_parameters(const std::vector<nmos::did_sdid>& did_sdids = {}, nmos::vpid_code vpid_code = {})
+            : did_sdids(did_sdids)
+            , vpid_code(vpid_code)
+        {}
+    };
+
+    // Additional "video/SMPTE2022-6" multiplexed payload parameters
+    // See SMPTE ST 2022-8:2019
+    struct video_SMPTE2022_6_parameters
+    {
+        sdp::type_parameter tp;
+
+        video_SMPTE2022_6_parameters() {}
+        video_SMPTE2022_6_parameters(const sdp::type_parameter& tp)
+            : tp(tp)
+        {}
+    };
+
+    void set_video_raw_parameters(sdp_parameters& sdp_params, const video_raw_parameters& params, uint64_t payload_type);
+    video_raw_parameters get_video_raw_parameters(const sdp_parameters& sdp_params);
+
+    void set_audio_L_parameters(sdp_parameters& sdp_params, const audio_L_parameters& params, uint64_t payload_type);
+    audio_L_parameters get_audio_L_parameters(const sdp_parameters& sdp_params);
+
+    void set_video_smpte291_parameters(sdp_parameters& sdp_params, const video_smpte291_parameters& params, uint64_t payload_type);
+    video_smpte291_parameters get_video_smpte291_parameters(const sdp_parameters& sdp_params);
+
+    void set_video_SMPTE2022_6_parameters(sdp_parameters& sdp_params, const video_SMPTE2022_6_parameters& params, uint64_t payload_type);
+    video_SMPTE2022_6_parameters get_video_SMPTE2022_6_parameters(const sdp_parameters& sdp_params);
+
+    // deprecated, construct "video/raw" SDP parameters with sensible defaults for unspecified fields
+    inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const video_t& video, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
+        : sdp_parameters(session_name, sdp::media_types::video, {}, {}, {}, {}, {}, {}, media_stream_ids, ts_refclk)
+    {
+        set_video_raw_parameters(*this, video, payload_type);
+    }
+
+    // deprecated, construct "audio/L" SDP parameters with sensible defaults for unspecified fields
+    inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const audio_t& audio, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
+        : sdp_parameters(session_name, sdp::media_types::audio, {}, {}, {}, {}, {}, {}, media_stream_ids, ts_refclk)
+    {
+        set_audio_L_parameters(*this, audio, payload_type);
+    }
+
+    // deprecated, construct "video/smpte291" SDP parameters with sensible defaults for unspecified fields
+    inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const data_t& data, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
+        : sdp_parameters(session_name, sdp::media_types::video, {}, {}, {}, {}, {}, {}, media_stream_ids, ts_refclk)
+    {
+        set_video_smpte291_parameters(*this, data, payload_type);
+    }
+
+    // deprecated, construct "video/SMPTE2022-6" SDP parameters with sensible defaults for unspecified fields
+    inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
+        : sdp_parameters(session_name, sdp::media_types::video, {}, {}, {}, {}, {}, {}, media_stream_ids, ts_refclk)
+    {
+        set_video_SMPTE2022_6_parameters(*this, mux, payload_type);
+    }
 }
 
 #endif

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -133,8 +133,7 @@ namespace nmos
 
             bandwidth_t() : bandwidth() {}
             bandwidth_t(const sdp::bandwidth_type& bandwidth_type, uint64_t bandwidth) : bandwidth_type(bandwidth_type), bandwidth(bandwidth) {}
-        };
-        std::vector<bandwidth_t> bandwidth;
+        } bandwidth;
 
         // Packet Time ("a=ptime:") (e.g. for "audio/L16")
         // See https://tools.ietf.org/html/rfc4566#section-6
@@ -243,7 +242,7 @@ namespace nmos
             , group(!media_stream_ids.empty() ? group_t{ sdp::group_semantics::duplication, media_stream_ids } : group_t{})
             , media_type(media_type)
             , protocol(sdp::protocols::RTP_AVP)
-            , bandwidth(0 != bandwidth ? std::vector<bandwidth_t>{ bandwidth_t{ sdp::bandwidth_types::application_specific, bandwidth } } : std::vector<bandwidth_t>{})
+            , bandwidth(0 != bandwidth ? bandwidth_t{ sdp::bandwidth_types::application_specific, bandwidth } : bandwidth_t{})
             , packet_time(packet_time)
             , max_packet_time(max_packet_time)
             , rtpmap(rtpmap)

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -57,7 +57,7 @@ namespace nmos
     // Get IS-05 transport parameters from the json representation of an SDP file, e.g. from sdp::parse_session_description
     web::json::value get_session_description_transport_params(const web::json::value& session_description);
 
-    // Get other SDP parameters from the json representation of an SDP file, e.g. from sdp::parse_session_description
+    // Get the additional (non-transport) SDP parameters from the json representation of an SDP file, e.g. from sdp::parse_session_description
     sdp_parameters get_session_description_sdp_parameters(const web::json::value& session_description);
 
     // Get SDP parameters from the json representation of an SDP file, e.g. from sdp::parse_session_description
@@ -195,7 +195,6 @@ namespace nmos
         double framerate;
 
         // Format-specific Parameters ("a=fmtp:")
-        // The payload type is specified by the RTP payload mapping
         // See https://tools.ietf.org/html/rfc4566#section-6
         typedef std::vector<std::pair<utility::string_t, utility::string_t>> fmtp_t;
         fmtp_t fmtp;
@@ -284,16 +283,16 @@ namespace nmos
         typedef video_smpte291_parameters data_t;
         typedef video_SMPTE2022_6_parameters mux_t;
 
-        // deprecated, construct "video/raw" SDP parameters with sensible defaults for unspecified fields
+        // deprecated, use make_video_raw_sdp_parameters
         sdp_parameters(const utility::string_t& session_name, const video_t& video, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
 
-        // deprecated, construct "audio/L" SDP parameters with sensible defaults for unspecified fields
+        // deprecated, use make_audio_L_sdp_parameters
         sdp_parameters(const utility::string_t& session_name, const audio_t& audio, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
 
-        // deprecated, construct "video/smpte291" SDP parameters with sensible defaults for unspecified fields
+        // deprecated, use make_video_smpte291_sdp_parameters
         sdp_parameters(const utility::string_t& session_name, const data_t& data, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
 
-        // deprecated, construct "video/SMPTE2022-6" SDP parameters with sensible defaults for unspecified fields
+        // deprecated, use make_video_SMPTE2022_6_sdp_parameters
         sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<ts_refclk_t>& ts_refclk = {});
     };
 
@@ -390,45 +389,45 @@ namespace nmos
         {}
     };
 
-    void set_video_raw_parameters(sdp_parameters& sdp_params, const video_raw_parameters& params, uint64_t payload_type);
+    // Construct SDP parameters for "video/raw", with sensible defaults for unspecified fields
+    sdp_parameters make_video_raw_sdp_parameters(const utility::string_t& session_name, const video_raw_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
+    // Get additional "video/raw" parameters from the SDP parameters
     video_raw_parameters get_video_raw_parameters(const sdp_parameters& sdp_params);
 
-    void set_audio_L_parameters(sdp_parameters& sdp_params, const audio_L_parameters& params, uint64_t payload_type);
+    // Construct SDP parameters for "audio/L", with sensible defaults for unspecified fields
+    sdp_parameters make_audio_L_sdp_parameters(const utility::string_t& session_name, const audio_L_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
+    // Get additional "audio/L" parameters from the SDP parameters
     audio_L_parameters get_audio_L_parameters(const sdp_parameters& sdp_params);
 
-    void set_video_smpte291_parameters(sdp_parameters& sdp_params, const video_smpte291_parameters& params, uint64_t payload_type);
+    // Construct SDP parameters for "video/smpte291", with sensible defaults for unspecified fields
+    sdp_parameters make_video_smpte291_sdp_parameters(const utility::string_t& session_name, const video_smpte291_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
+    // Get additional "video/smpte291" parameters from the SDP parameters
     video_smpte291_parameters get_video_smpte291_parameters(const sdp_parameters& sdp_params);
 
-    void set_video_SMPTE2022_6_parameters(sdp_parameters& sdp_params, const video_SMPTE2022_6_parameters& params, uint64_t payload_type);
+    // Construct SDP parameters for "video/SMPTE2022-6", with sensible defaults for unspecified fields
+    sdp_parameters make_video_SMPTE2022_6_sdp_parameters(const utility::string_t& session_name, const video_SMPTE2022_6_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
+    // Get additional "video/SMPTE2022-6" parameters from the SDP parameters
     video_SMPTE2022_6_parameters get_video_SMPTE2022_6_parameters(const sdp_parameters& sdp_params);
 
-    // deprecated, construct "video/raw" SDP parameters with sensible defaults for unspecified fields
+    // deprecated, use make_video_raw_sdp_parameters
     inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const video_t& video, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
-        : sdp_parameters(session_name, sdp::media_types::video, {}, {}, {}, {}, {}, {}, media_stream_ids, ts_refclk)
-    {
-        set_video_raw_parameters(*this, video, payload_type);
-    }
+        : sdp_parameters(make_video_raw_sdp_parameters(session_name, video, payload_type, media_stream_ids, ts_refclk))
+    {}
 
-    // deprecated, construct "audio/L" SDP parameters with sensible defaults for unspecified fields
+    // deprecated, use make_audio_L_sdp_parameters
     inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const audio_t& audio, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
-        : sdp_parameters(session_name, sdp::media_types::audio, {}, {}, {}, {}, {}, {}, media_stream_ids, ts_refclk)
-    {
-        set_audio_L_parameters(*this, audio, payload_type);
-    }
+        : sdp_parameters(make_audio_L_sdp_parameters(session_name, audio, payload_type, media_stream_ids, ts_refclk))
+    {}
 
-    // deprecated, construct "video/smpte291" SDP parameters with sensible defaults for unspecified fields
+    // deprecated, use make_video_smpte291_sdp_parameters
     inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const data_t& data, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
-        : sdp_parameters(session_name, sdp::media_types::video, {}, {}, {}, {}, {}, {}, media_stream_ids, ts_refclk)
-    {
-        set_video_smpte291_parameters(*this, data, payload_type);
-    }
+        : sdp_parameters(make_video_smpte291_sdp_parameters(session_name, data, payload_type, media_stream_ids, ts_refclk))
+    {}
 
-    // deprecated, construct "video/SMPTE2022-6" SDP parameters with sensible defaults for unspecified fields
+    // deprecated, use make_video_SMPTE2022_6_sdp_parameters
     inline sdp_parameters::sdp_parameters(const utility::string_t& session_name, const mux_t& mux, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<ts_refclk_t>& ts_refclk)
-        : sdp_parameters(session_name, sdp::media_types::video, {}, {}, {}, {}, {}, {}, media_stream_ids, ts_refclk)
-    {
-        set_video_SMPTE2022_6_parameters(*this, mux, payload_type);
-    }
+        : sdp_parameters(make_video_SMPTE2022_6_sdp_parameters(session_name, mux, payload_type, media_stream_ids, ts_refclk))
+    {}
 }
 
 #endif

--- a/Development/sdp/json.h
+++ b/Development/sdp/json.h
@@ -206,9 +206,9 @@ namespace sdp
     }
 
     // make a named value (useful for format specific parameters)
-    inline web::json::value named_value(const utility::string_t& name, const utility::string_t& value)
+    inline web::json::value named_value(const utility::string_t& name, const utility::string_t& value, bool keep_order = true)
     {
-        return named_value(name, web::json::value::string(value));
+        return named_value(name, !value.empty() ? web::json::value::string(value) : web::json::value::null(), keep_order);
     }
 
     // find an array element with the specified name (useful with attributes and format specific parameters)


### PR DESCRIPTION
Refactor (and a few breaking interface changes) of _nmos/sdp_utils.{cpp,h}_ to tease apart format-agnostic SDP creation, parsing and validation from format-specific functionality.

This is intended to simplify future addition of support for `video/jxsv` and other media types mentioned in #213, whether within nmos-cpp or in application code for specific use cases.

### Details

1. `sdp_parameters` is now format-agnostic.
   It no longer includes any format (media type/subtype) specific fields, like `video.width`.
   Instead, the format-specific parameters for the `a=fmtp:` line are serialized to a vector of pairs of string in this object. (It can't be a map because some keys may appear multiple times, like `DID_SDID`.)
   Other common (RFC4566-defined) attributes that are likely to be used, like `a=ptime:`, `a=maxptime:` and `a=framerate:` are added to the format-agnostic struct, as is direct support for one bandwidth `b=` line.
2. There are now free functions to get and set typed format-specific parameters from/to the `fmtp`, `rtpmap` and other member variables.
   E.g. audio sample rate and channel count from the `m=` line, packet time from `a=ptime:`, and in the future, JPEG XS bit rate from the `b=` line.
   These are `make_<media type/subtype>_sdp_parameters` but `get_<media type/subtype>_parameters` rather than `parse_` because there are other members of `sdp_parameters` which are not reflected into the `<media type/subtype>_parameters` objects.

### Breaking interface changes

* Constructors of `sdp_parameters` that took `sdp_parameters::video_t`, `audio_t`, etc. are deprecated (so not a breaking change, yet!).
  Equivalent constructors for new media types should not be added in the future. The free function approach should be adopted. See below...
* Instead of `sdp.video`, `sdp.audio`, etc. application code must now use `get_video_raw_parameters(sdp)`, `get_audio_L_parameters(sdp)`, etc.
* `sdp_parameters::audio_t::sample_rate` is now a `uint64_t` rather than an `nmos::rational` to correspond more closely with the SDP spec and roundtrip better

### Adding a new media type

0. Create a struct `<media type/subtype>_parameters` with members for the necessary format parameters.
   You may not want to include everything mentioned in the IANA registration, but that's a good place to start.
   See e.g. `video_raw_parameters`.
1. Add `make_<media type/subtype>_parameters` which constructs the struct from info in the IS-04 resources and possibly commonly required additional info not carried in IS-04 resources (e.g. packet time for audio).
   See e.g. `make_video_raw_parameters`.
2. Add `make_<media type/subtype>_sdp_parameters` which constructs the format-agnostic `sdp_parameters` from the struct (and the non-transport, non-format-specific, parameters such as the SDP session name).
   This function can usually be very simple, for example building the rtpmap and fmtp from the `<media type/subtype>_parameters`.
   Also add an equivalent overload of `make_sdp_parameters`; should be a one-liner.
   See e.g. `make_video_raw_sdp_parameters`.
3. Add `get_<media type/subtype>_parameters` which constructs the struct from `sdp_parameters`.
   This function can usually be very simple, for example extracting the values for the `<media type/subtype>_parameters` from the rtpmap and fmtp.
   See e.g. `get_video_raw_parameters`.
4. Support creation of SDP files of the new format based on the IS-04 resources.
   Within the nmos-cpp library this would be done by updating the `nmos::make_sdp_parameters` overload to use the new `make_<media type/subtype>_sdp_parameters` function.
   This nmos-cpp library function obviously couldn't be updated by application code, but since this function is only called from application code, such applications would use their own function for the application-specific media types instead.
5. Support the new format for validation of SDP files for receiver capabilities.
   Within the nmos-cpp library, this would be done by updating `nmos::validate_sdp_parameters`.
   This nmos-cpp library function couldn't be updated by application code. It _is_ called by a library function, `nmos::parse_rtp_transport_file`, but since _that_ function isn't used if the application provides an `nmos::transport_file_parser`. An application can use `nmos::details::parse_rtp_transport_file` which now provides a way for application code to easily plug in the application-specific SDP parameters validation.
