### PR TITLE
Fix Ubuntu 14.04 build again, per latest pip instructions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -465,7 +465,7 @@ jobs:
         make install
         update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.6 3
         ln -s /usr/local/bin/python3.6 /usr/bin/python
-        curl -sS https://bootstrap.pypa.io/get-pip.py | python
+        curl -sS https://bootstrap.pypa.io/pip/3.6/get-pip.py | python
         curl -sS https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-x64.tar.xz | tar -xJ
         echo "`pwd`/node-v12.16.2-linux-x64/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/src/build-test.yml
+++ b/.github/workflows/src/build-test.yml
@@ -105,7 +105,7 @@ jobs:
         make install
         update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.6 3
         ln -s /usr/local/bin/python3.6 /usr/bin/python
-        curl -sS https://bootstrap.pypa.io/get-pip.py | python
+        curl -sS https://bootstrap.pypa.io/pip/3.6/get-pip.py | python
         curl -sS https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-x64.tar.xz | tar -xJ
         echo "`pwd`/node-v12.16.2-linux-x64/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
"ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead."