### PR TITLE
Bump CMake to 3.23

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -97,7 +97,7 @@ jobs:
         conan config set general.revisions_enabled=1
 
     - name: install cmake
-      uses: lukka/get-cmake@v3.21.1
+      uses: lukka/get-cmake@v3.23.0
 
     - name: setup bash path
       working-directory: ${{ env.GITHUB_WORKSPACE }}
@@ -601,7 +601,7 @@ jobs:
         conan config set general.revisions_enabled=1
 
     - name: install cmake
-      uses: lukka/get-cmake@v3.21.1
+      uses: lukka/get-cmake@v3.23.0
 
     - name: setup bash path
       working-directory: ${{ env.GITHUB_WORKSPACE }}

--- a/.github/workflows/src/build-setup.yml
+++ b/.github/workflows/src/build-setup.yml
@@ -5,7 +5,7 @@
     conan config set general.revisions_enabled=1
 
 - name: install cmake
-  uses: lukka/get-cmake@v3.21.1
+  uses: lukka/get-cmake@v3.23.0
 
 - name: setup bash path
   working-directory: ${{ env.GITHUB_WORKSPACE }}

--- a/Development/cmake/NmosCppDependencies.cmake
+++ b/Development/cmake/NmosCppDependencies.cmake
@@ -1,7 +1,7 @@
 # Boost
 
 set(BOOST_VERSION_MIN "1.54.0")
-set(BOOST_VERSION_CUR "1.78.0")
+set(BOOST_VERSION_CUR "1.79.0")
 # note: 1.57.0 doesn't work due to https://svn.boost.org/trac10/ticket/10754
 # note: some components are only required for one platform or other
 # so find_package(Boost) is called after adding those components

--- a/Development/conanfile.txt
+++ b/Development/conanfile.txt
@@ -2,7 +2,7 @@
 boost/1.78.0
 cpprestsdk/2.10.18
 websocketpp/0.8.2
-openssl/1.1.1n
+openssl/1.1.1o
 json-schema-validator/2.1.0
 
 [imports]

--- a/Development/conanfile.txt
+++ b/Development/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-boost/1.78.0
+boost/1.79.0
 cpprestsdk/2.10.18
 websocketpp/0.8.2
 openssl/1.1.1o

--- a/Documents/Dependencies.md
+++ b/Documents/Dependencies.md
@@ -80,9 +80,9 @@ If using Conan, this section can be skipped.
 
 1. Download a [recent release](http://www.boost.org/users/download/)  
    Notes:
-   - Several Boost releases have been tested, including Version 1.78.0 (latest release at the time) and Version 1.54.0
+   - Several Boost releases have been tested, including Version 1.79.0 (latest release at the time) and Version 1.54.0
    - On Linux distributions, a Boost libraries package may already be installed, e.g. Ubuntu 14.04 LTS has Version 1.54.0
-2. Expand the archive so that, for example, the boost\_1\_78\_0 directory is at the same level as the nmos-cpp directory
+2. Expand the archive so that, for example, the boost\_1\_79\_0 directory is at the same level as the nmos-cpp directory
 3. Build and stage (or install) the following Boost libraries for your platform/toolset:
    - atomic
    - chrono
@@ -152,8 +152,8 @@ If using Conan, this section can be skipped.
      - Set ``Boost_USE_STATIC_LIBS`` (BOOL) to ``1`` (true)
    - If CMake cannot find it automatically, set hints for [finding Boost](https://cmake.org/cmake/help/latest/module/FindBoost.html), for example:
      - *Either* set ``Boost_DIR`` (PATH) to the location of the installed BoostConfig.cmake (since Boost 1.70.0)
-     - *Or* set ``BOOST_INCLUDEDIR`` (PATH) and ``BOOST_LIBRARYDIR`` (PATH) to the appropriate full paths, e.g. *``<home-dir>``*``/boost_1_78_0``
-       and *``<home-dir>``*``/boost_1_78_0/x64/lib`` respectively to match the suggested ``b2`` command
+     - *Or* set ``BOOST_INCLUDEDIR`` (PATH) and ``BOOST_LIBRARYDIR`` (PATH) to the appropriate full paths, e.g. *``<home-dir>``*``/boost_1_79_0``
+       and *``<home-dir>``*``/boost_1_79_0/x64/lib`` respectively to match the suggested ``b2`` command
    - Due to interactions with other dependencies, it may also be necessary to explicitly set ``WERROR`` (BOOL) to ``0`` so that compiler warnings are not treated as errors
    - To speed up the build by omitting the C++ REST SDK sample apps and test suite, set ``BUILD_SAMPLES`` and ``BUILD_TESTS`` (BOOL) to ``0`` (false)
 3. Use CMake to generate build/project files, and then build *and* install  
@@ -172,8 +172,8 @@ cmake .. ^
   -DCPPREST_EXCLUDE_COMPRESSION:BOOL="1" ^
   -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" ^
   -DBoost_USE_STATIC_LIBS:BOOL="1" ^
-  -DBOOST_INCLUDEDIR:PATH="<home-dir>/boost_1_78_0" ^
-  -DBOOST_LIBRARYDIR:PATH="<home-dir>/boost_1_78_0/x64/lib" ^
+  -DBOOST_INCLUDEDIR:PATH="<home-dir>/boost_1_79_0" ^
+  -DBOOST_LIBRARYDIR:PATH="<home-dir>/boost_1_79_0/x64/lib" ^
   -DWERROR:BOOL="0" ^
   -DBUILD_SAMPLES:BOOL="0" ^
   -DBUILD_TESTS:BOOL="0"

--- a/Documents/Dependencies.md
+++ b/Documents/Dependencies.md
@@ -33,14 +33,14 @@ Specific instructions for [cross-compiling for Raspberry Pi](Raspberry-Pi.md) ar
 
 1. Download and install a recent [CMake stable release](https://cmake.org/download/#latest) for your platform  
    Notes:
-   - Currently, CMake 3.17 or higher is required; version 3.21.1 (latest release at the time) has been tested
+   - Currently, CMake 3.17 or higher is required; version 3.23.2 (latest release at the time) has been tested
    - Pre-built binary distributions are available for many platforms
    - On Linux distributions, e.g. Ubuntu 14.04 LTS (long-term support), the pre-built binary version available via ``apt-get`` may be too out-of-date  
      Fetch, build and install a suitable version:  
      ```sh
-     wget "https://cmake.org/files/v3.21/cmake-3.21.1.tar.gz"
-     tar -zxvf cmake-3.21.1.tar.gz
-     cd cmake-3.21.1
+     wget "https://cmake.org/files/v3.23/cmake-3.23.2.tar.gz"
+     tar -zxvf cmake-3.23.2.tar.gz
+     cd cmake-3.23.2
      ./bootstrap
      make
      sudo make install

--- a/Documents/Dependencies.md
+++ b/Documents/Dependencies.md
@@ -240,7 +240,7 @@ It is also possible to use OpenSSL 1.0, but the OpenSSL team announced that [use
 1. Download and install a recent release
    Notes:
    - On Windows, an installer can be downloaded from [Shining Light Productions - Win32 OpenSSL](https://slproweb.com/products/Win32OpenSSL.html)  
-     The Win64 OpenSSL v1.1.1n installer (latest release at the time) has been tested
+     The Win64 OpenSSL v1.1.1o installer (latest release at the time) has been tested
    - On Linux distributions, an OpenSSL package may already be available  
      The Ubuntu team announced an [OpenSSL 1.1.1 stable release update (SRU) for Ubuntu 18.04 LTS](https://lists.ubuntu.com/archives/ubuntu-devel/2018-December/040567.html)
 

--- a/Documents/Getting-Started.md
+++ b/Documents/Getting-Started.md
@@ -32,8 +32,8 @@ Notes:
 
      - If CMake cannot find it automatically, set hints for [finding Boost](https://cmake.org/cmake/help/latest/module/FindBoost.html), for example:
        - *Either* set ``Boost_DIR`` (PATH) to the location of the installed *BoostConfig.cmake* (since Boost 1.70.0)
-       - *Or* set ``BOOST_INCLUDEDIR`` (PATH) and ``BOOST_LIBRARYDIR`` (PATH) to the appropriate full paths, e.g. *``<home-dir>``*``/boost_1_78_0``
-         and *``<home-dir>``*``/boost_1_78_0/x64/lib`` respectively to match the suggested ``b2`` command
+       - *Or* set ``BOOST_INCLUDEDIR`` (PATH) and ``BOOST_LIBRARYDIR`` (PATH) to the appropriate full paths, e.g. *``<home-dir>``*``/boost_1_79_0``
+         and *``<home-dir>``*``/boost_1_79_0/x64/lib`` respectively to match the suggested ``b2`` command
      - If CMake cannot find them automatically, set hints for finding the C++ REST SDK and WebSocket++, for example:
        - Set ``cpprestsdk_DIR`` (PATH) to the location of the installed *cpprestsdk-config.cmake*
        - *Either* set ``websocketpp_DIR`` (PATH) to the location of the installed *websocketpp-config.cmake*
@@ -75,8 +75,8 @@ cmake .. ^
   -G "Visual Studio 16 2019" ^
   -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" ^
   -DBoost_USE_STATIC_LIBS:BOOL="1" ^
-  -DBOOST_INCLUDEDIR:PATH="<home-dir>/boost_1_78_0" ^
-  -DBOOST_LIBRARYDIR:PATH="<home-dir>/boost_1_78_0/x64/lib" ^
+  -DBOOST_INCLUDEDIR:PATH="<home-dir>/boost_1_79_0" ^
+  -DBOOST_LIBRARYDIR:PATH="<home-dir>/boost_1_79_0/x64/lib" ^
   -DWEBSOCKETPP_INCLUDE_DIR:PATH="<home-dir>/cpprestsdk/Release/libs/websocketpp"
 ```
 

--- a/Sandbox/conan-recipe/conanfile.py
+++ b/Sandbox/conan-recipe/conanfile.py
@@ -45,7 +45,7 @@ class NmosCppConan(ConanFile):
 
     def requirements(self):
         # for now, consistent with project's conanfile.txt
-        self.requires("boost/1.78.0")
+        self.requires("boost/1.79.0")
         self.requires("cpprestsdk/2.10.18")
         self.requires("websocketpp/0.8.2")
         self.requires("openssl/1.1.1o")

--- a/Sandbox/conan-recipe/conanfile.py
+++ b/Sandbox/conan-recipe/conanfile.py
@@ -48,7 +48,7 @@ class NmosCppConan(ConanFile):
         self.requires("boost/1.78.0")
         self.requires("cpprestsdk/2.10.18")
         self.requires("websocketpp/0.8.2")
-        self.requires("openssl/1.1.1n")
+        self.requires("openssl/1.1.1o")
         self.requires("json-schema-validator/2.1.0")
 
     def build_requirements(self):


### PR DESCRIPTION
CMake 3.23.0 was released 29 March 2022.
https://www.kitware.com/cmake-3-23-0-is-available-for-download/

CMake 3.23.2 was released 25 May 2022.
https://www.kitware.com/cmake-3-23-2-available-for-download/

(Merge after #267.)