### PR TITLE
Resolve crash in nmos::server::close

### DIFF
--- a/Development/cmake/NmosCppTest.cmake
+++ b/Development/cmake/NmosCppTest.cmake
@@ -52,6 +52,12 @@ set(NMOS_CPP_TEST_NMOS_TEST_SOURCES
 set(NMOS_CPP_TEST_NMOS_TEST_HEADERS
     )
 
+set(NMOS_CPP_TEST_PPLX_TEST_SOURCES
+    pplx/test/pplx_utils_test.cpp
+    )
+set(NMOS_CPP_TEST_PPLX_TEST_HEADERS
+    )
+
 set(NMOS_CPP_TEST_RQL_TEST_SOURCES
     rql/test/rql_test.cpp
     )
@@ -78,6 +84,8 @@ add_executable(
     ${NMOS_CPP_TEST_MDNS_TEST_HEADERS}
     ${NMOS_CPP_TEST_NMOS_TEST_SOURCES}
     ${NMOS_CPP_TEST_NMOS_TEST_HEADERS}
+    ${NMOS_CPP_TEST_PPLX_TEST_SOURCES}
+    ${NMOS_CPP_TEST_PPLX_TEST_HEADERS}
     ${NMOS_CPP_TEST_RQL_TEST_SOURCES}
     ${NMOS_CPP_TEST_RQL_TEST_HEADERS}
     ${NMOS_CPP_TEST_SDP_TEST_SOURCES}
@@ -90,6 +98,7 @@ source_group("cpprest\\test\\Source Files" FILES ${NMOS_CPP_TEST_CPPREST_TEST_SO
 source_group("lldp\\test\\Source Files" FILES ${NMOS_CPP_TEST_LLDP_TEST_SOURCES})
 source_group("mdns\\test\\Source Files" FILES ${NMOS_CPP_TEST_MDNS_TEST_SOURCES})
 source_group("nmos\\test\\Source Files" FILES ${NMOS_CPP_TEST_NMOS_TEST_SOURCES})
+source_group("pplx\\test\\Source Files" FILES ${NMOS_CPP_TEST_PPLX_TEST_SOURCES})
 source_group("rql\\test\\Source Files" FILES ${NMOS_CPP_TEST_RQL_TEST_SOURCES})
 source_group("sdp\\test\\Source Files" FILES ${NMOS_CPP_TEST_SDP_TEST_SOURCES})
 
@@ -99,6 +108,7 @@ source_group("cpprest\\test\\Header Files" FILES ${NMOS_CPP_TEST_CPPREST_TEST_HE
 source_group("lldp\\test\\Header Files" FILES ${NMOS_CPP_TEST_LLDP_TEST_HEADERS})
 source_group("mdns\\test\\Header Files" FILES ${NMOS_CPP_TEST_MDNS_TEST_HEADERS})
 source_group("nmos\\test\\Header Files" FILES ${NMOS_CPP_TEST_NMOS_TEST_HEADERS})
+source_group("pplx\\test\\Header Files" FILES ${NMOS_CPP_TEST_PPLX_TEST_HEADERS})
 source_group("rql\\test\\Header Files" FILES ${NMOS_CPP_TEST_RQL_TEST_HEADERS})
 source_group("sdp\\test\\Header Files" FILES ${NMOS_CPP_TEST_SDP_TEST_HEADERS})
 

--- a/Development/nmos/connection_events_activation.cpp
+++ b/Development/nmos/connection_events_activation.cpp
@@ -34,12 +34,12 @@ namespace nmos
             if (active && !connection_uri_or_null.is_null() && !ext_is_07_source_id_or_null.is_null())
             {
                 events_ws_client->subscribe(connection_resource.id, connection_uri_or_null.as_string(), ext_is_07_source_id_or_null.as_string())
-                    .then(pplx::observe_exception<void>());
+                    .then(pplx::observe_exception());
             }
             else
             {
                 events_ws_client->unsubscribe(connection_resource.id)
-                    .then(pplx::observe_exception<void>());
+                    .then(pplx::observe_exception());
             }
         };
     }

--- a/Development/nmos/events_ws_client.cpp
+++ b/Development/nmos/events_ws_client.cpp
@@ -281,7 +281,7 @@ namespace nmos
                                     .then([] { return true; });
                             });
                         }, token);
-                    }).then(pplx::observe_exception<void>());
+                    }).then(pplx::observe_exception());
 
                     connection = connections.insert({ connection_uri, client }).first;
                 }
@@ -333,7 +333,7 @@ namespace nmos
             subscriptions.clear();
             connections.clear();
 
-            return pplx::ranges::when_all(tasks).then(pplx::observe_exceptions<void>(tasks));
+            return pplx::ranges::when_all(tasks).then(pplx::observe_exceptions(tasks));
         }
     }
 

--- a/Development/nmos/mdns.cpp
+++ b/Development/nmos/mdns.cpp
@@ -524,7 +524,7 @@ namespace nmos
 
                     // when either task is completed, cancel and wait for the other to be completed
                     // and then merge the two sets of results
-                    resolve_task = pplx::when_any(both_tasks.begin(), both_tasks.end()).then([both_results, linked_source, both_tasks](std::pair<bool, size_t> first_result)
+                    resolve_task = pplx::ranges::when_any(both_tasks).then([both_results, linked_source, both_tasks](std::pair<bool, size_t> first_result)
                     {
                         if (!both_results[first_result.second]->empty()) linked_source.cancel();
 

--- a/Development/nmos/mdns_api.cpp
+++ b/Development/nmos/mdns_api.cpp
@@ -206,13 +206,10 @@ namespace nmos
                                 return mdns_result(browsed1, resolved);
                             }));
                         }
-                        return pplx::when_all(tasks.begin(), tasks.end()).then([res, version, tasks](pplx::task<std::vector<mdns_result>> finally) mutable
+                        return pplx::ranges::when_all(tasks).then([res, version, tasks](pplx::task<std::vector<mdns_result>> finally) mutable
                         {
                             // to ensure an exception from one doesn't leave other tasks' exceptions unobserved
-                            for (auto& task : tasks)
-                            {
-                                try { task.wait(); } catch (...) {}
-                            }
+                            for (auto& task : tasks) pplx::details::wait_nothrow(task);
 
                             // merge results that have the same host_target, port and txt records
                             // and only differ in the resolved addresses

--- a/Development/nmos/server.cpp
+++ b/Development/nmos/server.cpp
@@ -65,7 +65,7 @@ namespace nmos
                 if (0 <= ws_listener.uri().port()) tasks.push_back(ws_listener.open());
             }
 
-            return pplx::ranges::when_all(tasks).then(pplx::observe_exceptions<void>(tasks));
+            return pplx::ranges::when_all(tasks).then(pplx::observe_exceptions(tasks));
         });
     }
 
@@ -86,7 +86,7 @@ namespace nmos
                 if (0 <= ws_listener.uri().port()) tasks.push_back(ws_listener.close());
             }
 
-            return pplx::ranges::when_all(tasks).then(pplx::observe_exceptions<void>(tasks));
+            return pplx::ranges::when_all(tasks).then(pplx::observe_exceptions(tasks));
         });
     }
 

--- a/Development/pplx/pplx_utils.h
+++ b/Development/pplx/pplx_utils.h
@@ -116,6 +116,18 @@ namespace pplx
         }
     };
 
+    namespace details
+    {
+        // see http://ericniebler.com/2013/08/07/universal-references-and-the-copy-constructo/
+        template<typename A, typename B>
+        using disable_if_same_or_derived =
+            typename std::enable_if<
+                !std::is_base_of<A,typename
+                    std::remove_reference<B>::type
+                >::value
+            >::type;
+    }
+
     /// <summary>
     ///     Silently 'observe' all exceptions thrown from a range of tasks.
     /// </summary>
@@ -126,7 +138,7 @@ namespace pplx
     template <typename ReturnType>
     struct observe_exceptions
     {
-        template <typename InputRange>
+        template <typename InputRange, typename X = pplx::details::disable_if_same_or_derived<observe_exceptions, InputRange>>
         explicit observe_exceptions(InputRange&& tasks) : tasks(tasks.begin(), tasks.end()) {}
 
         template <typename InputIterator>

--- a/Development/pplx/test/pplx_utils_test.cpp
+++ b/Development/pplx/test/pplx_utils_test.cpp
@@ -7,8 +7,8 @@
 BST_TEST_CASE(testWhenAll)
 {
     pplx::task<void> default_task;
-    pplx::task<void> successful_task1 = pplx::task_from_result<void>();
-    pplx::task<void> successful_task2 = pplx::task_from_result<void>();
+    pplx::task<void> successful_task1 = pplx::task_from_result();
+    pplx::task<void> successful_task2 = pplx::task_from_result();
     pplx::task<void> failed_task = pplx::task_from_exception<void>(std::runtime_error("failed"));
 
     BST_REQUIRE_THROW(failed_task.wait(), std::runtime_error);

--- a/Development/pplx/test/pplx_utils_test.cpp
+++ b/Development/pplx/test/pplx_utils_test.cpp
@@ -3,46 +3,105 @@
 
 #include "bst/test/test.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////
-BST_TEST_CASE(testWhenAll)
+namespace
 {
-    pplx::task<void> default_task;
-    pplx::task<void> successful_task1 = pplx::task_from_result();
-    pplx::task<void> successful_task2 = pplx::task_from_result();
-    pplx::task<void> failed_task = pplx::task_from_exception<void>(std::runtime_error("failed"));
+    template <typename ReturnType>
+    inline pplx::task<ReturnType> task_from_default() { return pplx::task_from_result(ReturnType()); }
+
+    template <>
+    inline pplx::task<void> task_from_default() { return pplx::task_from_result(); }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEMPLATE_TEST_CASE_2(testPplxWhenAll, ReturnType, void, int)
+{
+    pplx::task<ReturnType> default_task;
+    pplx::task<ReturnType> successful_task1 = task_from_default<ReturnType>();
+    pplx::task<ReturnType> successful_task2 = task_from_default<ReturnType>();
+    pplx::task<ReturnType> failed_task = pplx::task_from_exception<ReturnType>(std::runtime_error("failed"));
+    pplx::task_completion_event<ReturnType> tce;
+    pplx::task<ReturnType> incomplete_task(tce);
+    using final_task = decltype(pplx::ranges::when_all(std::declval<std::initializer_list<pplx::task<ReturnType>>>()));
 
     BST_REQUIRE_THROW(failed_task.wait(), std::runtime_error);
+    BST_REQUIRE_THROW(default_task.wait(), pplx::invalid_operation);
 
     {
         auto tasks = { successful_task1, successful_task2 };
         bool continuation = false;
-        pplx::ranges::when_all(tasks).then([&](pplx::task<void> finally)
+        pplx::ranges::when_all(tasks).then([&](final_task finally)
         {
-            finally.get();
+            finally.wait();
             continuation = true;
         }).wait();
         BST_REQUIRE(continuation);
     }
 
     {
-        auto tasks = { successful_task1, failed_task };
+        auto tasks = { successful_task1, failed_task, incomplete_task };
         bool continuation = false;
-        pplx::ranges::when_all(tasks).then([&](pplx::task<void> finally)
+        pplx::ranges::when_all(tasks).then([&](final_task finally)
         {
-            BST_REQUIRE_THROW(finally.get(), std::runtime_error);
+            BST_REQUIRE_THROW(finally.wait(), std::runtime_error);
             continuation = true;
         }).wait();
         BST_REQUIRE(continuation);
     }
 
+    {
+        auto tasks = { default_task, incomplete_task };
+        bool continuation = false;
+        pplx::ranges::when_all(tasks).then([&](final_task finally)
+        {
+            BST_REQUIRE_THROW(finally.wait(), pplx::invalid_operation);
+            continuation = true;
+        }).wait();
+        BST_REQUIRE(continuation);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEMPLATE_TEST_CASE_2(testPplxWhenAny, ReturnType, void, int)
+{
+    pplx::task<ReturnType> default_task;
+    pplx::task<ReturnType> successful_task1 = task_from_default<ReturnType>();
+    pplx::task<ReturnType> successful_task2 = task_from_default<ReturnType>();
+    pplx::task<ReturnType> failed_task = pplx::task_from_exception<ReturnType>(std::runtime_error("failed"));
+    pplx::task_completion_event<ReturnType> tce;
+    pplx::task<ReturnType> incomplete_task(tce);
+    using final_task = decltype(pplx::ranges::when_any(std::declval<std::initializer_list<pplx::task<ReturnType>>>()));
+
+    BST_REQUIRE_THROW(failed_task.wait(), std::runtime_error);
     BST_REQUIRE_THROW(default_task.wait(), pplx::invalid_operation);
 
     {
-        auto tasks = { successful_task1, default_task };
+        auto tasks = { successful_task1, successful_task2 };
         bool continuation = false;
-        pplx::ranges::when_all(tasks).then([&](pplx::task<void> finally)
+        pplx::ranges::when_any(tasks).then([&](final_task finally)
         {
-            BST_REQUIRE_THROW(finally.get(), pplx::invalid_operation);
+            finally.wait();
+            continuation = true;
+        }).wait();
+        BST_REQUIRE(continuation);
+    }
+
+    {
+        auto tasks = { successful_task1, failed_task, incomplete_task };
+        bool continuation = false;
+        pplx::ranges::when_any(tasks).then([&](final_task finally)
+        {
+            finally.wait();
+            continuation = true;
+        }).wait();
+        BST_REQUIRE(continuation);
+    }
+
+    {
+        auto tasks = { default_task };
+        bool continuation = false;
+        pplx::ranges::when_any(tasks).then([&](final_task finally)
+        {
+            BST_REQUIRE_THROW(finally.wait(), pplx::invalid_operation);
             continuation = true;
         }).wait();
         BST_REQUIRE(continuation);

--- a/Development/pplx/test/pplx_utils_test.cpp
+++ b/Development/pplx/test/pplx_utils_test.cpp
@@ -1,0 +1,50 @@
+// The first "test" is of course whether the header compiles standalone
+#include "pplx/pplx_utils.h"
+
+#include "bst/test/test.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testWhenAll)
+{
+    pplx::task<void> default_task;
+    pplx::task<void> successful_task1 = pplx::task_from_result<void>();
+    pplx::task<void> successful_task2 = pplx::task_from_result<void>();
+    pplx::task<void> failed_task = pplx::task_from_exception<void>(std::runtime_error("failed"));
+
+    BST_REQUIRE_THROW(failed_task.wait(), std::runtime_error);
+
+    {
+        auto tasks = { successful_task1, successful_task2 };
+        bool continuation = false;
+        pplx::ranges::when_all(tasks).then([&](pplx::task<void> finally)
+        {
+            finally.get();
+            continuation = true;
+        }).wait();
+        BST_REQUIRE(continuation);
+    }
+
+    {
+        auto tasks = { successful_task1, failed_task };
+        bool continuation = false;
+        pplx::ranges::when_all(tasks).then([&](pplx::task<void> finally)
+        {
+            BST_REQUIRE_THROW(finally.get(), std::runtime_error);
+            continuation = true;
+        }).wait();
+        BST_REQUIRE(continuation);
+    }
+
+    BST_REQUIRE_THROW(default_task.wait(), pplx::invalid_operation);
+
+    {
+        auto tasks = { successful_task1, default_task };
+        bool continuation = false;
+        pplx::ranges::when_all(tasks).then([&](pplx::task<void> finally)
+        {
+            BST_REQUIRE_THROW(finally.get(), pplx::invalid_operation);
+            continuation = true;
+        }).wait();
+        BST_REQUIRE(continuation);
+    }
+}


### PR DESCRIPTION
Many thanks to @SvenKordon, Rohde & Schwarz GmbH, for identifying and discussing this issue in #258.
The underlying issues have been raised on cpprestsdk (linked from above), but this PR provides a general purpose workaround within nmos-cpp.