### PR TITLE
Bump OpenSSL to 1.1.1o

### DIFF
--- a/Development/conanfile.txt
+++ b/Development/conanfile.txt
@@ -2,7 +2,7 @@
 boost/1.78.0
 cpprestsdk/2.10.18
 websocketpp/0.8.2
-openssl/1.1.1n
+openssl/1.1.1o
 json-schema-validator/2.1.0
 
 [imports]

--- a/Documents/Dependencies.md
+++ b/Documents/Dependencies.md
@@ -240,7 +240,7 @@ It is also possible to use OpenSSL 1.0, but the OpenSSL team announced that [use
 1. Download and install a recent release
    Notes:
    - On Windows, an installer can be downloaded from [Shining Light Productions - Win32 OpenSSL](https://slproweb.com/products/Win32OpenSSL.html)  
-     The Win64 OpenSSL v1.1.1n installer (latest release at the time) has been tested
+     The Win64 OpenSSL v1.1.1o installer (latest release at the time) has been tested
    - On Linux distributions, an OpenSSL package may already be available  
      The Ubuntu team announced an [OpenSSL 1.1.1 stable release update (SRU) for Ubuntu 18.04 LTS](https://lists.ubuntu.com/archives/ubuntu-devel/2018-December/040567.html)
 

--- a/Sandbox/conan-recipe/conanfile.py
+++ b/Sandbox/conan-recipe/conanfile.py
@@ -48,7 +48,7 @@ class NmosCppConan(ConanFile):
         self.requires("boost/1.78.0")
         self.requires("cpprestsdk/2.10.18")
         self.requires("websocketpp/0.8.2")
-        self.requires("openssl/1.1.1n")
+        self.requires("openssl/1.1.1o")
         self.requires("json-schema-validator/2.1.0")
 
     def build_requirements(self):


### PR DESCRIPTION
OpenSSL 1.1.1o was released on 3 May 2022.
https://www.openssl.org/news/openssl-1.1.1-notes.html