### PR TITLE
Add YCbCr 4:4:4 and YCbCr 4:2:0 subsamplings

### DIFF
--- a/Development/nmos/components.cpp
+++ b/Development/nmos/components.cpp
@@ -29,10 +29,22 @@ namespace nmos
                 make_component(component_names::B, frame_width, frame_height, bit_depth)
             });
         case YCbCr422:
-            return  value_of({
+            return value_of({
                 make_component(component_names::Y, frame_width, frame_height, bit_depth),
                 make_component(component_names::Cb, frame_width / 2, frame_height, bit_depth),
                 make_component(component_names::Cr, frame_width / 2, frame_height, bit_depth)
+            });
+        case YCbCr444:
+            return value_of({
+                make_component(component_names::Y, frame_width, frame_height, bit_depth),
+                make_component(component_names::Cb, frame_width, frame_height, bit_depth),
+                make_component(component_names::Cr, frame_width, frame_height, bit_depth)
+            });
+        case YCbCr420:
+            return value_of({
+                make_component(component_names::Y, frame_width, frame_height, bit_depth),
+                make_component(component_names::Cb, frame_width / 2, frame_height / 2, bit_depth),
+                make_component(component_names::Cr, frame_width / 2, frame_height / 2, bit_depth)
             });
         default:
             return web::json::value::null();

--- a/Development/nmos/components.h
+++ b/Development/nmos/components.h
@@ -37,7 +37,7 @@ namespace nmos
 
     web::json::value make_component(const nmos::component_name& name, unsigned int width, unsigned int height, unsigned int bit_depth);
 
-    enum chroma_subsampling : int { YCbCr422, RGB444 };
+    enum chroma_subsampling : int { YCbCr422, RGB444, YCbCr444, YCbCr420 };
     // deprecated, see overload with sdp::sampling in nmos/sdp_utils.h
     web::json::value make_components(chroma_subsampling chroma_subsampling = YCbCr422, unsigned int frame_width = 1920, unsigned int frame_height = 1080, unsigned int bit_depth = 10);
 }


### PR DESCRIPTION
This PR adds YCbCr 4:4:4 and YCbCr 4:2:0 subsamplings to the end of `chroma_subsampling` enum to not break numeration.