### PR TITLE
Output GitHub job summary for "AMWA test suite" step

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -464,7 +464,7 @@ jobs:
           avahi-publish -a -R nmos-api.local ${{ env.HOST_IP_ADDRESS }} &
         fi
 
-        ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
+        ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges $GITHUB_STEP_SUMMARY ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
 
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           if [[ "${{ matrix.install_mdns }}" == "true" ]]; then
@@ -968,7 +968,7 @@ jobs:
           avahi-publish -a -R nmos-api.local ${{ env.HOST_IP_ADDRESS }} &
         fi
 
-        ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
+        ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges $GITHUB_STEP_SUMMARY ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
 
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           if [[ "${{ matrix.install_mdns }}" == "true" ]]; then

--- a/.github/workflows/src/amwa-test.yml
+++ b/.github/workflows/src/amwa-test.yml
@@ -147,7 +147,7 @@
       avahi-publish -a -R nmos-api.local ${{ env.HOST_IP_ADDRESS }} &
     fi
     
-    ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
+    ${{ env.GITHUB_WORKSPACE_BASH }}/Sandbox/run_nmos_testing.sh "$run_python" ${domain} ${root_dir}/build/nmos-cpp-node ${root_dir}/build/nmos-cpp-registry results badges $GITHUB_STEP_SUMMARY ${{ env.HOST_IP_ADDRESS }} "${{ env.GITHUB_COMMIT }}-${{ env.BUILD_NAME }}-"
 
     if [[ "${{ runner.os }}" == "Linux" ]]; then
       if [[ "${{ matrix.install_mdns }}" == "true" ]]; then

--- a/Sandbox/run_nmos_testing.sh
+++ b/Sandbox/run_nmos_testing.sh
@@ -12,6 +12,8 @@ results_dir=$1
 shift
 badges_dir=$1
 shift
+summary_path=$1
+shift
 host_ip=$1
 shift
 build_prefix=$1
@@ -160,8 +162,12 @@ function do_run_test() {
     fi
   fi
   case $result in
-  [0-1])  echo "Pass" | tee ${badges_dir}/${suite}.txt ;;
-  *)      echo "Fail" | tee ${badges_dir}/${suite}.txt ;;
+  [0-1])  echo "Pass" | tee ${badges_dir}/${suite}.txt
+          echo "${suite} :heavy_check_mark:" >> ${summary_path}
+          ;;
+  *)      echo "Fail" | tee ${badges_dir}/${suite}.txt
+          echo "${suite} :x:" >> ${summary_path}
+          ;;
   esac
 }
 


### PR DESCRIPTION
We can finally output nice AMWA test results in the GitHub Actions job summary so we don't have to scroll through the logs!!!! https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/

![Screenshot from 2022-05-12 13-12-09](https://user-images.githubusercontent.com/31761158/168072008-4c9f2d9b-ae9c-45ac-9db0-194a230145b5.png)
