### PR TITLE
Test unicast DNS-SD as well as multicast, with both Avahi and mDNSResponder, on Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,13 +23,20 @@ jobs:
         force_cpprest_asio: [false]
         dns_sd_mode: [multicast, unicast]
         exclude:
+          # install_mdns is only meaningful on Linux
           - os: macos-11
             install_mdns: true
           - os: windows-2019
             install_mdns: true
+          # for now, unicast DNS-SD tests are only implemented on Linux
           - os: macos-11
             dns_sd_mode: unicast
           - os: windows-2019
+            dns_sd_mode: unicast
+          # for now, exclude unicast DNS-SD with mDNSResponder due to
+          # intermittent *** buffer overflow detected *** in mdnsd
+          - os: ubuntu-20.04
+            install_mdns: true
             dns_sd_mode: unicast
         include:
           - os: windows-2019

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -444,8 +444,8 @@ jobs:
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
             echo "Restarting mdnsd"
-            #sudo /etc/init.d/mdns start
-            sudo /usr/sbin/mdnsd -debug &
+            sudo /etc/init.d/mdns start
+            #sudo /usr/sbin/mdnsd -debug &
             sleep 2
 
             dns-sd -V
@@ -948,8 +948,8 @@ jobs:
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
             echo "Restarting mdnsd"
-            #sudo /etc/init.d/mdns start
-            sudo /usr/sbin/mdnsd -debug &
+            sudo /etc/init.d/mdns start
+            #sudo /usr/sbin/mdnsd -debug &
             sleep 2
 
             dns-sd -V

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -332,7 +332,7 @@ jobs:
         # Configure the Testing Tool so all APIs are tested with TLS
         printf "from . import Config as CONFIG\nCONFIG.ENABLE_HTTPS = True\n" > nmostesting/UserConfig.py
         # Set the DNS-SD mode
-        printf 'CONFIG.DNS_SD_MODE = "${{ matrix.dns_sd_mode }}"\n' >> nmostesting/UserConfig.py
+        printf 'CONFIG.DNS_SD_MODE = "'${{ matrix.dns_sd_mode }}'"\n' >> nmostesting/UserConfig.py
 
         # Download testssl
         cd testssl
@@ -421,7 +421,12 @@ jobs:
             # force testing tool to cache specification repos before changing the resolver configuration
             $run_python nmos-test.py suite IS-04-01 --selection auto --host ${{ env.HOST_IP_ADDRESS }} --port 444 --version v1.3 || true
             # change the resolver configuration to use only the testing tool's mock DNS server
+            # and instead configure the mock DNS server to use an upstream DNS server
             # as unicast DNS-SD test results are inconsistent if other servers are also configured
+            dns_upstream_ip=$(cat /etc/resolv.conf | grep ^nameserver | tr -s [:space:] ' ' | cut -f2 -d ' ' -s)
+            if [[ ! -z "$dns_upstream_ip" ]]; then
+              printf 'CONFIG.DNS_UPSTREAM_IP = "'${dns_upstream_ip}'"\n' >> nmostesting/UserConfig.py
+            fi
             sudo cp /etc/resolv.conf /etc/resolv.conf.bak
             echo -e "nameserver ${{ env.HOST_IP_ADDRESS }}" | sudo tee /etc/resolv.conf > /dev/null
           else
@@ -831,7 +836,7 @@ jobs:
         # Configure the Testing Tool so all APIs are tested with TLS
         printf "from . import Config as CONFIG\nCONFIG.ENABLE_HTTPS = True\n" > nmostesting/UserConfig.py
         # Set the DNS-SD mode
-        printf 'CONFIG.DNS_SD_MODE = "${{ matrix.dns_sd_mode }}"\n' >> nmostesting/UserConfig.py
+        printf 'CONFIG.DNS_SD_MODE = "'${{ matrix.dns_sd_mode }}'"\n' >> nmostesting/UserConfig.py
 
         # Download testssl
         cd testssl
@@ -920,7 +925,12 @@ jobs:
             # force testing tool to cache specification repos before changing the resolver configuration
             $run_python nmos-test.py suite IS-04-01 --selection auto --host ${{ env.HOST_IP_ADDRESS }} --port 444 --version v1.3 || true
             # change the resolver configuration to use only the testing tool's mock DNS server
+            # and instead configure the mock DNS server to use an upstream DNS server
             # as unicast DNS-SD test results are inconsistent if other servers are also configured
+            dns_upstream_ip=$(cat /etc/resolv.conf | grep ^nameserver | tr -s [:space:] ' ' | cut -f2 -d ' ' -s)
+            if [[ ! -z "$dns_upstream_ip" ]]; then
+              printf 'CONFIG.DNS_UPSTREAM_IP = "'${dns_upstream_ip}'"\n' >> nmostesting/UserConfig.py
+            fi
             sudo cp /etc/resolv.conf /etc/resolv.conf.bak
             echo -e "nameserver ${{ env.HOST_IP_ADDRESS }}" | sudo tee /etc/resolv.conf > /dev/null
           else

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,28 +12,31 @@ env:
   SECRET_RESULTS_SHEET_ID: ${{ secrets.RESULTS_SHEET_ID }}
 jobs:
   build_and_test:
-    name: '${{ matrix.os }}: build and test (install mdns: ${{ matrix.install_mdns }}, use conan: ${{ matrix.use_conan }}, force cpprest asio: ${{ matrix.force_cpprest_asio }})'
+    name: '${{ matrix.os }}: build and test (install mdns: ${{ matrix.install_mdns }}, use conan: ${{ matrix.use_conan }}, force cpprest asio: ${{ matrix.force_cpprest_asio }}, dns-sd mode: ${{ matrix.dns_sd_mode}})'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
-        install_mdns: [false]
+        os: [ubuntu-20.04, macos-11, windows-2019]
+        install_mdns: [false, true]
         use_conan: [true]
         force_cpprest_asio: [false]
+        dns_sd_mode: [multicast, unicast]
+        exclude:
+          - os: macos-11
+            install_mdns: true
+          - os: windows-2019
+            install_mdns: true
+          - os: macos-11
+            dns_sd_mode: unicast
+          - os: windows-2019
+            dns_sd_mode: unicast
         include:
-          - install_mdns: true
-            use_conan: true
-            force_cpprest_asio: false
-            os: ubuntu-18.04
-          - install_mdns: true
-            use_conan: true
-            force_cpprest_asio: false
-            os: ubuntu-20.04
-          - install_mdns: false
+          - os: windows-2019
+            install_mdns: false
             use_conan: true
             force_cpprest_asio: true
-            os: windows-latest
+            dns_sd_mode: multicast
 
     steps:
     - uses: actions/checkout@v2
@@ -43,9 +46,9 @@ jobs:
       run: |
         if [[ "${{ runner.os }}"  == "Linux" ]]; then
           if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
-            echo "BUILD_NAME=${{ matrix.os }}_mdns" >> $GITHUB_ENV
+            echo "BUILD_NAME=${{ matrix.os }}_mdns_${{ matrix.dns_sd_mode }}" >> $GITHUB_ENV
           else
-            echo "BUILD_NAME=${{ matrix.os }}_avahi" >> $GITHUB_ENV
+            echo "BUILD_NAME=${{ matrix.os }}_avahi_${{ matrix.dns_sd_mode }}" >> $GITHUB_ENV
           fi
         elif [[ "${{ matrix.force_cpprest_asio }}" == "true" ]]; then
           echo "BUILD_NAME=${{ matrix.os }}_asio" >> $GITHUB_ENV
@@ -74,16 +77,16 @@ jobs:
         mkdir -p gdrive
         echo "${{ env.SECRET_GOOGLE_CREDENTIALS }}" | openssl base64 -d -A -out gdrive/credentials.json
         echo "GDRIVE_CREDENTIALS=`pwd`/gdrive/credentials.json" >> $GITHUB_ENV
-    
+
     - name: install conan
       if: matrix.use_conan == true
       run: |
         pip install conan
         conan config set general.revisions_enabled=1
-    
+
     - name: install cmake
       uses: lukka/get-cmake@v3.21.1
-    
+
     - name: setup bash path
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       shell: bash
@@ -91,7 +94,7 @@ jobs:
         # translate GITHUB_WORKSPACE into a bash path from a windows path
         workspace_dir=`pwd`
         echo "GITHUB_WORKSPACE_BASH=${workspace_dir}" >> $GITHUB_ENV
-    
+
     - name: windows setup
       if: runner.os == 'Windows'
       run: |
@@ -109,7 +112,7 @@ jobs:
         ).IPv4Address.IPAddress
         echo "HOST_IP_ADDRESS=$env:hostip" >> $env:GITHUB_ENV
         ipconfig
-        # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
+        # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode
         # and avoid SSL Error: WINHTTP_CALLBACK_STATUS_FLAG_CERT_REV_FAILED failed to check revocation status.
         Add-Content $env:WINDIR\System32\Drivers\Etc\Hosts "`n$env:hostip crl.testsuite.nmos.tv`n"
         # add nmos-api.local to hosts to workaround mDNS lookups on windows being very slow and causing the AMWA test suite to take 2-3 hours to complete
@@ -118,7 +121,7 @@ jobs:
         Add-Content $env:WINDIR\System32\Drivers\Etc\Hosts "`n$env:hostip nmos-mocks.local`n"
         # Configure SCHANNEL, e.g. to disable TLS 1.0 and TLS 1.1
         reg import ${{ env.GITHUB_WORKSPACE }}/Sandbox/configure_schannel.reg
-    
+
     - name: windows install bonjour
       if: runner.os == 'Windows'
       run: |
@@ -126,7 +129,7 @@ jobs:
         curl -L https://download.info.apple.com/Mac_OS_X/061-8098.20100603.gthyu/BonjourPSSetup.exe -o BonjourPSSetup.exe -q
         & 7z.exe e BonjourPSSetup.exe Bonjour64.msi -y
         msiexec /i ${{ env.GITHUB_WORKSPACE }}\Bonjour64.msi /qn /norestart
-    
+
     - name: mac setup
       if: runner.os == 'macOS'
       run: |
@@ -137,11 +140,11 @@ jobs:
         ifconfig
         echo "CTEST_EXTRA_ARGS=$CTEST_EXTRA_ARGS -E testMdnsResolveAPIs" >> $GITHUB_ENV
         echo "CTEST_EXPECTED_FAILURES=$CTEST_EXPECTED_FAILURES -R testMdnsResolveAPIs" >> $GITHUB_ENV
-        # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
-        echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts
+        # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode
+        echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts > /dev/null
         # testssl.sh needs "timeout"
         brew install coreutils
-    
+
     - name: mac docker install
       # installs docker on a mac runner. Github's documentation states docker is already available so this shouldn't be necessary
       # can be used to run AWMA test suite but test suite doesn't seem to be able to communicate with nodes running on the host
@@ -167,7 +170,7 @@ jobs:
         echo "DOCKER_TLS_VERIFY=$DOCKER_TLS_VERIFY" >> $GITHUB_ENV
         echo "DOCKER_HOST=$DOCKER_HOST" >> $GITHUB_ENV
         echo "DOCKER_CERT_PATH=$DOCKER_CERT_PATH" >> $GITHUB_ENV
-    
+
     - name: ubuntu setup
       if: runner.os == 'Linux'
       run: |
@@ -175,11 +178,11 @@ jobs:
         hostip=$(hostname -I | cut -f1 -d' ')
         echo "HOST_IP_ADDRESS=$hostip" >> $GITHUB_ENV
         ip address
-        # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
-        echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts
+        # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode
+        echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts > /dev/null
         # re-synchronize the package index
         sudo apt-get update -q
-    
+
     - name: ubuntu mdns install
       if: runner.os == 'Linux' && matrix.install_mdns == true
       run: |
@@ -200,7 +203,7 @@ jobs:
         fi
         # force dependency on mDNSResponder
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_AVAHI:BOOL=\"0\"" >> $GITHUB_ENV
-    
+
     - name: ubuntu non-conan setup
       if: runner.os == 'Linux' && matrix.use_conan == false
       run: |
@@ -214,7 +217,7 @@ jobs:
           libboost-filesystem-dev \
           openssl \
           libssl-dev
-    
+
         cd ${{ env.RUNNER_WORKSPACE }}
         git clone --recurse-submodules --branch v2.10.18 https://github.com/Microsoft/cpprestsdk
         cd cpprestsdk/Release
@@ -222,15 +225,15 @@ jobs:
         cd build
         cmake .. -DCMAKE_BUILD_TYPE:STRING="Release" -DWERROR:BOOL="0" -DBUILD_SAMPLES:BOOL="0" -DBUILD_TESTS:BOOL="0"
         make -j 2 && sudo make install
-    
+
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DWEBSOCKETPP_INCLUDE_DIR:PATH=\"${{ env.RUNNER_WORKSPACE }}/cpprestsdk/Release/libs/websocketpp\"" >> $GITHUB_ENV
-    
+
     - name: disable conan
       if: matrix.use_conan == false
       shell: bash
       run: |
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_CONAN:BOOL=\"0\"" >> $GITHUB_ENV
-    
+
     - name: ubuntu avahi setup
       if: runner.os == 'Linux' && matrix.install_mdns == false
       run: |
@@ -244,13 +247,13 @@ jobs:
         sudo apt-get install -f nscd
         # force dependency on avahi
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_AVAHI:BOOL=\"1\"" >> $GITHUB_ENV
-    
+
     - name: force cpprest asio
       if: matrix.force_cpprest_asio == true
       shell: bash
       run: |
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_CONAN_OPTIONS:STRING=\"cpprestsdk:http_client_impl=asio;cpprestsdk:http_listener_impl=asio\"" >> $GITHUB_ENV
-    
+
     - uses: ilammy/msvc-dev-cmd@v1
     - name: build
       uses: lukka/run-cmake@v3.4
@@ -259,20 +262,19 @@ jobs:
         cmakeListsTxtPath: '${{ env.GITHUB_WORKSPACE }}/Development/CMakeLists.txt'
         buildDirectory: '${{ env.RUNNER_WORKSPACE }}/build/'
         cmakeAppendedArgs: '-GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${{ env.RUNNER_WORKSPACE }}/install" ${{ env.CMAKE_EXTRA_ARGS }}'
-    
+
     - name: unit test
       run: |
         cd ${{ env.RUNNER_WORKSPACE }}/build/
         ctest --output-on-failure ${{ env.CTEST_EXTRA_ARGS }}
-    
+
     - name: expected unit test failures
       if: env.CTEST_EXPECTED_FAILURES != null
       continue-on-error: true
       run: |
         cd ${{ env.RUNNER_WORKSPACE }}/build/
         ctest --output-on-failure ${{ env.CTEST_EXPECTED_FAILURES }}
-    
-    
+
     - name: install
       uses: lukka/run-cmake@v3.4
       with:
@@ -280,13 +282,13 @@ jobs:
         cmakeListsTxtPath: '${{ env.GITHUB_WORKSPACE }}/Development/CMakeLists.txt'
         buildDirectory: '${{ env.RUNNER_WORKSPACE }}/build/'
         buildWithCMakeArgs: '--target install'
-    
+
     - name: set install test environment variable
       shell: bash
       run: |
         # replace backslashes with forward slashes on Windows
         echo "CMAKE_WORKSPACE=${RUNNER_WORKSPACE//\\/\/}" >> $GITHUB_ENV
-    
+
     - name: install test
       uses: lukka/run-cmake@v3.4
       with:
@@ -300,12 +302,12 @@ jobs:
             -DCMAKE_PREFIX_PATH="${{ env.CMAKE_WORKSPACE }}/install"
             -DCMAKE_INSTALL_PREFIX="${{ env.CMAKE_WORKSPACE }}/build"
             ${{ env.CMAKE_EXTRA_ARGS }}'
-    
+
     - name: install test log
       run: |
         # dump the log file created in Sandbox/my-nmos-node/CMakeLists.txt
         cat ${{ env.RUNNER_WORKSPACE }}/build-my-nmos-node/my-nmos-node_include-release.txt
-    
+
     - name: install wsl
       if: runner.os == 'Windows'
       run: |
@@ -314,7 +316,7 @@ jobs:
         Expand-Archive .\ubuntu-1804.zip .\ubuntu-1804
         cd ubuntu-1804
         .\ubuntu1804.exe install --root
-    
+
     - name: AMWA test suite
       shell: bash
       working-directory: ${{ env.RUNNER_WORKSPACE }}
@@ -322,93 +324,134 @@ jobs:
         |
         set -x
         root_dir=`pwd`
-    
+
         # Install AMWA NMOS Testing Tool
         git clone https://github.com/AMWA-TV/nmos-testing.git
         cd nmos-testing
-    
+
         # Configure the Testing Tool so all APIs are tested with TLS
         printf "from . import Config as CONFIG\nCONFIG.ENABLE_HTTPS = True\n" > nmostesting/UserConfig.py
-    
+        # Set the DNS-SD mode
+        printf 'CONFIG.DNS_SD_MODE = "${{ matrix.dns_sd_mode }}"\n' >> nmostesting/UserConfig.py
+
         # Download testssl
         cd testssl
-        curl -L https://github.com/drwetter/testssl.sh/archive/3.0.2.tar.gz | tar -xvzf - --strip-components=1
+        curl -L https://github.com/drwetter/testssl.sh/archive/3.0.2.tar.gz -s | tar -xvzf - --strip-components=1 > /dev/null
         cd ..
-    
+
         # Create output directories
         mkdir results
         mkdir badges
-    
+
         if [[ "${{ env.DOCKER_TEST_SUITE }}" == "true" ]]; then
           # run test suite in amwa/nmos-testing docker container
           docker pull amwa/nmos-testing
           docker run -d --name "nmos_testing" --entrypoint="/usr/bin/tail" -v `pwd`/results:/home/nmos-testing/results amwa/nmos-testing -f /dev/null
           run_python="docker exec -i nmos_testing python3"
-        elif  [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
+        elif [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
           # run test suite in vagrant VM
           cp ${{ env.GITHUB_WORKSPACE_BASH }}/.github/workflows/mac_Vagrantfile ./Vagrantfile
           vagrant plugin install vagrant-scp
           vagrant up
           vagrant ssh -- mkdir results
           run_python="vagrant ssh -- python3"
+        elif [[ "${{ runner.os }}" == "Linux" && "${{ matrix.dns_sd_mode }}" == "unicast" ]]; then
+          # run test suite directly
+          sudo pip install --upgrade -r requirements.txt
+          # install SDPoker
+          npm install -g git+https://git@github.com/AMWA-TV/sdpoker.git
+          run_python="sudo python"
         else
           # run test suite directly
           pip install -r requirements.txt
-    
-          # Install SDPoker
+          # install SDPoker
           npm install -g git+https://git@github.com/AMWA-TV/sdpoker.git
           run_python="python"
         fi
         pip install -r utilities/run-test-suites/gsheetsImport/requirements.txt
-        
-        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
             certutil -enterprise -addstore -user root test_data\\BCP00301\\ca\\certs\\ca.cert.pem
             certutil -enterprise -addstore -user ca test_data\\BCP00301\\ca\\intermediate\\certs\\intermediate.cert.pem
             certutil -importpfx -enterprise test_data\\BCP00301\\ca\\intermediate\\certs\\ecdsa.api.testsuite.nmos.tv.cert.chain.pfx
             certutil -importpfx -enterprise test_data\\BCP00301\\ca\\intermediate\\certs\\rsa.api.testsuite.nmos.tv.cert.chain.pfx
-    
+
             # RSA
             netsh http add sslcert ipport=0.0.0.0:1080 certhash=021d50df2177c07095485184206ee2297e50b65c appid="{00000000-0000-0000-0000-000000000000}"
             # ECDSA
             #netsh http add sslcert ipport=0.0.0.0:1080 certhash=875eca592c49120254b32bb8bed90ac3679015a5 appid="{00000000-0000-0000-0000-000000000000}"
-    
+
             # RSA
             netsh http add sslcert ipport=0.0.0.0:8088 certhash=021d50df2177c07095485184206ee2297e50b65c appid="{00000000-0000-0000-0000-000000000000}"
             # ECDSA
             #netsh http add sslcert ipport=0.0.0.0:8088 certhash=875eca592c49120254b32bb8bed90ac3679015a5 appid="{00000000-0000-0000-0000-000000000000}"
         fi
-    
-        if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
           # force DNS lookups to IPv4 as mDNS lookups on macos seem to wait for the IPv6 lookup to timeout before returning the IPv4 result
           mv nmostesting/GenericTest.py nmostesting/GenericTest.py.old
           printf 'import socket\nold_getaddrinfo = socket.getaddrinfo\ndef new_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):\n    return old_getaddrinfo(host, port, socket.AF_INET, type, proto, flags)\nsocket.getaddrinfo = new_getaddrinfo\n' > nmostesting/GenericTest.py
           cat nmostesting/GenericTest.py.old >> nmostesting/GenericTest.py
         fi
-    
-        if [[ "${{ runner.os }}" == "Linux" && "${{ matrix.install_mdns }}" == "false" ]]; then
-          # nmos-cpp-node doesn't currently support advertising hostnames to Avahi
-          avahi-publish -a -R nmos-api.local ${{ env.HOST_IP_ADDRESS }} &
-        fi
-    
+
         if [[ "${{ runner.os }}" == "Linux" && "${{ matrix.use_conan }}" == "false" ]]; then
           # ubuntu 14 non-conan build uses boost 1.54.0 which doesn't support disabling TLS 1.1
           mkdir -p ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/nmos-testing-options/
           echo "--ignore test_01" > ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/nmos-testing-options/BCP-003-01.txt
           echo "1" > ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/nmos-testing-options/BCP-003-01_max_disabled.txt
         fi
-    
-        ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
-    
+
+        if [[ "${{ matrix.dns_sd_mode }}" == "multicast" ]]; then
+          domain=local
+        else
+          domain=testsuite.nmos.tv
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            # add host names
+            echo -e "${{ env.HOST_IP_ADDRESS }} api.$domain\n${{ env.HOST_IP_ADDRESS }} mocks.$domain" | sudo tee -a /etc/hosts > /dev/null
+            # force testing tool to cache specification repos before changing the resolver configuration
+            $run_python nmos-test.py suite IS-04-01 --selection auto --host ${{ env.HOST_IP_ADDRESS }} --port 444 --version v1.3 || true
+            # change the resolver configuration to use only the testing tool's mock DNS server
+            # as unicast DNS-SD test results are inconsistent if other servers are also configured
+            sudo cp /etc/resolv.conf /etc/resolv.conf.bak
+            echo -e "nameserver ${{ env.HOST_IP_ADDRESS }}" | sudo tee /etc/resolv.conf > /dev/null
+            if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+              echo "Restarting mdnsd"
+              sudo /etc/init.d/mdns restart
+              sleep 2
+            else
+              echo "Restarting avahi-daemon"
+              sudo systemctl restart avahi-daemon
+              sleep 2
+            fi
+          else
+            echo "Unicast DNS-SD testing not yet supported on ${{ runner.os }}" && false
+          fi
+        fi
+
+        if [[ "${{ runner.os }}" == "Linux" && "${{ matrix.install_mdns }}" == "false" ]]; then
+          # nmos-cpp-node doesn't currently support advertising hostnames to Avahi
+          avahi-publish -a -R nmos-api.local ${{ env.HOST_IP_ADDRESS }} &
+        fi
+
+        ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
+
+        if [[ "${{ matrix.dns_sd_mode }}" == "unicast" ]]; then
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            # restore DNS Server
+            cat /etc/resolv.conf.bak | sudo tee /etc/resolv.conf > /dev/null
+          fi
+        fi
+
         if [[ "${{ env.DOCKER_TEST_SUITE }}" == "true" ]]; then
           docker stop nmos_testing
           docker rm nmos_testing
         fi
-        if  [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
+        if [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
           vagrant scp :results/* results/
           vagrant destroy -f
         fi
         exit 0
-    
+
     - name: upload to google sheets
       if: github.ref == 'refs/heads/master' && github.event_name == 'push'
       working-directory: ${{ env.RUNNER_WORKSPACE }}
@@ -416,12 +459,12 @@ jobs:
       run: |
         export SHEET=https://docs.google.com/spreadsheets/d/${{ env.SECRET_RESULTS_SHEET_ID }}
         python nmos-testing/utilities/run-test-suites/gsheetsImport/resultsImporter.py --credentials ${{ env.GDRIVE_CREDENTIALS }} --sheet "$SHEET" --insert --json nmos-testing/results/${{ env.GITHUB_COMMIT }}-*.json || echo "upload failed"
-    
+
     - uses: actions/upload-artifact@v1
       with:
         name: ${{ env.BUILD_NAME }}_badges
         path: ${{ runner.workspace }}/nmos-testing/badges
-    
+
     - uses: actions/upload-artifact@v1
       with:
         name: ${{ env.BUILD_NAME }}_results
@@ -429,22 +472,36 @@ jobs:
 
 
   build_and_test_ubuntu_14:
-    name: 'ubuntu-14.04: build and test (install mdns: ${{ matrix.install_mdns }}, use conan: ${{ matrix.use_conan }})'
-    runs-on: ubuntu-latest
+    name: '${{ matrix.os }}: build and test (install mdns: ${{ matrix.install_mdns }}, use conan: ${{ matrix.use_conan }}, force cpprest asio: ${{ matrix.force_cpprest_asio }}, dns-sd mode: ${{ matrix.dns_sd_mode}})'
+    runs-on: ubuntu-20.04
     container:
       image: ubuntu:14.04
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-14.04]
         install_mdns: [true]
         use_conan: [false]
+        force_cpprest_asio: [false]
+        dns_sd_mode: [multicast]
 
     steps:
     - uses: actions/checkout@v2
 
     - name: set environment variables
+      shell: bash
       run: |
-        echo "BUILD_NAME=ubuntu-14.04_mdns" >> $GITHUB_ENV
+        if [[ "${{ runner.os }}"  == "Linux" ]]; then
+          if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+            echo "BUILD_NAME=${{ matrix.os }}_mdns_${{ matrix.dns_sd_mode }}" >> $GITHUB_ENV
+          else
+            echo "BUILD_NAME=${{ matrix.os }}_avahi_${{ matrix.dns_sd_mode }}" >> $GITHUB_ENV
+          fi
+        elif [[ "${{ matrix.force_cpprest_asio }}" == "true" ]]; then
+          echo "BUILD_NAME=${{ matrix.os }}_asio" >> $GITHUB_ENV
+        else
+          echo "BUILD_NAME=${{ matrix.os }}" >> $GITHUB_ENV
+        fi
         GITHUB_COMMIT=`echo "${{ github.sha }}" | cut -c1-7`
         echo "GITHUB_COMMIT=$GITHUB_COMMIT" >> $GITHUB_ENV
         # github.workspace points to the host path not the docker path, the home directory defaults to the workspace directory
@@ -477,16 +534,16 @@ jobs:
         mkdir -p gdrive
         echo "${{ env.SECRET_GOOGLE_CREDENTIALS }}" | openssl base64 -d -A -out gdrive/credentials.json
         echo "GDRIVE_CREDENTIALS=`pwd`/gdrive/credentials.json" >> $GITHUB_ENV
-    
+
     - name: install conan
       if: matrix.use_conan == true
       run: |
         pip install conan
         conan config set general.revisions_enabled=1
-    
+
     - name: install cmake
       uses: lukka/get-cmake@v3.21.1
-    
+
     - name: setup bash path
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       shell: bash
@@ -494,7 +551,7 @@ jobs:
         # translate GITHUB_WORKSPACE into a bash path from a windows path
         workspace_dir=`pwd`
         echo "GITHUB_WORKSPACE_BASH=${workspace_dir}" >> $GITHUB_ENV
-    
+
     - name: windows setup
       if: runner.os == 'Windows'
       run: |
@@ -512,7 +569,7 @@ jobs:
         ).IPv4Address.IPAddress
         echo "HOST_IP_ADDRESS=$env:hostip" >> $env:GITHUB_ENV
         ipconfig
-        # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
+        # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode
         # and avoid SSL Error: WINHTTP_CALLBACK_STATUS_FLAG_CERT_REV_FAILED failed to check revocation status.
         Add-Content $env:WINDIR\System32\Drivers\Etc\Hosts "`n$env:hostip crl.testsuite.nmos.tv`n"
         # add nmos-api.local to hosts to workaround mDNS lookups on windows being very slow and causing the AMWA test suite to take 2-3 hours to complete
@@ -521,7 +578,7 @@ jobs:
         Add-Content $env:WINDIR\System32\Drivers\Etc\Hosts "`n$env:hostip nmos-mocks.local`n"
         # Configure SCHANNEL, e.g. to disable TLS 1.0 and TLS 1.1
         reg import ${{ env.GITHUB_WORKSPACE }}/Sandbox/configure_schannel.reg
-    
+
     - name: windows install bonjour
       if: runner.os == 'Windows'
       run: |
@@ -529,7 +586,7 @@ jobs:
         curl -L https://download.info.apple.com/Mac_OS_X/061-8098.20100603.gthyu/BonjourPSSetup.exe -o BonjourPSSetup.exe -q
         & 7z.exe e BonjourPSSetup.exe Bonjour64.msi -y
         msiexec /i ${{ env.GITHUB_WORKSPACE }}\Bonjour64.msi /qn /norestart
-    
+
     - name: mac setup
       if: runner.os == 'macOS'
       run: |
@@ -540,11 +597,11 @@ jobs:
         ifconfig
         echo "CTEST_EXTRA_ARGS=$CTEST_EXTRA_ARGS -E testMdnsResolveAPIs" >> $GITHUB_ENV
         echo "CTEST_EXPECTED_FAILURES=$CTEST_EXPECTED_FAILURES -R testMdnsResolveAPIs" >> $GITHUB_ENV
-        # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
-        echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts
+        # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode
+        echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts > /dev/null
         # testssl.sh needs "timeout"
         brew install coreutils
-    
+
     - name: mac docker install
       # installs docker on a mac runner. Github's documentation states docker is already available so this shouldn't be necessary
       # can be used to run AWMA test suite but test suite doesn't seem to be able to communicate with nodes running on the host
@@ -570,7 +627,7 @@ jobs:
         echo "DOCKER_TLS_VERIFY=$DOCKER_TLS_VERIFY" >> $GITHUB_ENV
         echo "DOCKER_HOST=$DOCKER_HOST" >> $GITHUB_ENV
         echo "DOCKER_CERT_PATH=$DOCKER_CERT_PATH" >> $GITHUB_ENV
-    
+
     - name: ubuntu setup
       if: runner.os == 'Linux'
       run: |
@@ -578,11 +635,11 @@ jobs:
         hostip=$(hostname -I | cut -f1 -d' ')
         echo "HOST_IP_ADDRESS=$hostip" >> $GITHUB_ENV
         ip address
-        # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
-        echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts
+        # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode
+        echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts > /dev/null
         # re-synchronize the package index
         sudo apt-get update -q
-    
+
     - name: ubuntu mdns install
       if: runner.os == 'Linux' && matrix.install_mdns == true
       run: |
@@ -603,7 +660,7 @@ jobs:
         fi
         # force dependency on mDNSResponder
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_AVAHI:BOOL=\"0\"" >> $GITHUB_ENV
-    
+
     - name: ubuntu non-conan setup
       if: runner.os == 'Linux' && matrix.use_conan == false
       run: |
@@ -617,7 +674,7 @@ jobs:
           libboost-filesystem-dev \
           openssl \
           libssl-dev
-    
+
         cd ${{ env.RUNNER_WORKSPACE }}
         git clone --recurse-submodules --branch v2.10.18 https://github.com/Microsoft/cpprestsdk
         cd cpprestsdk/Release
@@ -625,15 +682,15 @@ jobs:
         cd build
         cmake .. -DCMAKE_BUILD_TYPE:STRING="Release" -DWERROR:BOOL="0" -DBUILD_SAMPLES:BOOL="0" -DBUILD_TESTS:BOOL="0"
         make -j 2 && sudo make install
-    
+
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DWEBSOCKETPP_INCLUDE_DIR:PATH=\"${{ env.RUNNER_WORKSPACE }}/cpprestsdk/Release/libs/websocketpp\"" >> $GITHUB_ENV
-    
+
     - name: disable conan
       if: matrix.use_conan == false
       shell: bash
       run: |
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_CONAN:BOOL=\"0\"" >> $GITHUB_ENV
-    
+
     - name: ubuntu avahi setup
       if: runner.os == 'Linux' && matrix.install_mdns == false
       run: |
@@ -647,13 +704,13 @@ jobs:
         sudo apt-get install -f nscd
         # force dependency on avahi
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_AVAHI:BOOL=\"1\"" >> $GITHUB_ENV
-    
+
     - name: force cpprest asio
       if: matrix.force_cpprest_asio == true
       shell: bash
       run: |
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_CONAN_OPTIONS:STRING=\"cpprestsdk:http_client_impl=asio;cpprestsdk:http_listener_impl=asio\"" >> $GITHUB_ENV
-    
+
     - uses: ilammy/msvc-dev-cmd@v1
     - name: build
       uses: lukka/run-cmake@v3.4
@@ -662,20 +719,19 @@ jobs:
         cmakeListsTxtPath: '${{ env.GITHUB_WORKSPACE }}/Development/CMakeLists.txt'
         buildDirectory: '${{ env.RUNNER_WORKSPACE }}/build/'
         cmakeAppendedArgs: '-GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${{ env.RUNNER_WORKSPACE }}/install" ${{ env.CMAKE_EXTRA_ARGS }}'
-    
+
     - name: unit test
       run: |
         cd ${{ env.RUNNER_WORKSPACE }}/build/
         ctest --output-on-failure ${{ env.CTEST_EXTRA_ARGS }}
-    
+
     - name: expected unit test failures
       if: env.CTEST_EXPECTED_FAILURES != null
       continue-on-error: true
       run: |
         cd ${{ env.RUNNER_WORKSPACE }}/build/
         ctest --output-on-failure ${{ env.CTEST_EXPECTED_FAILURES }}
-    
-    
+
     - name: install
       uses: lukka/run-cmake@v3.4
       with:
@@ -683,13 +739,13 @@ jobs:
         cmakeListsTxtPath: '${{ env.GITHUB_WORKSPACE }}/Development/CMakeLists.txt'
         buildDirectory: '${{ env.RUNNER_WORKSPACE }}/build/'
         buildWithCMakeArgs: '--target install'
-    
+
     - name: set install test environment variable
       shell: bash
       run: |
         # replace backslashes with forward slashes on Windows
         echo "CMAKE_WORKSPACE=${RUNNER_WORKSPACE//\\/\/}" >> $GITHUB_ENV
-    
+
     - name: install test
       uses: lukka/run-cmake@v3.4
       with:
@@ -703,12 +759,12 @@ jobs:
             -DCMAKE_PREFIX_PATH="${{ env.CMAKE_WORKSPACE }}/install"
             -DCMAKE_INSTALL_PREFIX="${{ env.CMAKE_WORKSPACE }}/build"
             ${{ env.CMAKE_EXTRA_ARGS }}'
-    
+
     - name: install test log
       run: |
         # dump the log file created in Sandbox/my-nmos-node/CMakeLists.txt
         cat ${{ env.RUNNER_WORKSPACE }}/build-my-nmos-node/my-nmos-node_include-release.txt
-    
+
     - name: install wsl
       if: runner.os == 'Windows'
       run: |
@@ -717,7 +773,7 @@ jobs:
         Expand-Archive .\ubuntu-1804.zip .\ubuntu-1804
         cd ubuntu-1804
         .\ubuntu1804.exe install --root
-    
+
     - name: AMWA test suite
       shell: bash
       working-directory: ${{ env.RUNNER_WORKSPACE }}
@@ -725,93 +781,134 @@ jobs:
         |
         set -x
         root_dir=`pwd`
-    
+
         # Install AMWA NMOS Testing Tool
         git clone https://github.com/AMWA-TV/nmos-testing.git
         cd nmos-testing
-    
+
         # Configure the Testing Tool so all APIs are tested with TLS
         printf "from . import Config as CONFIG\nCONFIG.ENABLE_HTTPS = True\n" > nmostesting/UserConfig.py
-    
+        # Set the DNS-SD mode
+        printf 'CONFIG.DNS_SD_MODE = "${{ matrix.dns_sd_mode }}"\n' >> nmostesting/UserConfig.py
+
         # Download testssl
         cd testssl
-        curl -L https://github.com/drwetter/testssl.sh/archive/3.0.2.tar.gz | tar -xvzf - --strip-components=1
+        curl -L https://github.com/drwetter/testssl.sh/archive/3.0.2.tar.gz -s | tar -xvzf - --strip-components=1 > /dev/null
         cd ..
-    
+
         # Create output directories
         mkdir results
         mkdir badges
-    
+
         if [[ "${{ env.DOCKER_TEST_SUITE }}" == "true" ]]; then
           # run test suite in amwa/nmos-testing docker container
           docker pull amwa/nmos-testing
           docker run -d --name "nmos_testing" --entrypoint="/usr/bin/tail" -v `pwd`/results:/home/nmos-testing/results amwa/nmos-testing -f /dev/null
           run_python="docker exec -i nmos_testing python3"
-        elif  [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
+        elif [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
           # run test suite in vagrant VM
           cp ${{ env.GITHUB_WORKSPACE_BASH }}/.github/workflows/mac_Vagrantfile ./Vagrantfile
           vagrant plugin install vagrant-scp
           vagrant up
           vagrant ssh -- mkdir results
           run_python="vagrant ssh -- python3"
+        elif [[ "${{ runner.os }}" == "Linux" && "${{ matrix.dns_sd_mode }}" == "unicast" ]]; then
+          # run test suite directly
+          sudo pip install --upgrade -r requirements.txt
+          # install SDPoker
+          npm install -g git+https://git@github.com/AMWA-TV/sdpoker.git
+          run_python="sudo python"
         else
           # run test suite directly
           pip install -r requirements.txt
-    
-          # Install SDPoker
+          # install SDPoker
           npm install -g git+https://git@github.com/AMWA-TV/sdpoker.git
           run_python="python"
         fi
         pip install -r utilities/run-test-suites/gsheetsImport/requirements.txt
-        
-        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
             certutil -enterprise -addstore -user root test_data\\BCP00301\\ca\\certs\\ca.cert.pem
             certutil -enterprise -addstore -user ca test_data\\BCP00301\\ca\\intermediate\\certs\\intermediate.cert.pem
             certutil -importpfx -enterprise test_data\\BCP00301\\ca\\intermediate\\certs\\ecdsa.api.testsuite.nmos.tv.cert.chain.pfx
             certutil -importpfx -enterprise test_data\\BCP00301\\ca\\intermediate\\certs\\rsa.api.testsuite.nmos.tv.cert.chain.pfx
-    
+
             # RSA
             netsh http add sslcert ipport=0.0.0.0:1080 certhash=021d50df2177c07095485184206ee2297e50b65c appid="{00000000-0000-0000-0000-000000000000}"
             # ECDSA
             #netsh http add sslcert ipport=0.0.0.0:1080 certhash=875eca592c49120254b32bb8bed90ac3679015a5 appid="{00000000-0000-0000-0000-000000000000}"
-    
+
             # RSA
             netsh http add sslcert ipport=0.0.0.0:8088 certhash=021d50df2177c07095485184206ee2297e50b65c appid="{00000000-0000-0000-0000-000000000000}"
             # ECDSA
             #netsh http add sslcert ipport=0.0.0.0:8088 certhash=875eca592c49120254b32bb8bed90ac3679015a5 appid="{00000000-0000-0000-0000-000000000000}"
         fi
-    
-        if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
           # force DNS lookups to IPv4 as mDNS lookups on macos seem to wait for the IPv6 lookup to timeout before returning the IPv4 result
           mv nmostesting/GenericTest.py nmostesting/GenericTest.py.old
           printf 'import socket\nold_getaddrinfo = socket.getaddrinfo\ndef new_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):\n    return old_getaddrinfo(host, port, socket.AF_INET, type, proto, flags)\nsocket.getaddrinfo = new_getaddrinfo\n' > nmostesting/GenericTest.py
           cat nmostesting/GenericTest.py.old >> nmostesting/GenericTest.py
         fi
-    
-        if [[ "${{ runner.os }}" == "Linux" && "${{ matrix.install_mdns }}" == "false" ]]; then
-          # nmos-cpp-node doesn't currently support advertising hostnames to Avahi
-          avahi-publish -a -R nmos-api.local ${{ env.HOST_IP_ADDRESS }} &
-        fi
-    
+
         if [[ "${{ runner.os }}" == "Linux" && "${{ matrix.use_conan }}" == "false" ]]; then
           # ubuntu 14 non-conan build uses boost 1.54.0 which doesn't support disabling TLS 1.1
           mkdir -p ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/nmos-testing-options/
           echo "--ignore test_01" > ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/nmos-testing-options/BCP-003-01.txt
           echo "1" > ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/nmos-testing-options/BCP-003-01_max_disabled.txt
         fi
-    
-        ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
-    
+
+        if [[ "${{ matrix.dns_sd_mode }}" == "multicast" ]]; then
+          domain=local
+        else
+          domain=testsuite.nmos.tv
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            # add host names
+            echo -e "${{ env.HOST_IP_ADDRESS }} api.$domain\n${{ env.HOST_IP_ADDRESS }} mocks.$domain" | sudo tee -a /etc/hosts > /dev/null
+            # force testing tool to cache specification repos before changing the resolver configuration
+            $run_python nmos-test.py suite IS-04-01 --selection auto --host ${{ env.HOST_IP_ADDRESS }} --port 444 --version v1.3 || true
+            # change the resolver configuration to use only the testing tool's mock DNS server
+            # as unicast DNS-SD test results are inconsistent if other servers are also configured
+            sudo cp /etc/resolv.conf /etc/resolv.conf.bak
+            echo -e "nameserver ${{ env.HOST_IP_ADDRESS }}" | sudo tee /etc/resolv.conf > /dev/null
+            if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+              echo "Restarting mdnsd"
+              sudo /etc/init.d/mdns restart
+              sleep 2
+            else
+              echo "Restarting avahi-daemon"
+              sudo systemctl restart avahi-daemon
+              sleep 2
+            fi
+          else
+            echo "Unicast DNS-SD testing not yet supported on ${{ runner.os }}" && false
+          fi
+        fi
+
+        if [[ "${{ runner.os }}" == "Linux" && "${{ matrix.install_mdns }}" == "false" ]]; then
+          # nmos-cpp-node doesn't currently support advertising hostnames to Avahi
+          avahi-publish -a -R nmos-api.local ${{ env.HOST_IP_ADDRESS }} &
+        fi
+
+        ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
+
+        if [[ "${{ matrix.dns_sd_mode }}" == "unicast" ]]; then
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            # restore DNS Server
+            cat /etc/resolv.conf.bak | sudo tee /etc/resolv.conf > /dev/null
+          fi
+        fi
+
         if [[ "${{ env.DOCKER_TEST_SUITE }}" == "true" ]]; then
           docker stop nmos_testing
           docker rm nmos_testing
         fi
-        if  [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
+        if [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
           vagrant scp :results/* results/
           vagrant destroy -f
         fi
         exit 0
-    
+
     - name: upload to google sheets
       if: github.ref == 'refs/heads/master' && github.event_name == 'push'
       working-directory: ${{ env.RUNNER_WORKSPACE }}
@@ -819,12 +916,12 @@ jobs:
       run: |
         export SHEET=https://docs.google.com/spreadsheets/d/${{ env.SECRET_RESULTS_SHEET_ID }}
         python nmos-testing/utilities/run-test-suites/gsheetsImport/resultsImporter.py --credentials ${{ env.GDRIVE_CREDENTIALS }} --sheet "$SHEET" --insert --json nmos-testing/results/${{ env.GITHUB_COMMIT }}-*.json || echo "upload failed"
-    
+
     - uses: actions/upload-artifact@v1
       with:
         name: ${{ env.BUILD_NAME }}_badges
         path: ${{ runner.workspace }}/nmos-testing/badges
-    
+
     - uses: actions/upload-artifact@v1
       with:
         name: ${{ env.BUILD_NAME }}_results

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -401,6 +401,16 @@ jobs:
           echo "1" > ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/nmos-testing-options/BCP-003-01_max_disabled.txt
         fi
 
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+            echo "Stopping mdnsd"
+            sudo /etc/init.d/mdns stop
+          else
+            echo "Stopping avahi-daemon"
+            sudo systemctl stop avahi-daemon
+          fi
+        fi
+
         if [[ "${{ matrix.dns_sd_mode }}" == "multicast" ]]; then
           domain=local
         else
@@ -414,17 +424,26 @@ jobs:
             # as unicast DNS-SD test results are inconsistent if other servers are also configured
             sudo cp /etc/resolv.conf /etc/resolv.conf.bak
             echo -e "nameserver ${{ env.HOST_IP_ADDRESS }}" | sudo tee /etc/resolv.conf > /dev/null
-            if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
-              echo "Restarting mdnsd"
-              sudo /etc/init.d/mdns restart
-              sleep 2
-            else
-              echo "Restarting avahi-daemon"
-              sudo systemctl restart avahi-daemon
-              sleep 2
-            fi
           else
             echo "Unicast DNS-SD testing not yet supported on ${{ runner.os }}" && false
+          fi
+        fi
+
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+            echo "Restarting mdnsd"
+            #sudo /etc/init.d/mdns start
+            sudo /usr/sbin/mdnsd -debug &
+            sleep 2
+
+            dns-sd -V
+          else
+            echo "Restarting avahi-daemon"
+            sudo systemctl start avahi-daemon
+            sleep 2
+
+            ps -e | grep avahi-daemon
+            avahi-daemon -V
           fi
         fi
 
@@ -435,10 +454,32 @@ jobs:
 
         ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
 
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+            ps -e | grep mdnsd || true
+          else
+            ps -e | grep avahi-daemon || true
+          fi
+        fi
+
         if [[ "${{ matrix.dns_sd_mode }}" == "unicast" ]]; then
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             # restore DNS Server
+            if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+              echo "Stopping mdnsd"
+              sudo /etc/init.d/mdns stop
+            else
+              echo "Stopping avahi-daemon"
+              sudo systemctl stop avahi-daemon
+            fi
             cat /etc/resolv.conf.bak | sudo tee /etc/resolv.conf > /dev/null
+            if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+              echo "Restarting mdnsd"
+              sudo /etc/init.d/mdns start
+            else
+              echo "Restarting avahi-daemon"
+              sudo systemctl start avahi-daemon
+            fi
           fi
         fi
 
@@ -450,6 +491,7 @@ jobs:
           vagrant scp :results/* results/
           vagrant destroy -f
         fi
+
         exit 0
 
     - name: upload to google sheets
@@ -858,6 +900,16 @@ jobs:
           echo "1" > ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/nmos-testing-options/BCP-003-01_max_disabled.txt
         fi
 
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+            echo "Stopping mdnsd"
+            sudo /etc/init.d/mdns stop
+          else
+            echo "Stopping avahi-daemon"
+            sudo systemctl stop avahi-daemon
+          fi
+        fi
+
         if [[ "${{ matrix.dns_sd_mode }}" == "multicast" ]]; then
           domain=local
         else
@@ -871,17 +923,26 @@ jobs:
             # as unicast DNS-SD test results are inconsistent if other servers are also configured
             sudo cp /etc/resolv.conf /etc/resolv.conf.bak
             echo -e "nameserver ${{ env.HOST_IP_ADDRESS }}" | sudo tee /etc/resolv.conf > /dev/null
-            if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
-              echo "Restarting mdnsd"
-              sudo /etc/init.d/mdns restart
-              sleep 2
-            else
-              echo "Restarting avahi-daemon"
-              sudo systemctl restart avahi-daemon
-              sleep 2
-            fi
           else
             echo "Unicast DNS-SD testing not yet supported on ${{ runner.os }}" && false
+          fi
+        fi
+
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+            echo "Restarting mdnsd"
+            #sudo /etc/init.d/mdns start
+            sudo /usr/sbin/mdnsd -debug &
+            sleep 2
+
+            dns-sd -V
+          else
+            echo "Restarting avahi-daemon"
+            sudo systemctl start avahi-daemon
+            sleep 2
+
+            ps -e | grep avahi-daemon
+            avahi-daemon -V
           fi
         fi
 
@@ -892,10 +953,32 @@ jobs:
 
         ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
 
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+            ps -e | grep mdnsd || true
+          else
+            ps -e | grep avahi-daemon || true
+          fi
+        fi
+
         if [[ "${{ matrix.dns_sd_mode }}" == "unicast" ]]; then
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             # restore DNS Server
+            if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+              echo "Stopping mdnsd"
+              sudo /etc/init.d/mdns stop
+            else
+              echo "Stopping avahi-daemon"
+              sudo systemctl stop avahi-daemon
+            fi
             cat /etc/resolv.conf.bak | sudo tee /etc/resolv.conf > /dev/null
+            if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+              echo "Restarting mdnsd"
+              sudo /etc/init.d/mdns start
+            else
+              echo "Restarting avahi-daemon"
+              sudo systemctl start avahi-daemon
+            fi
           fi
         fi
 
@@ -907,6 +990,7 @@ jobs:
           vagrant scp :results/* results/
           vagrant destroy -f
         fi
+
         exit 0
 
     - name: upload to google sheets

--- a/.github/workflows/src/amwa-test.yml
+++ b/.github/workflows/src/amwa-test.yml
@@ -22,7 +22,7 @@
     # Configure the Testing Tool so all APIs are tested with TLS
     printf "from . import Config as CONFIG\nCONFIG.ENABLE_HTTPS = True\n" > nmostesting/UserConfig.py
     # Set the DNS-SD mode
-    printf 'CONFIG.DNS_SD_MODE = "${{ matrix.dns_sd_mode }}"\n' >> nmostesting/UserConfig.py
+    printf 'CONFIG.DNS_SD_MODE = "'${{ matrix.dns_sd_mode }}'"\n' >> nmostesting/UserConfig.py
 
     # Download testssl
     cd testssl
@@ -111,7 +111,12 @@
         # force testing tool to cache specification repos before changing the resolver configuration
         $run_python nmos-test.py suite IS-04-01 --selection auto --host ${{ env.HOST_IP_ADDRESS }} --port 444 --version v1.3 || true
         # change the resolver configuration to use only the testing tool's mock DNS server
+        # and instead configure the mock DNS server to use an upstream DNS server
         # as unicast DNS-SD test results are inconsistent if other servers are also configured
+        dns_upstream_ip=$(cat /etc/resolv.conf | grep ^nameserver | tr -s [:space:] ' ' | cut -f2 -d ' ' -s)
+        if [[ ! -z "$dns_upstream_ip" ]]; then
+          printf 'CONFIG.DNS_UPSTREAM_IP = "'${dns_upstream_ip}'"\n' >> nmostesting/UserConfig.py
+        fi
         sudo cp /etc/resolv.conf /etc/resolv.conf.bak
         echo -e "nameserver ${{ env.HOST_IP_ADDRESS }}" | sudo tee /etc/resolv.conf > /dev/null
       else

--- a/.github/workflows/src/amwa-test.yml
+++ b/.github/workflows/src/amwa-test.yml
@@ -127,8 +127,8 @@
     if [[ "${{ runner.os }}" == "Linux" ]]; then
       if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
         echo "Restarting mdnsd"
-        #sudo /etc/init.d/mdns start
-        sudo /usr/sbin/mdnsd -debug &
+        sudo /etc/init.d/mdns start
+        #sudo /usr/sbin/mdnsd -debug &
         sleep 2
 
         dns-sd -V

--- a/.github/workflows/src/amwa-test.yml
+++ b/.github/workflows/src/amwa-test.yml
@@ -21,10 +21,12 @@
 
     # Configure the Testing Tool so all APIs are tested with TLS
     printf "from . import Config as CONFIG\nCONFIG.ENABLE_HTTPS = True\n" > nmostesting/UserConfig.py
+    # Set the DNS-SD mode
+    printf 'CONFIG.DNS_SD_MODE = "${{ matrix.dns_sd_mode }}"\n' >> nmostesting/UserConfig.py
 
     # Download testssl
     cd testssl
-    curl -L https://github.com/drwetter/testssl.sh/archive/3.0.2.tar.gz | tar -xvzf - --strip-components=1
+    curl -L https://github.com/drwetter/testssl.sh/archive/3.0.2.tar.gz -s | tar -xvzf - --strip-components=1 > /dev/null
     cd ..
 
     # Create output directories
@@ -36,24 +38,29 @@
       docker pull amwa/nmos-testing
       docker run -d --name "nmos_testing" --entrypoint="/usr/bin/tail" -v `pwd`/results:/home/nmos-testing/results amwa/nmos-testing -f /dev/null
       run_python="docker exec -i nmos_testing python3"
-    elif  [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
+    elif [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
       # run test suite in vagrant VM
       cp ${{ env.GITHUB_WORKSPACE_BASH }}/.github/workflows/mac_Vagrantfile ./Vagrantfile
       vagrant plugin install vagrant-scp
       vagrant up
       vagrant ssh -- mkdir results
       run_python="vagrant ssh -- python3"
+    elif [[ "${{ runner.os }}" == "Linux" && "${{ matrix.dns_sd_mode }}" == "unicast" ]]; then
+      # run test suite directly
+      sudo pip install --upgrade -r requirements.txt
+      # install SDPoker
+      npm install -g git+https://git@github.com/AMWA-TV/sdpoker.git
+      run_python="sudo python"
     else
       # run test suite directly
       pip install -r requirements.txt
-
-      # Install SDPoker
+      # install SDPoker
       npm install -g git+https://git@github.com/AMWA-TV/sdpoker.git
       run_python="python"
     fi
     pip install -r utilities/run-test-suites/gsheetsImport/requirements.txt
-    
-    if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+
+    if [[ "${{ runner.os }}" == "Windows" ]]; then
         certutil -enterprise -addstore -user root test_data\\BCP00301\\ca\\certs\\ca.cert.pem
         certutil -enterprise -addstore -user ca test_data\\BCP00301\\ca\\intermediate\\certs\\intermediate.cert.pem
         certutil -importpfx -enterprise test_data\\BCP00301\\ca\\intermediate\\certs\\ecdsa.api.testsuite.nmos.tv.cert.chain.pfx
@@ -70,16 +77,11 @@
         #netsh http add sslcert ipport=0.0.0.0:8088 certhash=875eca592c49120254b32bb8bed90ac3679015a5 appid="{00000000-0000-0000-0000-000000000000}"
     fi
 
-    if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+    if [[ "${{ runner.os }}" == "macOS" ]]; then
       # force DNS lookups to IPv4 as mDNS lookups on macos seem to wait for the IPv6 lookup to timeout before returning the IPv4 result
       mv nmostesting/GenericTest.py nmostesting/GenericTest.py.old
       printf 'import socket\nold_getaddrinfo = socket.getaddrinfo\ndef new_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):\n    return old_getaddrinfo(host, port, socket.AF_INET, type, proto, flags)\nsocket.getaddrinfo = new_getaddrinfo\n' > nmostesting/GenericTest.py
       cat nmostesting/GenericTest.py.old >> nmostesting/GenericTest.py
-    fi
-
-    if [[ "${{ runner.os }}" == "Linux" && "${{ matrix.install_mdns }}" == "false" ]]; then
-      # nmos-cpp-node doesn't currently support advertising hostnames to Avahi
-      avahi-publish -a -R nmos-api.local ${{ env.HOST_IP_ADDRESS }} &
     fi
 
     if [[ "${{ runner.os }}" == "Linux" && "${{ matrix.use_conan }}" == "false" ]]; then
@@ -89,13 +91,52 @@
       echo "1" > ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/nmos-testing-options/BCP-003-01_max_disabled.txt
     fi
 
-    ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
+    if [[ "${{ matrix.dns_sd_mode }}" == "multicast" ]]; then
+      domain=local
+    else
+      domain=testsuite.nmos.tv
+      if [[ "${{ runner.os }}" == "Linux" ]]; then
+        # add host names
+        echo -e "${{ env.HOST_IP_ADDRESS }} api.$domain\n${{ env.HOST_IP_ADDRESS }} mocks.$domain" | sudo tee -a /etc/hosts > /dev/null
+        # force testing tool to cache specification repos before changing the resolver configuration
+        $run_python nmos-test.py suite IS-04-01 --selection auto --host ${{ env.HOST_IP_ADDRESS }} --port 444 --version v1.3 || true
+        # change the resolver configuration to use only the testing tool's mock DNS server
+        # as unicast DNS-SD test results are inconsistent if other servers are also configured
+        sudo cp /etc/resolv.conf /etc/resolv.conf.bak
+        echo -e "nameserver ${{ env.HOST_IP_ADDRESS }}" | sudo tee /etc/resolv.conf > /dev/null
+        if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+          echo "Restarting mdnsd"
+          sudo /etc/init.d/mdns restart
+          sleep 2
+        else
+          echo "Restarting avahi-daemon"
+          sudo systemctl restart avahi-daemon
+          sleep 2
+        fi
+      else
+        echo "Unicast DNS-SD testing not yet supported on ${{ runner.os }}" && false
+      fi
+    fi
+
+    if [[ "${{ runner.os }}" == "Linux" && "${{ matrix.install_mdns }}" == "false" ]]; then
+      # nmos-cpp-node doesn't currently support advertising hostnames to Avahi
+      avahi-publish -a -R nmos-api.local ${{ env.HOST_IP_ADDRESS }} &
+    fi
+    
+    ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
+
+    if [[ "${{ matrix.dns_sd_mode }}" == "unicast" ]]; then
+      if [[ "${{ runner.os }}" == "Linux" ]]; then
+        # restore DNS Server
+        cat /etc/resolv.conf.bak | sudo tee /etc/resolv.conf > /dev/null
+      fi
+    fi
 
     if [[ "${{ env.DOCKER_TEST_SUITE }}" == "true" ]]; then
       docker stop nmos_testing
       docker rm nmos_testing
     fi
-    if  [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
+    if [[ "${{ env.VAGRANT_TEST_SUITE }}" == "true" ]]; then
       vagrant scp :results/* results/
       vagrant destroy -f
     fi

--- a/.github/workflows/src/amwa-test.yml
+++ b/.github/workflows/src/amwa-test.yml
@@ -91,6 +91,16 @@
       echo "1" > ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/nmos-testing-options/BCP-003-01_max_disabled.txt
     fi
 
+    if [[ "${{ runner.os }}" == "Linux" ]]; then
+      if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+        echo "Stopping mdnsd"
+        sudo /etc/init.d/mdns stop
+      else
+        echo "Stopping avahi-daemon"
+        sudo systemctl stop avahi-daemon
+      fi
+    fi
+
     if [[ "${{ matrix.dns_sd_mode }}" == "multicast" ]]; then
       domain=local
     else
@@ -104,17 +114,26 @@
         # as unicast DNS-SD test results are inconsistent if other servers are also configured
         sudo cp /etc/resolv.conf /etc/resolv.conf.bak
         echo -e "nameserver ${{ env.HOST_IP_ADDRESS }}" | sudo tee /etc/resolv.conf > /dev/null
-        if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
-          echo "Restarting mdnsd"
-          sudo /etc/init.d/mdns restart
-          sleep 2
-        else
-          echo "Restarting avahi-daemon"
-          sudo systemctl restart avahi-daemon
-          sleep 2
-        fi
       else
         echo "Unicast DNS-SD testing not yet supported on ${{ runner.os }}" && false
+      fi
+    fi
+
+    if [[ "${{ runner.os }}" == "Linux" ]]; then
+      if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+        echo "Restarting mdnsd"
+        #sudo /etc/init.d/mdns start
+        sudo /usr/sbin/mdnsd -debug &
+        sleep 2
+
+        dns-sd -V
+      else
+        echo "Restarting avahi-daemon"
+        sudo systemctl start avahi-daemon
+        sleep 2
+
+        ps -e | grep avahi-daemon
+        avahi-daemon -V
       fi
     fi
 
@@ -125,10 +144,32 @@
     
     ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
 
+    if [[ "${{ runner.os }}" == "Linux" ]]; then
+      if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+        ps -e | grep mdnsd || true
+      else
+        ps -e | grep avahi-daemon || true
+      fi
+    fi
+
     if [[ "${{ matrix.dns_sd_mode }}" == "unicast" ]]; then
       if [[ "${{ runner.os }}" == "Linux" ]]; then
         # restore DNS Server
+        if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+          echo "Stopping mdnsd"
+          sudo /etc/init.d/mdns stop
+        else
+          echo "Stopping avahi-daemon"
+          sudo systemctl stop avahi-daemon
+        fi
         cat /etc/resolv.conf.bak | sudo tee /etc/resolv.conf > /dev/null
+        if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+          echo "Restarting mdnsd"
+          sudo /etc/init.d/mdns start
+        else
+          echo "Restarting avahi-daemon"
+          sudo systemctl start avahi-daemon
+        fi
       fi
     fi
 
@@ -140,4 +181,5 @@
       vagrant scp :results/* results/
       vagrant destroy -f
     fi
+
     exit 0

--- a/.github/workflows/src/build-setup.yml
+++ b/.github/workflows/src/build-setup.yml
@@ -32,7 +32,7 @@
     ).IPv4Address.IPAddress
     echo "HOST_IP_ADDRESS=$env:hostip" >> $env:GITHUB_ENV
     ipconfig
-    # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
+    # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode
     # and avoid SSL Error: WINHTTP_CALLBACK_STATUS_FLAG_CERT_REV_FAILED failed to check revocation status.
     Add-Content $env:WINDIR\System32\Drivers\Etc\Hosts "`n$env:hostip crl.testsuite.nmos.tv`n"
     # add nmos-api.local to hosts to workaround mDNS lookups on windows being very slow and causing the AMWA test suite to take 2-3 hours to complete
@@ -60,8 +60,8 @@
     ifconfig
     echo "CTEST_EXTRA_ARGS=$CTEST_EXTRA_ARGS -E testMdnsResolveAPIs" >> $GITHUB_ENV
     echo "CTEST_EXPECTED_FAILURES=$CTEST_EXPECTED_FAILURES -R testMdnsResolveAPIs" >> $GITHUB_ENV
-    # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
-    echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts
+    # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode
+    echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts > /dev/null
     # testssl.sh needs "timeout"
     brew install coreutils
 
@@ -98,8 +98,8 @@
     hostip=$(hostname -I | cut -f1 -d' ')
     echo "HOST_IP_ADDRESS=$hostip" >> $GITHUB_ENV
     ip address
-    # add the CRL Distribution Point to hosts so that it's discoverable when runing the AMWA test suite in mDNS mode
-    echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts
+    # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode
+    echo "$hostip crl.testsuite.nmos.tv" | sudo tee -a /etc/hosts > /dev/null
     # re-synchronize the package index
     sudo apt-get update -q
 

--- a/.github/workflows/src/build-test.yml
+++ b/.github/workflows/src/build-test.yml
@@ -23,13 +23,20 @@ jobs:
         force_cpprest_asio: [false]
         dns_sd_mode: [multicast, unicast]
         exclude:
+          # install_mdns is only meaningful on Linux
           - os: macos-11
             install_mdns: true
           - os: windows-2019
             install_mdns: true
+          # for now, unicast DNS-SD tests are only implemented on Linux
           - os: macos-11
             dns_sd_mode: unicast
           - os: windows-2019
+            dns_sd_mode: unicast
+          # for now, exclude unicast DNS-SD with mDNSResponder due to
+          # intermittent *** buffer overflow detected *** in mdnsd
+          - os: ubuntu-20.04
+            install_mdns: true
             dns_sd_mode: unicast
         include:
           - os: windows-2019

--- a/.github/workflows/src/build-test.yml
+++ b/.github/workflows/src/build-test.yml
@@ -12,28 +12,31 @@ env:
   SECRET_RESULTS_SHEET_ID: ${{ secrets.RESULTS_SHEET_ID }}
 jobs:
   build_and_test:
-    name: '${{ matrix.os }}: build and test (install mdns: ${{ matrix.install_mdns }}, use conan: ${{ matrix.use_conan }}, force cpprest asio: ${{ matrix.force_cpprest_asio }})'
+    name: '${{ matrix.os }}: build and test (install mdns: ${{ matrix.install_mdns }}, use conan: ${{ matrix.use_conan }}, force cpprest asio: ${{ matrix.force_cpprest_asio }}, dns-sd mode: ${{ matrix.dns_sd_mode}})'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
-        install_mdns: [false]
+        os: [ubuntu-20.04, macos-11, windows-2019]
+        install_mdns: [false, true]
         use_conan: [true]
         force_cpprest_asio: [false]
+        dns_sd_mode: [multicast, unicast]
+        exclude:
+          - os: macos-11
+            install_mdns: true
+          - os: windows-2019
+            install_mdns: true
+          - os: macos-11
+            dns_sd_mode: unicast
+          - os: windows-2019
+            dns_sd_mode: unicast
         include:
-          - install_mdns: true
-            use_conan: true
-            force_cpprest_asio: false
-            os: ubuntu-18.04
-          - install_mdns: true
-            use_conan: true
-            force_cpprest_asio: false
-            os: ubuntu-20.04
-          - install_mdns: false
+          - os: windows-2019
+            install_mdns: false
             use_conan: true
             force_cpprest_asio: true
-            os: windows-latest
+            dns_sd_mode: multicast
 
     steps:
     - uses: actions/checkout@v2
@@ -43,9 +46,9 @@ jobs:
       run: |
         if [[ "${{ runner.os }}"  == "Linux" ]]; then
           if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
-            echo "BUILD_NAME=${{ matrix.os }}_mdns" >> $GITHUB_ENV
+            echo "BUILD_NAME=${{ matrix.os }}_mdns_${{ matrix.dns_sd_mode }}" >> $GITHUB_ENV
           else
-            echo "BUILD_NAME=${{ matrix.os }}_avahi" >> $GITHUB_ENV
+            echo "BUILD_NAME=${{ matrix.os }}_avahi_${{ matrix.dns_sd_mode }}" >> $GITHUB_ENV
           fi
         elif [[ "${{ matrix.force_cpprest_asio }}" == "true" ]]; then
           echo "BUILD_NAME=${{ matrix.os }}_asio" >> $GITHUB_ENV
@@ -69,22 +72,36 @@ jobs:
     @import build-and-test
 
   build_and_test_ubuntu_14:
-    name: 'ubuntu-14.04: build and test (install mdns: ${{ matrix.install_mdns }}, use conan: ${{ matrix.use_conan }})'
-    runs-on: ubuntu-latest
+    name: '${{ matrix.os }}: build and test (install mdns: ${{ matrix.install_mdns }}, use conan: ${{ matrix.use_conan }}, force cpprest asio: ${{ matrix.force_cpprest_asio }}, dns-sd mode: ${{ matrix.dns_sd_mode}})'
+    runs-on: ubuntu-20.04
     container:
       image: ubuntu:14.04
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-14.04]
         install_mdns: [true]
         use_conan: [false]
+        force_cpprest_asio: [false]
+        dns_sd_mode: [multicast]
 
     steps:
     - uses: actions/checkout@v2
 
     - name: set environment variables
+      shell: bash
       run: |
-        echo "BUILD_NAME=ubuntu-14.04_mdns" >> $GITHUB_ENV
+        if [[ "${{ runner.os }}"  == "Linux" ]]; then
+          if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
+            echo "BUILD_NAME=${{ matrix.os }}_mdns_${{ matrix.dns_sd_mode }}" >> $GITHUB_ENV
+          else
+            echo "BUILD_NAME=${{ matrix.os }}_avahi_${{ matrix.dns_sd_mode }}" >> $GITHUB_ENV
+          fi
+        elif [[ "${{ matrix.force_cpprest_asio }}" == "true" ]]; then
+          echo "BUILD_NAME=${{ matrix.os }}_asio" >> $GITHUB_ENV
+        else
+          echo "BUILD_NAME=${{ matrix.os }}" >> $GITHUB_ENV
+        fi
         GITHUB_COMMIT=`echo "${{ github.sha }}" | cut -c1-7`
         echo "GITHUB_COMMIT=$GITHUB_COMMIT" >> $GITHUB_ENV
         # github.workspace points to the host path not the docker path, the home directory defaults to the workspace directory
@@ -98,8 +115,8 @@ jobs:
         apt-get install -y software-properties-common
         apt-get --allow-unauthenticated update -q
         apt-get --allow-unauthenticated install -y curl g++ git make patch zlib1g-dev libssl-dev bsdmainutils dnsutils unzip
-        curl -sS https://www.python.org/ftp/python/3.6.9/Python-3.6.9.xz | tar -xJ
-        cd Python-3.6.3
+        curl -sS https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tar.xz | tar -xJ
+        cd Python-3.6.9
         ./configure
         make -j8
         make install

--- a/Development/cmake/NmosCppConan.cmake
+++ b/Development/cmake/NmosCppConan.cmake
@@ -6,7 +6,7 @@ endif()
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake")
     message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-    file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.16.1/conan.cmake"
+    file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/0.18.1/conan.cmake"
                   "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake")
 endif()
 

--- a/Development/mdns/service_discovery_impl.cpp
+++ b/Development/mdns/service_discovery_impl.cpp
@@ -287,8 +287,7 @@ namespace mdns_details
 
     static bool resolve(const resolve_handler& handler, const std::string& name, const std::string& type, const std::string& domain, std::uint32_t interface_id, const std::chrono::steady_clock::duration& latest_timeout_, DNSServiceCancellationToken cancel, slog::base_gate& gate)
     {
-        // apply a minimum timeout when the interface id isn't known e.g. from the result of a browse
-        const auto earliest_timeout_ = std::chrono::seconds(0 == interface_id ? 1 : 0);
+        const auto earliest_timeout_ = std::chrono::seconds(0);
 
         bool had_enough = false;
         bool more_coming = true;
@@ -347,8 +346,7 @@ namespace mdns_details
 
     static bool getaddrinfo(const address_handler& handler, const std::string& host_name, std::uint32_t interface_id, const std::chrono::steady_clock::duration& latest_timeout_, DNSServiceCancellationToken cancel, slog::base_gate& gate)
     {
-        // apply a minimum timeout when the interface id isn't known e.g. from the result of a browse
-        const auto earliest_timeout_ = std::chrono::seconds(0 == interface_id ? 1 : 0);
+        const auto earliest_timeout_ = std::chrono::seconds(0);
 
         bool had_enough = false;
 #ifdef HAVE_DNSSERVICEGETADDRINFO

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ The following configurations, defined by the [build-test](.github/workflows/src/
 | Linux    | Ubuntu 20.04 (GCC 9.4.0) | Avahi                              | Secure Communications, Multicast DNS-SD    |
 | Linux    | Ubuntu 20.04 (GCC 9.4.0) | Avahi                              | Secure Communications, Unicast DNS-SD      |
 | Linux    | Ubuntu 20.04 (GCC 9.4.0) | mDNSResponder                      | Secure Communications, Multicast DNS-SD    |
-| Linux    | Ubuntu 20.04 (GCC 9.4.0) | mDNSResponder                      | Secure Communications, Unicast DNS-SD      |
 | Linux    | Ubuntu 14.04 (GCC 4.8.4) | mDNSResponder, not using Conan     | Secure Communications, Multicast DNS-SD    |
 | Windows  | Server 2019 (VS 2019)    | Bonjour (mDNSResponder), WinHTTP   | Secure Communications, Multicast DNS-SD    |
 | Windows  | Server 2019 (VS 2019)    | Bonjour (mDNSResponder), ASIO      | Secure Communications, Multicast DNS-SD    |

--- a/README.md
+++ b/README.md
@@ -50,14 +50,16 @@ Several vendors have deployed JT-NM Tested badged products, using nmos-cpp, to t
 
 The following configurations, defined by the [build-test](.github/workflows/src/build-test.yml) jobs, are built and unit tested automatically via continuous integration.
 
-| Platform | Version                  | Configuration Options                  |
-|----------|--------------------------|----------------------------------------|
-| Linux    | Ubuntu 20.04 (GCC 9.3.0) | mDNSResponder                          |
-| Linux    | Ubuntu 18.04 (GCC 7.5.0) | Avahi                                  |
-| Linux    | Ubuntu 18.04 (GCC 7.5.0) | mDNSResponder                          |
-| Linux    | Ubuntu 14.04 (GCC 4.8.4) | mDNSResponder, not using Conan         |
-| Windows  | Server 2019 (VS 2019)    | Bonjour (mDNSResponder)                |
-| macOS    | 10.15 (AppleClang 12.0)  | (Experimental)                         |
+| Platform | Version                  | Build Options                      | Test Options                               |
+|----------|--------------------------|------------------------------------|--------------------------------------------|
+| Linux    | Ubuntu 20.04 (GCC 9.4.0) | Avahi                              | Secure Communications, Multicast DNS-SD    |
+| Linux    | Ubuntu 20.04 (GCC 9.4.0) | Avahi                              | Secure Communications, Unicast DNS-SD      |
+| Linux    | Ubuntu 20.04 (GCC 9.4.0) | mDNSResponder                      | Secure Communications, Multicast DNS-SD    |
+| Linux    | Ubuntu 20.04 (GCC 9.4.0) | mDNSResponder                      | Secure Communications, Unicast DNS-SD      |
+| Linux    | Ubuntu 14.04 (GCC 4.8.4) | mDNSResponder, not using Conan     | Secure Communications, Multicast DNS-SD    |
+| Windows  | Server 2019 (VS 2019)    | Bonjour (mDNSResponder), WinHTTP   | Secure Communications, Multicast DNS-SD    |
+| Windows  | Server 2019 (VS 2019)    | Bonjour (mDNSResponder), ASIO      | Secure Communications, Multicast DNS-SD    |
+| macOS    | 11 (AppleClang 13.0)     | Bonjour (mDNSResponder)            | Secure Communications, Multicast DNS-SD    |
 
 The [AMWA NMOS API Testing Tool](https://github.com/AMWA-TV/nmos-testing) is automatically run against the APIs of the **nmos-cpp-node** and **nmos-cpp-registry** applications.
 


### PR DESCRIPTION
Test unicast DNS-SD as well as multicast, with both Avahi and mDNSResponder, on Ubuntu 20.04

* Add `matrix.dns_sd_mode` as 'unicast' or 'multicast', used in job name and results filenames
* For now, unicast DNS-SD testing is not supported on Windows and macOS
* Add _api.testsuite.nmos.tv_ and _mocks.testsuite.nmos.tv_ to _/etc/hosts_ (as per https://github.com/AMWA-TV/nmos-testing/blob/master/test_data/BCP00301/README.md#hosts-files)
* Stomp on _/etc/resolv.conf_ (`systemd-resolve --set-dns` didn't replace only add) to ensure that only the mock DNS server is used and restart the Avahi or mDNSResponder daemon (reloading and/or invalidating/flushing systemd-resolve and nscd caches between test suite runs was found to be unnecessary)
* Configure nmos-cpp-node to timeout registration requests (after 5s) and retry long-running DNS-SD queries (after 10s), well before the testing tool's `DNS_SD_ADVERT_TIMEOUT` (30s by default)
* Run the testing tool with elevated permissions when testing unicast DNS-SD (unfortunately necessitating quick hack of `pip install`-ing packages as root)
* Note the domain names passed to _run_nmos_testing.sh_ mustn't have trailing dots to avoid "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'api.testsuite.nmos.tv.'. (_ssk.c:1131)" from e.g. IS-07-02 `test_05`

Unrelated changes:
* Update to conan-cmake 0.18.1 to support Visual Studio 2022 (a.k.a. "17", or "MSVC 19.31.31105.0" as now [installed on GitHub windows-latest runnner](https://github.com/actions/virtual-environments/issues/4856))
* However, switch to windows-2019 rather than windows-latest (now an alias for windows-2022) because [there aren't yet any Conan binary packages for VS 2022](https://github.com/conan-io/conan-center-index/issues/8795) and _testssl.sh_ is consistently failing with "Fatal error: No IPv4/IPv6 address(es) for "nmos-api.local" available" on the newer virtual environment
* Add `host_addresses` to config because on Windows I'm seeing "No matching mDNS announcement" failures in IS-04-02 and IS-04-03 and a second "Registered address" in the _nodeoutput_ log for the "vEthernet (nat)" adapter, despite it being disabled in the "windows setup" step...
* Use latest https://github.com/DannyBen/kojo which means whitespace-only lines due to indented imports are gone