### PR TITLE
Urgent fix for Conan build on GCC 5

### DIFF
--- a/Development/nmos-cpp-node/main.cpp
+++ b/Development/nmos-cpp-node/main.cpp
@@ -143,12 +143,7 @@ int main(int argc, char* argv[])
     catch (const std::ios_base::failure& e)
     {
         // most likely from failing to open the command line settings file
-        slog::log<slog::severities::error>(gate, SLOG_FLF) << "File error: " << e.what()
-#if !defined(__GNUC__) || __GNUC__ > 4
-            // std::ios_base::failure doesn't derive from std::system_error until GCC 5
-            << " [" << e.code() << "]"
-#endif
-            ;
+        slog::log<slog::severities::error>(gate, SLOG_FLF) << "File error: " << e.what();
         return 1;
     }
     catch (const std::system_error& e)

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -183,7 +183,7 @@ void node_implementation_thread(nmos::node_model& model, slog::base_gate& gate_)
     }
     catch (const web::json::json_exception& e)
     {
-        // most likely from incorrect syntax or incorrect value types in the command line settings
+        // most likely from incorrect value types in the command line settings
         slog::log<slog::severities::error>(gate, SLOG_FLF) << "JSON error: " << e.what();
     }
     catch (const std::system_error& e)


### PR DESCRIPTION
See https://github.com/conan-io/conan-center-index/pull/8895#issuecomment-1015724194.
And the gory details in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145.
Successful compilation, e.g. https://godbolt.org/x/qr1Yf7oo1, demonstrates that `std::ios_base::failure` _is_ derived from `std::system_error` in some environments with GCC 5, but since the error code is rarely useful, it's pragmatic just to delete this troublesome line of code.

(Oh, and a comment fix I had lying around.)