### PR TITLE
Fixed closing of already closed http_listener.

### DIFF
--- a/Development/nmos/server.cpp
+++ b/Development/nmos/server.cpp
@@ -88,7 +88,12 @@ namespace nmos
 
             for (auto& http_listener : http_listeners)
             {
-                if (0 <= http_listener.uri().port()) tasks.push_back(http_listener.close());
+                if (0 <= http_listener.uri().port())
+                {
+                    // close returns default pplx<void>::tasks if listener is already closed which crashes pplx::when_all.
+                    auto task = http_listener.close();
+                    if (task != pplx::task<void>()) tasks.push_back(task);
+                }
             }
             for (auto& ws_listener : ws_listeners)
             {


### PR DESCRIPTION
I observed a crash of the nmos-cpp library when the nmos::server is closed and the http_listeners vector contains already closed listeners. 

http_listener::close() returns a default created pplx<void>::task from cpprest (2.10.17). This leads to a crash in pplx::when_all() under Linux CentOS8.1. I did not investigate the reason for this crash further, however, default created pplx::task behave different. For example they throw on wait or get calls. 

To solve this issue I propose the following fix which only adds non default created tasks to the vector. 

The provided fix is tested in my application where the problem occurs when a nmos::server is closed that comprises invalid http_listeners due to wrong socket configurations, like for example an already existing port number. 
