### PR TITLE
Poison json value init from e.g. char*

### DIFF
--- a/Development/cpprest/json_ops.h
+++ b/Development/cpprest/json_ops.h
@@ -375,6 +375,10 @@ namespace web
                 value_init(bool b) : value(b) {}
                 value_init(utility::string_t s) : value(std::move(s)) {}
                 value_init(const utility::char_t* s) : value(s) {}
+
+            private:
+                // this prevents the surprising implicit conversion from e.g. char* to bool
+                template <typename T> value_init(T*) = delete;
             };
         }
 


### PR DESCRIPTION
The following test case currently fails, because `char*` is implicitly converted to `bool`.

```C++
#include "cpprest/json_ops.h"

#include "bst/test/test.h"

////////////////////////////////////////////////////////////////////////////////////////////
BST_TEST_CASE(testJsonValueOfPointer)
{
    using web::json::value_of;

    char* foo = "bar";

    // ...

    const auto value = value_of({
        { U("foo"), foo }
    });

    BST_REQUIRE(value.at(U("foo")).is_string());
}
```

What was probably intended was:
```diff
<        { U("foo"), foo }
---
>        { U("foo"), utility::us2s(foo) }
```

After this PR, this would be a compile-time error, e.g.
```
error C2280: 'web::json::details::value_init::value_init<char>(T *)': attempting to reference a deleted function
        with
        [
            T=char
        ]
```

Since this makes it a compile-time error, I haven't added the test case in this PR!
