### PR TITLE
Resurrect Ubuntu 14.04

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -458,11 +458,15 @@ jobs:
       run: |
         apt-get update -q
         apt-get install -y software-properties-common
-        add-apt-repository ppa:deadsnakes/ppa -y
         apt-get --allow-unauthenticated update -q
-        apt-get --allow-unauthenticated install -y curl g++ git make patch python3.6 python3.6-gdbm bsdmainutils dnsutils unzip
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 3
-        ln -s /usr/bin/python3.6 /usr/bin/python
+        apt-get --allow-unauthenticated install -y curl g++ git make patch zlib1g-dev libssl-dev bsdmainutils dnsutils unzip
+        curl -sS https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tar.xz | tar -xJ
+        cd Python-3.6.9
+        ./configure
+        make -j8
+        make install
+        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.6 3
+        ln -s /usr/local/bin/python3.6 /usr/bin/python
         curl -sS https://bootstrap.pypa.io/get-pip.py | python
         curl -sS https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-x64.tar.xz | tar -xJ
         echo "`pwd`/node-v12.16.2-linux-x64/bin" >> $GITHUB_PATH

--- a/.github/workflows/src/build-test.yml
+++ b/.github/workflows/src/build-test.yml
@@ -96,11 +96,15 @@ jobs:
       run: |
         apt-get update -q
         apt-get install -y software-properties-common
-        add-apt-repository ppa:deadsnakes/ppa -y
         apt-get --allow-unauthenticated update -q
-        apt-get --allow-unauthenticated install -y curl g++ git make patch python3.6 python3.6-gdbm bsdmainutils dnsutils unzip
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 3
-        ln -s /usr/bin/python3.6 /usr/bin/python
+        apt-get --allow-unauthenticated install -y curl g++ git make patch zlib1g-dev libssl-dev bsdmainutils dnsutils unzip
+        curl -sS https://www.python.org/ftp/python/3.6.9/Python-3.6.9.xz | tar -xJ
+        cd Python-3.6.3
+        ./configure
+        make -j8
+        make install
+        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.6 3
+        ln -s /usr/local/bin/python3.6 /usr/bin/python
         curl -sS https://bootstrap.pypa.io/get-pip.py | python
         curl -sS https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-x64.tar.xz | tar -xJ
         echo "`pwd`/node-v12.16.2-linux-x64/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Since deadsnakes/ppa retired all support for Ubuntu 14.04 and 16.04 on 15 Jan 2022, reasonably enough because these OS are end of life, build python 3.6 from sources