### PR TITLE
Fix macOS exclusion in make_badges 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1032,7 +1032,7 @@ jobs:
   make_badges:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     needs: [build_and_test, build_and_test_ubuntu_14]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
 
@@ -1050,8 +1050,8 @@ jobs:
 
     - name: make badges
       run: |
-        # combine badges from all builds, exclude macos-latest
-        ${{ github.workspace }}/Sandbox/make_badges.sh ${{ github.workspace }} ${{ runner.workspace }}/artifacts macos-latest
+        # combine badges from all builds, exclude macos-11
+        ${{ github.workspace }}/Sandbox/make_badges.sh ${{ github.workspace }} ${{ runner.workspace }}/artifacts macos-11
 
         # force push to github onto an orphan 'badges' branch
         cd ${{ github.workspace }}

--- a/.github/workflows/src/build-test.yml
+++ b/.github/workflows/src/build-test.yml
@@ -138,7 +138,7 @@ jobs:
   make_badges:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     needs: [build_and_test, build_and_test_ubuntu_14]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
 
@@ -156,8 +156,8 @@ jobs:
 
     - name: make badges
       run: |
-        # combine badges from all builds, exclude macos-latest
-        ${{ github.workspace }}/Sandbox/make_badges.sh ${{ github.workspace }} ${{ runner.workspace }}/artifacts macos-latest
+        # combine badges from all builds, exclude macos-11
+        ${{ github.workspace }}/Sandbox/make_badges.sh ${{ github.workspace }} ${{ runner.workspace }}/artifacts macos-11
 
         # force push to github onto an orphan 'badges' branch
         cd ${{ github.workspace }}


### PR DESCRIPTION
Sorry, we missed this in commit 7a84327b963291b38f20e6a1bb223c63374bce5e in PR #250, which is why the IS-04-01 badge is currently red.