### PR TITLE
OCSP patch 1

### DIFF
--- a/Development/cpprest/http_utils.h
+++ b/Development/cpprest/http_utils.h
@@ -207,10 +207,10 @@ namespace web
                 typedef pplx::open_close_guard<http_listener> http_listener_guard;
 
                 // platform-specific wildcard address to accept connections for any address
-#if defined(_WIN32) && !defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
-                const utility::string_t host_wildcard{ _XPLATSTR("*") }; // "weak wildcard"
-#else
+#if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
                 const utility::string_t host_wildcard{ _XPLATSTR("0.0.0.0") };
+#else
+                const utility::string_t host_wildcard{ _XPLATSTR("*") }; // "weak wildcard"
 #endif
 
                 // make an address to be used to accept HTTP or HTTPS connections for the specified address and port

--- a/Development/cpprest/test/api_router_test.cpp
+++ b/Development/cpprest/test/api_router_test.cpp
@@ -7,10 +7,11 @@
 ////////////////////////////////////////////////////////////////////////////////////////////
 BST_TEST_CASE(testMakeListenerUri)
 {
-#if defined(_WIN32) && !defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
-    BST_REQUIRE_STRING_EQUAL("http://*:42/", utility::us2s(web::http::experimental::listener::make_listener_uri(42).to_string()));
-#else
+// cf. preprocessor conditions for web::http::experimental::listener::host_wildcard
+#if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
     BST_REQUIRE_STRING_EQUAL("http://0.0.0.0:42/", utility::us2s(web::http::experimental::listener::make_listener_uri(42).to_string()));
+#else
+    BST_REQUIRE_STRING_EQUAL("http://*:42/", utility::us2s(web::http::experimental::listener::make_listener_uri(42).to_string()));
 #endif
 
     BST_REQUIRE_STRING_EQUAL("http://203.0.113.42:42/", utility::us2s(web::http::experimental::listener::make_listener_uri(U("203.0.113.42"), 42).to_string()));

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -1,5 +1,6 @@
 #include "nmos/client_utils.h"
 
+// cf. preprocessor conditions in nmos::details::make_client_ssl_context_callback
 #if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
 #include "boost/asio/ssl/set_cipher_list.hpp"
 #endif
@@ -27,6 +28,7 @@ namespace nmos
 
     namespace details
     {
+// cf. preprocessor conditions in nmos::make_http_client_config and nmos::make_websocket_client_config
 #if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
         template <typename ExceptionType>
         inline std::function<void(boost::asio::ssl::context&)> make_client_ssl_context_callback(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, slog::base_gate& gate)

--- a/Development/nmos/node_server.cpp
+++ b/Development/nmos/node_server.cpp
@@ -116,12 +116,15 @@ namespace nmos
                 node_server.thread_functions.push_back([&, load_ca_certificates, system_changed] { nmos::node_system_behaviour_thread(node_model, load_ca_certificates, system_changed, gate); });
             }
 
-#if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
+// only implement communication with OCSP responder if http_listener supports OCSP stapling
+// cf. preprocessor conditions in nmos::make_http_listener_config
+#if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
             if (server_secure)
             {
                 node_server.thread_functions.push_back([&, load_ca_certificates, load_server_certificates] { nmos::ocsp_behaviour_thread(node_model, node_server.ocsp_settings, load_ca_certificates, load_server_certificates, gate); });
             }
 #endif
+
             return node_server;
         }
 

--- a/Development/nmos/ocsp_behaviour.cpp
+++ b/Development/nmos/ocsp_behaviour.cpp
@@ -1,6 +1,5 @@
 #include "nmos/ocsp_behaviour.h"
 
-#if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
 #include "pplx/pplx_utils.h" // for pplx::complete_at
 #include "nmos/client_utils.h"
 #include "nmos/model.h"
@@ -373,5 +372,3 @@ namespace nmos
         }
     }
 }
-
-#endif

--- a/Development/nmos/ocsp_behaviour.h
+++ b/Development/nmos/ocsp_behaviour.h
@@ -18,10 +18,8 @@ namespace nmos
         struct ocsp_settings;
     }
 
-#if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
     // callbacks from this function are called with the model locked, and may read or write directly to the model
     void ocsp_behaviour_thread(nmos::model& model, nmos::experimental::ocsp_settings& ocsp_settings, load_ca_certificates_handler load_ca_certificates, load_server_certificates_handler load_server_certificate, slog::base_gate & gate);
-#endif
 }
 
 #endif

--- a/Development/nmos/registry_server.cpp
+++ b/Development/nmos/registry_server.cpp
@@ -142,7 +142,9 @@ namespace nmos
                 [&] { nmos::advertise_registry_thread(registry_model, gate); }
             });
 
-#if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
+// only implement communication with OCSP responder if http_listener supports OCSP stapling
+// cf. preprocessor conditions in nmos::make_http_listener_config
+#if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
             if (server_secure)
             {
                 auto load_ca_certificates = registry_implementation.load_ca_certificates;
@@ -150,6 +152,7 @@ namespace nmos
                 registry_server.thread_functions.push_back([&, load_ca_certificates, load_server_certificates] { nmos::ocsp_behaviour_thread(registry_model, registry_server.ocsp_settings, load_ca_certificates, load_server_certificates, gate); });
             }
 #endif
+
             return registry_server;
         }
 

--- a/Development/nmos/server_utils.cpp
+++ b/Development/nmos/server_utils.cpp
@@ -1,7 +1,8 @@
 #include "nmos/server_utils.h"
 
 #include <algorithm>
-#if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
+// cf. preprocessor conditions in nmos::details::make_listener_ssl_context_callback
+#if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
 #include "boost/asio/ssl/set_cipher_list.hpp"
 #include "boost/asio/ssl/use_tmp_ecdh.hpp"
 #endif
@@ -20,7 +21,8 @@ namespace nmos
 {
     namespace details
     {
-#if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
+// cf. preprocessor conditions in nmos::make_http_listener_config and nmos::make_websocket_listener_config
+#if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
         template <typename ExceptionType>
         inline std::function<void(boost::asio::ssl::context&)> make_listener_ssl_context_callback(const nmos::settings& settings, const nmos::experimental::ocsp_settings& ocsp_settings,load_server_certificates_handler load_server_certificates, load_dh_param_handler load_dh_param, slog::base_gate& gate)
         {

--- a/Development/nmos/ssl_context_options.h
+++ b/Development/nmos/ssl_context_options.h
@@ -1,7 +1,8 @@
 #ifndef NMOS_SSL_CONTEXT_OPTIONS_H
 #define NMOS_SSL_CONTEXT_OPTIONS_H
 
-#if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
+// cf. preprocessor conditions in nmos/client_utils.cpp and nmos/server_utils.cpp
+#if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
 #include "boost/asio/ssl.hpp"
 
 namespace nmos


### PR DESCRIPTION
Tweak preprocessor conditions for code that are only used with the Boost.ASIO implementation of http_client, http_listener, websocket_client, websocket_listener