### PR TITLE
Relax fmtp requirement for whitespace after semicolon

### DIFF
--- a/Development/sdp/sdp_grammar.cpp
+++ b/Development/sdp/sdp_grammar.cpp
@@ -160,8 +160,8 @@ namespace sdp
         // ST 2110-20:2022 says "the <format specific parameters> section shall consist of a sequence of
         // media type parameter entries, separated by the semicolon (";") character followed by whitespace"
         // but RFC 4566 does not itself specify the syntax of format-specific parameters and many examples
-        // in other RFCs and SMPTE standards are inconsistent, so make the following whitespace optional
-        const converter named_values_converter = array_converter(key_value_converter('=', { sdp::fields::name, string_converter }, { sdp::fields::value, string_converter }), "; ", ";[ \\t]*");
+        // in other RFCs and SMPTE standards are inconsistent, so allow additional whitespace
+        const converter named_values_converter = array_converter(key_value_converter('=', { sdp::fields::name, string_converter }, { sdp::fields::value, string_converter }), "; ", "[ \\t]*(;[ \\t]*|$)");
 
         converter object_converter(const std::vector<std::pair<utility::string_t, converter>>& field_converters, const std::string& delimiter = " ")
         {

--- a/Development/sdp/sdp_grammar.cpp
+++ b/Development/sdp/sdp_grammar.cpp
@@ -567,7 +567,7 @@ namespace sdp
                             s += " ";
                             // <format specific parameters> are required but may be empty
                             const auto& params = v.at(sdp::fields::format_specific_parameters);
-                            if (0 != params.size()) s += named_values_converter.format(params) + "; ";
+                            s += named_values_converter.format(params);
                             return s;
                         },
                         [](const std::string& s) {

--- a/Development/sdp/test/sdp_test.cpp
+++ b/Development/sdp/test/sdp_test.cpp
@@ -19,7 +19,7 @@ c=IN IP4 239.22.142.1/32
 a=ts-refclk:ptp=IEEE1588-2008:traceable
 a=source-filter: incl IN IP4 239.22.142.1 192.168.9.142
 a=rtpmap:96 raw/90000
-a=fmtp:96 colorimetry=BT709; exactframerate=30000/1001; depth=10; TCS=SDR; sampling=YCbCr-4:2:2; width=1920; interlace; TP=2110TPN; PM=2110GPM; height=1080; SSN=ST2110-20:2017; 
+a=fmtp:96 colorimetry=BT709; exactframerate=30000/1001; depth=10; TCS=SDR; sampling=YCbCr-4:2:2; width=1920; interlace; TP=2110TPN; PM=2110GPM; height=1080; SSN=ST2110-20:2017
 a=mediaclk:direct=0
 a=mid:PRIMARY
 m=video 50120 RTP/AVP 96
@@ -27,7 +27,7 @@ c=IN IP4 239.122.142.1/32
 a=ts-refclk:ptp=IEEE1588-2008:traceable
 a=source-filter: incl IN IP4 239.122.142.1 192.168.109.142
 a=rtpmap:96 raw/90000
-a=fmtp:96 colorimetry=BT709; exactframerate=30000/1001; depth=10; TCS=SDR; sampling=YCbCr-4:2:2; width=1920; interlace; TP=2110TPN; PM=2110GPM; height=1080; SSN=ST2110-20:2017; 
+a=fmtp:96 colorimetry=BT709; exactframerate=30000/1001; depth=10; TCS=SDR; sampling=YCbCr-4:2:2; width=1920; interlace; TP=2110TPN; PM=2110GPM; height=1080; SSN=ST2110-20:2017
 a=mediaclk:direct=0
 a=mid:SECONDARY
 )";

--- a/Development/sdp/test/sdp_test.cpp
+++ b/Development/sdp/test/sdp_test.cpp
@@ -408,7 +408,9 @@ a=fmtp:96)";
     const std::vector<std::string> bad_params = {
         " ;",
         " ; foo=meow",
+        " foo=",
         " foo=meow;;",
+        " bar=; foo=meow",
         " bar=purr; ; foo=meow"
     };
 


### PR DESCRIPTION
ST 2110-20 requires whitespace after the semicolon within format-specific parameters:

![tempFileForShare_20220825-064715](https://user-images.githubusercontent.com/31761158/186616631-48ebe338-44d7-40a3-abc5-a42035ebed1f.jpg)

However, RFC 4566 (and RFC 8866) doesn't specify this syntax, and many examples, in both RFCs and SMPTE specs, show semicolon used as separator with no following whitespace.

We relaxed the SDPoker check some time ago... https://github.com/AMWA-TV/sdpoker/pull/6.

Note that this does not accept whitespace _preceding_ the semicolon, partly because I'm lazy and handling trailing whitespace after the last parameter (with no semicolon) is a harder change, and because ST 2110-20 also says no whitespace within the name or value.
