### PR TITLE
throw is simpler than std::rethrow_exception(std::current_exception())

### DIFF
--- a/Development/nmos/api_utils.cpp
+++ b/Development/nmos/api_utils.cpp
@@ -603,7 +603,7 @@ namespace nmos
             nmos::api_gate gate(gate_, req, parameters);
             try
             {
-                std::rethrow_exception(std::current_exception());
+                throw;
             }
             // assume a JSON error indicates a bad request
             catch (const web::json::json_exception& e)


### PR DESCRIPTION
Why use two library functions and 48 characters when you can use zero and five?
Not sure what I was thinking tbh.