### PR TITLE
video/jxsv

### DIFF
--- a/Development/cmake/NmosCppLibraries.cmake
+++ b/Development/cmake/NmosCppLibraries.cmake
@@ -799,6 +799,7 @@ set(NMOS_CPP_NMOS_SOURCES
     nmos/settings_api.cpp
     nmos/system_api.cpp
     nmos/system_resources.cpp
+    nmos/video_jxsv.cpp
     )
 set(NMOS_CPP_NMOS_HEADERS
     nmos/activation_mode.h
@@ -895,6 +896,7 @@ set(NMOS_CPP_NMOS_HEADERS
     nmos/transport.h
     nmos/type.h
     nmos/version.h
+    nmos/video_jxsv.h
     nmos/vpid_code.h
     nmos/websockets.h
     )

--- a/Development/cmake/NmosCppLibraries.cmake
+++ b/Development/cmake/NmosCppLibraries.cmake
@@ -886,6 +886,7 @@ set(NMOS_CPP_NMOS_HEADERS
     nmos/settings_api.h
     nmos/slog.h
     nmos/ssl_context_options.h
+    nmos/st2110_21_sender_type.h
     nmos/string_enum.h
     nmos/string_enum_fwd.h
     nmos/system_api.h

--- a/Development/cmake/NmosCppTest.cmake
+++ b/Development/cmake/NmosCppTest.cmake
@@ -48,6 +48,7 @@ set(NMOS_CPP_TEST_NMOS_TEST_SOURCES
     nmos/test/query_api_test.cpp
     nmos/test/sdp_utils_test.cpp
     nmos/test/system_resources_test.cpp
+    nmos/test/video_jxsv_test.cpp
     )
 set(NMOS_CPP_TEST_NMOS_TEST_HEADERS
     )

--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -35,6 +35,9 @@
     // component_depth: controls the bits per component sample of video flows
     //"component_depth": 10,
 
+    // video_type: media type of video flows, e.g. "video/raw" or "video/jxsv", see nmos::media_types
+    //"video_type": "video/jxsv",
+
     // channel_count: controls the number of channels in audio sources
     //"channel_count": 8,
 

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -40,6 +40,7 @@
 #include "nmos/system_resources.h"
 #include "nmos/transfer_characteristic.h"
 #include "nmos/transport.h"
+#include "nmos/video_jxsv.h"
 #include "sdp/sdp.h"
 
 // example node implementation details
@@ -89,6 +90,9 @@ namespace impl
         // component_depth: controls the bits per component sample of video flows
         const web::json::field_as_integer_or component_depth{ U("component_depth"), 10 };
 
+        // video_type: media type of video flows, e.g. "video/raw" or "video/jxsv", see nmos::media_types
+        const web::json::field_as_string_or video_type{ U("video_type"), U("video/raw") };
+
         // channel_count: controls the number of channels in audio sources
         const web::json::field_as_integer_or channel_count{ U("channel_count"), 4 };
 
@@ -103,7 +107,7 @@ namespace impl
     DEFINE_STRING_ENUM(port)
     namespace ports
     {
-        // video/raw
+        // video/raw, video/jxsv, etc.
         const port video{ U("v") };
         // audio/L24
         const port audio{ U("a") };
@@ -224,8 +228,18 @@ void node_implementation_init(nmos::node_model& model, slog::base_gate& gate)
     const auto transfer_characteristic = nmos::transfer_characteristic{ impl::fields::transfer_characteristic(model.settings) };
     const auto sampling = sdp::sampling{ impl::fields::color_sampling(model.settings) };
     const auto bit_depth = impl::fields::component_depth(model.settings);
+    const auto video_type = nmos::media_type{ impl::fields::video_type(model.settings) };
     const auto channel_count = impl::fields::channel_count(model.settings);
     const auto smpte2022_7 = impl::fields::smpte2022_7(model.settings);
+
+    // for now, some typical values for video/jxsv, based on VSF TR-08:2022
+    // see https://vsf.tv/download/technical_recommendations/VSF_TR-08_2022-04-20.pdf
+    const auto profile = nmos::profiles::High444_12;
+    const auto level = nmos::get_video_jxsv_level(frame_rate, frame_width, frame_height);
+    const auto sublevel = nmos::sublevels::Sublev3bpp;
+    const auto max_bits_per_pixel = 4.0; // min coding efficiency
+    const auto bits_per_pixel = 2.0;
+    const auto transport_bit_rate_factor = 1.05;
 
     // any delay between updates to the model resources is unnecessary unless for debugging purposes
     const unsigned int delay_millis{ 0 };
@@ -343,13 +357,37 @@ void node_implementation_init(nmos::node_model& model, slog::base_gate& gate)
             nmos::resource flow;
             if (impl::ports::video == port)
             {
-                flow = nmos::make_raw_video_flow(
-                    flow_id, source_id, device_id,
-                    frame_rate,
-                    frame_width, frame_height, interlace_mode,
-                    colorspace, transfer_characteristic, sampling, bit_depth,
-                    model.settings
-                );
+                if (nmos::media_types::video_raw == video_type)
+                {
+                    flow = nmos::make_raw_video_flow(
+                        flow_id, source_id, device_id,
+                        frame_rate,
+                        frame_width, frame_height, interlace_mode,
+                        colorspace, transfer_characteristic, sampling, bit_depth,
+                        model.settings
+                    );
+                }
+                else
+                {
+                    flow = nmos::make_coded_video_flow(
+                        flow_id, source_id, device_id,
+                        frame_rate,
+                        frame_width, frame_height, interlace_mode,
+                        colorspace, transfer_characteristic, sampling, bit_depth,
+                        video_type,
+                        model.settings
+                    );
+                    if (nmos::media_types::video_jxsv == video_type)
+                    {
+                        // additional attributes required by BCP-006-01
+                        // see https://specs.amwa.tv/bcp-006-01/branches/v1.0-dev/docs/NMOS_With_JPEG_XS.html#flows
+                        flow.data[nmos::fields::components] = nmos::make_components(sampling, frame_width, frame_height, bit_depth);
+                        flow.data[nmos::fields::profile] = value(profile.name);
+                        flow.data[nmos::fields::level] = value(level.name);
+                        flow.data[nmos::fields::sublevel] = value(sublevel.name);
+                        flow.data[nmos::fields::bit_rate] = value(nmos::get_video_jxsv_bit_rate(frame_rate, frame_width, frame_height, bits_per_pixel));
+                    }
+                }
             }
             else if (impl::ports::audio == port)
             {
@@ -378,6 +416,16 @@ void node_implementation_init(nmos::node_model& model, slog::base_gate& gate)
 
             const auto manifest_href = nmos::experimental::make_manifest_api_manifest(sender_id, model.settings);
             auto sender = nmos::make_sender(sender_id, flow_id, nmos::transports::rtp, device_id, manifest_href.to_string(), interface_names, model.settings);
+            if (impl::ports::video == port && nmos::media_types::video_jxsv == video_type)
+            {
+                // additional attributes required by BCP-006-01
+                // see https://specs.amwa.tv/bcp-006-01/branches/v1.0-dev/docs/NMOS_With_JPEG_XS.html#senders
+                const auto format_bit_rate = nmos::get_video_jxsv_bit_rate(frame_rate, frame_width, frame_height, bits_per_pixel);
+                // round to nearest Megabit/second per examples in VSF TR-08:2022
+                const auto transport_bit_rate = uint64_t(transport_bit_rate_factor * format_bit_rate / 1e3 + 0.5) * 1000;
+                sender.data[nmos::fields::bit_rate] = value(transport_bit_rate);
+                sender.data[nmos::fields::st2110_21_sender_type] = value(nmos::st2110_21_sender_types::type_N.name);
+            }
             impl::set_label_description(sender, port, index);
             impl::insert_group_hint(sender, port, index);
 
@@ -417,20 +465,47 @@ void node_implementation_init(nmos::node_model& model, slog::base_gate& gate)
             nmos::resource receiver;
             if (impl::ports::video == port)
             {
-                receiver = nmos::make_video_receiver(receiver_id, device_id, nmos::transports::rtp, interface_names, model.settings);
-                // add an example constraint set; these should be completed fully!
+                const auto video_types = nmos::media_types::video_raw == video_type
+                    ? std::vector<nmos::media_type>{ video_type }
+                    : std::vector<nmos::media_type>{ nmos::media_types::video_raw, video_type };
+
+                receiver = nmos::make_receiver(receiver_id, device_id, nmos::transports::rtp, interface_names, nmos::formats::video, video_types, model.settings);
+                // add an example constraint set for each type; these should be completed fully!
                 const auto interlace_modes = nmos::interlace_modes::progressive != interlace_mode
                     ? std::vector<utility::string_t>{ nmos::interlace_modes::interlaced_bff.name, nmos::interlace_modes::interlaced_tff.name, nmos::interlace_modes::interlaced_psf.name }
                     : std::vector<utility::string_t>{ nmos::interlace_modes::progressive.name };
-                receiver.data[nmos::fields::caps][nmos::fields::constraint_sets] = value_of({
-                    value_of({
-                        { nmos::caps::format::grain_rate, nmos::make_caps_rational_constraint({ frame_rate }) },
-                        { nmos::caps::format::frame_width, nmos::make_caps_integer_constraint({ frame_width }) },
-                        { nmos::caps::format::frame_height, nmos::make_caps_integer_constraint({ frame_height }) },
-                        { nmos::caps::format::interlace_mode, nmos::make_caps_string_constraint(interlace_modes) },
-                        { nmos::caps::format::color_sampling, nmos::make_caps_string_constraint({ sampling.name }) }
-                    })
-                });
+                web::json::push_back(receiver.data[nmos::fields::caps][nmos::fields::constraint_sets], value_of({
+                    { nmos::media_types::video_raw != video_type ? nmos::caps::format::media_type.key : U(""), nmos::make_caps_string_constraint({ nmos::media_types::video_raw.name })},
+                    { nmos::caps::format::grain_rate, nmos::make_caps_rational_constraint({ frame_rate }) },
+                    { nmos::caps::format::frame_width, nmos::make_caps_integer_constraint({ frame_width }) },
+                    { nmos::caps::format::frame_height, nmos::make_caps_integer_constraint({ frame_height }) },
+                    { nmos::caps::format::interlace_mode, nmos::make_caps_string_constraint(interlace_modes) },
+                    { nmos::caps::format::color_sampling, nmos::make_caps_string_constraint({ sampling.name }) }
+                }));
+                if (nmos::media_types::video_jxsv == video_type)
+                {
+                    // some of the parameter constraints recommended by BCP-006-01
+                    // see https://specs.amwa.tv/bcp-006-01/branches/v1.0-dev/docs/NMOS_With_JPEG_XS.html#receivers
+                    const auto max_format_bit_rate = nmos::get_video_jxsv_bit_rate(frame_rate, frame_width, frame_height, max_bits_per_pixel);
+                    // round to nearest Megabit/second per examples in VSF TR-08:2022
+                    const auto max_transport_bit_rate = uint64_t(transport_bit_rate_factor * max_format_bit_rate / 1e3 + 0.5) * 1000;
+
+                    web::json::push_back(receiver.data[nmos::fields::caps][nmos::fields::constraint_sets], value_of({
+                        { nmos::caps::format::media_type, nmos::make_caps_string_constraint({ video_type.name })},
+                        { nmos::caps::format::profile, nmos::make_caps_string_constraint({ profile.name }) },
+                        { nmos::caps::format::level, nmos::make_caps_string_constraint({ level.name }) },
+                        { nmos::caps::format::sublevel, nmos::make_caps_string_constraint({ nmos::sublevels::Sublev3bpp.name, nmos::sublevels::Sublev4bpp.name }) },
+                        { nmos::caps::format::bit_rate, nmos::make_caps_integer_constraint({}, nmos::no_minimum<int64_t>(), (int64_t)max_format_bit_rate) },
+                        { nmos::caps::transport::bit_rate, nmos::make_caps_integer_constraint({}, nmos::no_minimum<int64_t>(), (int64_t)max_transport_bit_rate) },
+                        { nmos::caps::transport::packet_transmission_mode, nmos::make_caps_string_constraint({ nmos::packet_transmission_modes::codestream.name }) }
+                    }));
+                }
+                else
+                {
+                    web::json::push_back(receiver.data[nmos::fields::caps][nmos::fields::constraint_sets], value_of({
+                        { nmos::caps::format::media_type, nmos::make_caps_string_constraint({ video_type.name })}
+                    }));
+                }
                 receiver.data[nmos::fields::version] = receiver.data[nmos::fields::caps][nmos::fields::version] = value(nmos::make_version());
             }
             else if (impl::ports::audio == port)
@@ -903,9 +978,25 @@ nmos::registration_handler make_node_implementation_registration_handler(slog::b
 // Example Connection API callback to parse "transport_file" during a PATCH /staged request
 nmos::transport_file_parser make_node_implementation_transport_file_parser()
 {
-    // this example uses the default transport file parser explicitly
+    // this example uses a custom transport file parser to handle video/jxsv in addition to the core media types
+    // otherwise, it could simply return &nmos::parse_rtp_transport_file
     // (if this callback is specified, an 'empty' std::function is not allowed)
-    return &nmos::parse_rtp_transport_file;
+    return [](const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate)
+    {
+        const auto validate_sdp_parameters = [](const web::json::value& receiver, const nmos::sdp_parameters& sdp_params)
+        {
+            if (nmos::media_types::video_jxsv == nmos::get_media_type(sdp_params))
+            {
+                nmos::validate_video_jxsv_sdp_parameters(receiver, sdp_params);
+            }
+            else
+            {
+                // validate core media types, i.e., "video/raw", "audio/L", "video/smpte291" and "video/SMPTE2022-6"
+                nmos::validate_sdp_parameters(receiver, sdp_params);
+            }
+        };
+        return nmos::details::parse_rtp_transport_file(validate_sdp_parameters, receiver, connection_receiver, transport_file_type, transport_file_data, gate);
+    };
 }
 
 // Example Connection API callback to perform application-specific validation of the merged /staged endpoint during a PATCH /staged request
@@ -1014,7 +1105,21 @@ nmos::connection_sender_transportfile_setter make_node_implementation_transportf
                 const nmos::format format{ nmos::fields::format(flow->data) };
                 if (nmos::formats::video == format)
                 {
-                    return nmos::make_video_sdp_parameters(node->data, source->data, flow->data, sender.data, nmos::details::payload_type_video_default, mids, {}, sdp::type_parameters::type_N);
+                    const nmos::media_type video_type{ nmos::fields::media_type(flow->data) };
+                    if (nmos::media_types::video_raw == video_type)
+                    {
+                        return nmos::make_video_sdp_parameters(node->data, source->data, flow->data, sender.data, nmos::details::payload_type_video_default, mids, {}, sdp::type_parameters::type_N);
+                    }
+                    else if (nmos::media_types::video_jxsv == video_type)
+                    {
+                        const auto params = nmos::make_video_jxsv_parameters(node->data, source->data, flow->data, sender.data);
+                        const auto ts_refclk = nmos::details::make_ts_refclk(node->data, source->data, sender.data, {});
+                        return nmos::make_sdp_parameters(nmos::fields::label(sender.data), params, nmos::details::payload_type_video_default, mids, ts_refclk);
+                    }
+                    else
+                    {
+                        throw std::logic_error("unexpected flow media_type");
+                    }
                 }
                 else if (nmos::formats::audio == format)
                 {

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -36,6 +36,7 @@
 #include "nmos/random.h"
 #include "nmos/sdp_utils.h"
 #include "nmos/slog.h"
+#include "nmos/st2110_21_sender_type.h"
 #include "nmos/system_resources.h"
 #include "nmos/transfer_characteristic.h"
 #include "nmos/transport.h"

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -571,7 +571,7 @@ void node_implementation_init(nmos::node_model& model, slog::base_gate& gate)
         }
     }
 
-    // example event sources, senders, flows
+    // example event sources, flows and senders
     for (int index = 0; 0 <= nmos::fields::events_port(model.settings) && index < how_many; ++index)
     {
         for (const auto& port : impl::ports::ws)

--- a/Development/nmos/json_fields.h
+++ b/Development/nmos/json_fields.h
@@ -229,6 +229,13 @@ namespace nmos
         const web::json::field_as_value_or syslogv2{ U("syslogv2"), {} };
         const web::json::field_as_string hostname{ U("hostname") }; // hostname, ipv4 or ipv6
         const web::json::field_as_integer port{ U("port") }; // 1..65535
+
+        // NMOS Parameter Registers
+
+        // Sender Attributes Register
+
+        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#st-2110-21-sender-type
+        const web::json::field_as_string st2110_21_sender_type{ U("st2110_21_sender_type") };
     }
 
     // Fields for experimental extensions

--- a/Development/nmos/json_fields.h
+++ b/Development/nmos/json_fields.h
@@ -72,6 +72,7 @@ namespace nmos
         const web::json::field_as_value grain_rate{ U("grain_rate") }; // or field<nmos::rational> with a bit of work!
         const web::json::field_as_integer numerator{ U("numerator") };
         const web::json::field_as_integer_or denominator{ U("denominator"), 1 };
+        const web::json::field_as_string media_type{ U("media_type") }; // strictly speaking, defined in flow_video_raw, flow_video_coded, etc.
         // flow_video
         const web::json::field_as_integer frame_width{ U("frame_width") };
         const web::json::field_as_integer frame_height{ U("frame_height") };

--- a/Development/nmos/json_fields.h
+++ b/Development/nmos/json_fields.h
@@ -30,13 +30,13 @@ namespace nmos
     // Field accessors simplify access to fields in json request bodies
     namespace fields
     {
-        const web::json::field_as_string id{ U("id") };
+        const web::json::field_as_string id{ U("id") }; // see nmos::id
         const web::json::field<tai> version{ U("version") };
 
         // IS-04 Discovery and Registration
 
         // (mostly) for node_api and registration_api
-        const web::json::field_as_string type{ U("type") };
+        const web::json::field_as_string type{ U("type") }; // see nmos::type
         const web::json::field_as_value data{ U("data") };
         // resource_core
         const web::json::field_as_string label{ U("label") };
@@ -50,60 +50,60 @@ namespace nmos
         const web::json::field_as_string port_id{ U("port_id") };
         const web::json::field_as_value_or attached_network_device{ U("attached_network_device"), {} }; // object
         const web::json::field_as_array clocks{ U("clocks") };
-        const web::json::field_as_string ref_type{ U("ref_type") };
+        const web::json::field_as_string ref_type{ U("ref_type") }; // see nmos::clock_ref_type
         const web::json::field_as_string ptp_version{ U("version") };
         const web::json::field_as_string gmid{ U("gmid") };
         const web::json::field_as_bool traceable{ U("traceable") };
         const web::json::field_as_bool locked{ U("locked") };
         // device
-        const web::json::field_as_string node_id{ U("node_id") };
-        const web::json::field_as_array senders{ U("senders") }; // deprecated
-        const web::json::field_as_array receivers{ U("receivers") }; // deprecated
+        const web::json::field_as_string node_id{ U("node_id") }; // see nmos::id
+        const web::json::field_as_array senders{ U("senders") }; // deprecated, see nmos::id
+        const web::json::field_as_array receivers{ U("receivers") }; // deprecated, see nmos::id
         // source_core
-        const web::json::field_as_string device_id{ U("device_id") }; // also used in also used in sender, receiver, and flow from v1.1
-        const web::json::field_as_array parents{ U("parents") }; // also used in flow
-        const web::json::field_as_value clock_name{ U("clock_name") }; // string or null
-        const web::json::field_as_string format{ U("format") }; // also used in flow
+        const web::json::field_as_string device_id{ U("device_id") }; // also used in also used in sender, receiver, and flow from v1.1, see nmos::id
+        const web::json::field_as_array parents{ U("parents") }; // also used in flow, see nmos::id
+        const web::json::field_as_value clock_name{ U("clock_name") }; // string or null, see nmos::clock_name
+        const web::json::field_as_string format{ U("format") }; // also used in flow, see nmos::format
         // source_audio
         const web::json::field_as_array channels{ U("channels") };
-        const web::json::field_as_string_or symbol{ U("symbol"), U("") }; // or nmos::channel_symbol?
+        const web::json::field_as_string_or symbol{ U("symbol"), U("") }; // see nmos::channel_symbol
         // flow_core
-        const web::json::field_as_string source_id{ U("source_id") };
-        const web::json::field_as_value grain_rate{ U("grain_rate") }; // or field<nmos::rational> with a bit of work!
+        const web::json::field_as_string source_id{ U("source_id") }; // see nmos::id
+        const web::json::field_as_value grain_rate{ U("grain_rate") }; // see nmos::make_rational, etc.
         const web::json::field_as_integer numerator{ U("numerator") };
         const web::json::field_as_integer_or denominator{ U("denominator"), 1 };
-        const web::json::field_as_string media_type{ U("media_type") }; // strictly speaking, defined in flow_video_raw, flow_video_coded, etc.
+        const web::json::field_as_string media_type{ U("media_type") }; // strictly speaking, defined in flow_video_raw, flow_video_coded, etc., see nmos::media_type
         // flow_video
         const web::json::field_as_integer frame_width{ U("frame_width") };
         const web::json::field_as_integer frame_height{ U("frame_height") };
-        const web::json::field_as_string colorspace{ U("colorspace") };
+        const web::json::field_as_string colorspace{ U("colorspace") }; // see nmos::colorspace
         // flow_video_raw
-        const web::json::field_as_array components{ U("components") };
-        const web::json::field_as_string_or transfer_characteristic{ U("transfer_characteristic"), U("") }; // or "SDR"?
-        const web::json::field_as_string_or interlace_mode{ U("interlace_mode"), U("") }; // or "progressive"?
+        const web::json::field_as_array components{ U("components") }; // see nmos::make_components, etc.
+        const web::json::field_as_string_or transfer_characteristic{ U("transfer_characteristic"), U("") }; // if omitted (empty), assume "SDR", see nmos::transfer_characteristic
+        const web::json::field_as_string_or interlace_mode{ U("interlace_mode"), U("") }; // if omitted (empty), assume "progressive", see nmos::interlace_mode
         const web::json::field_as_integer width{ U("width") };
         const web::json::field_as_integer height{ U("height") };
         const web::json::field_as_integer bit_depth{ U("bit_depth") }; // also used in flow_audio_raw
         // flow_audio
-        const web::json::field_as_value sample_rate{ U("sample_rate") };
+        const web::json::field_as_value sample_rate{ U("sample_rate") }; // see nmos::rational
         // flow_sdianc_data
-        const web::json::field_as_value_or DID_SDID{ U("DID_SDID"), web::json::value::array() };
+        const web::json::field_as_value_or DID_SDID{ U("DID_SDID"), web::json::value::array() }; // see nmos::did_sdid
         const web::json::field_as_string_or DID{ U("DID"), U("0x00") }; // probably an oversight this isn't required
         const web::json::field_as_string_or SDID{ U("SDID"), U("0x00") };
         // sender
         const web::json::field_as_array interface_bindings{ U("interface_bindings") }; // also used in receiver
         const web::json::field_as_string transport{ U("transport") }; // also used in receiver
-        const web::json::field_as_value flow_id{ U("flow_id") };
+        const web::json::field_as_value flow_id{ U("flow_id") }; // see nmos::id
         const web::json::field_as_value_or manifest_href{ U("manifest_href"), {} }; // string, or null from v1.3
         const web::json::field_as_value subscription{ U("subscription") }; // from v1.2; also used in receiver from v1.0
-        const web::json::field_as_value receiver_id{ U("receiver_id") }; // used in sender subscription
+        const web::json::field_as_value receiver_id{ U("receiver_id") }; // used in sender subscription, see nmos::id
         const web::json::field_as_bool active{ U("active") }; // used in sender subscription; also used in receiver subscription from v1.2
         // receiver_core
-        const web::json::field_as_value sender_id{ U("sender_id") }; // used in receiver subscription
+        const web::json::field_as_value sender_id{ U("sender_id") }; // used in receiver subscription, see nmos::id
         // receiver_audio, receiver_data, receiver_mux, receiver_video
-        const web::json::field_as_value_or media_types{ U("media_types"), {} }; // array of string; used in receiver caps
+        const web::json::field_as_value_or media_types{ U("media_types"), {} }; // array of string; used in receiver caps, see nmos::media_type
         // receiver_data
-        const web::json::field_as_value_or event_types{ U("event_types"), {} }; // array of string; used in receiver caps
+        const web::json::field_as_value_or event_types{ U("event_types"), {} }; // array of string; used in receiver caps, see nmos::event_type
 
         // (mostly) for query_api
         const web::json::field_as_bool persist{ U("persist") };
@@ -137,9 +137,9 @@ namespace nmos
         const web::json::field_as_string transportfile_href{ U("href") };
         const web::json::field_as_bool master_enable{ U("master_enable") };
         const web::json::field_as_value_or activation{ U("activation"), {} }; // object
-        const web::json::field_as_value_or mode{ U("mode"), {} }; // string or null
-        const web::json::field_as_value_or requested_time{ U("requested_time"), {} }; // string or null
-        const web::json::field_as_value_or activation_time{ U("activation_time"), {} }; // string or null
+        const web::json::field_as_value_or mode{ U("mode"), {} }; // string or null, see nmos::activation_mode
+        const web::json::field_as_value_or requested_time{ U("requested_time"), {} }; // string or null, see nmos::tai
+        const web::json::field_as_value_or activation_time{ U("activation_time"), {} }; // string or null, see nmos::tai
         const web::json::field_as_value_or transport_file{ U("transport_file"), {} }; // object
         const web::json::field_as_value transport_params{ U("transport_params") }; // array
 
@@ -191,7 +191,7 @@ namespace nmos
         // for events_ws_api messages
         const web::json::field_as_string message_type{ U("message_type") };
         // for "state" messages
-        const web::json::field_as_string state_event_type{ U("event_type") };
+        const web::json::field_as_string state_event_type{ U("event_type") }; // see nmos::event_type
         const web::json::field_as_value state_payload{ U("payload") };
         const web::json::field_as_bool payload_boolean_value{ U("value") };
         const web::json::field_as_number payload_number_value{ U("value") };
@@ -235,7 +235,7 @@ namespace nmos
         // Sender Attributes Register
 
         // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#st-2110-21-sender-type
-        const web::json::field_as_string st2110_21_sender_type{ U("st2110_21_sender_type") };
+        const web::json::field_as_string st2110_21_sender_type{ U("st2110_21_sender_type") }; // see nmos::st2110_21_sender_type
     }
 
     // Fields for experimental extensions

--- a/Development/nmos/media_type.h
+++ b/Development/nmos/media_type.h
@@ -20,10 +20,6 @@ namespace nmos
         // See https://tools.ietf.org/html/rfc4175#section-6
         const media_type video_raw{ U("video/raw") };
 
-        // JPEG XS
-        // See https://tools.ietf.org/html/draft-ietf-payload-rtp-jpegxs-09#section-6
-        const media_type video_jxsv{ U("video/jxsv") };
-
         // Audio media types
 
         inline media_type audio_L(unsigned int bit_depth)

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -304,8 +304,8 @@ namespace nmos
         bool segmented;
         sdp::sampling sampling;
         uint32_t depth;
-        sdp::transfer_characteristic_system tcs; // nmos::transfer_characteristic is a subset
-        sdp::colorimetry colorimetry; // nmos::colorspace is a subset
+        sdp::transfer_characteristic_system tcs; // nmos::transfer_characteristic is compatible
+        sdp::colorimetry colorimetry; // nmos::colorspace is compatible
         sdp::type_parameter tp;
 
         video_raw_parameters() : width(), height(), interlace(), segmented(), depth() {}
@@ -496,6 +496,9 @@ namespace nmos
         // a map from parameter constraint URNs to parameter constraint functions
         typedef std::map<utility::string_t, sdp_parameter_constraint> sdp_parameter_constraints;
 
+        // Check the specified SDP interlace and segmented parameters against the specified interlace_mode constraint
+        bool match_interlace_mode_constraint(bool interlace, bool segmented, const web::json::value& constraint);
+
         // Check the specified SDP parameters and format-specific parameters against the specified constraint set
         // using the specified parameter constraint functions
         bool match_sdp_parameters_constraint_set(const sdp_parameter_constraints& constraints, const sdp_parameters& sdp_params, const format_parameters& format_params, const web::json::value& constraint_set);
@@ -512,6 +515,14 @@ namespace nmos
 
         // cf. nmos::make_components
         sdp::sampling make_sampling(const web::json::array& components);
+
+        // Exact Frame Rate
+        // "Integer frame rates shall be signaled as a single decimal number (e.g. "25") whilst non-integer frame rates shall be
+        // signaled as a ratio of two integer decimal numbers separated by a "forward-slash" character (e.g. "30000/1001"),
+        // utilizing the numerically smallest numerator value possible."
+        // See ST 2110-20:2017 Section 7.2 Required Media Type Parameters
+        utility::string_t make_exactframerate(const nmos::rational& exactframerate);
+        nmos::rational parse_exactframerate(const utility::string_t& exactframerate);
 
         // Payload identifiers 96-127 are used for payloads defined dynamically during a session
         // 96 and 97 are suitable for video and audio encodings not covered by the IANA registry

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -292,34 +292,85 @@ namespace nmos
     // Format-specific types and functions
 
     // Additional "video/raw" parameters
-    // See SMPTE ST 2110-20:2017
+    // See SMPTE ST 2110-20:2022
+    // and SMPTE ST 2110-10:2022
+    // and SMPTE ST 2110-21:2022
     // and https://www.iana.org/assignments/media-types/video/raw
+    // and https://tools.ietf.org/html/rfc4175
     struct video_raw_parameters
     {
         // fmtp indicates format
+        sdp::sampling sampling;
+        uint32_t depth;
         uint32_t width;
         uint32_t height;
         nmos::rational exactframerate;
         bool interlace;
         bool segmented;
-        sdp::sampling sampling;
-        uint32_t depth;
-        sdp::transfer_characteristic_system tcs; // nmos::transfer_characteristic is compatible
+        sdp::transfer_characteristic_system tcs; // if omitted (empty), assume sdp::transfer_characteristic_systems::SDR; nmos::transfer_characteristic is compatible
         sdp::colorimetry colorimetry; // nmos::colorspace is compatible
-        sdp::type_parameter tp;
+        sdp::range range; // if omitted (empty), assume sdp::ranges::NARROW
+        nmos::rational par; // if omitted (zero), assume 1:1
+        sdp::packing_mode pm;
+        sdp::smpte_standard_number ssn;
 
-        video_raw_parameters() : width(), height(), interlace(), segmented(), depth() {}
-        video_raw_parameters(uint32_t width, uint32_t height, const nmos::rational& exactframerate, bool interlace, bool segmented, const sdp::sampling& sampling, uint32_t depth, const sdp::transfer_characteristic_system& tcs, const sdp::colorimetry& colorimetry, const sdp::type_parameter& tp)
-            : width(width)
+        // additional fmtp parameters from ST 2110-21:2022
+        sdp::type_parameter tp;
+        uint32_t troff; // if omitted (zero), assume default
+        uint32_t cmax; // if omitted (zero), assume max defined for tp
+
+        // additional fmtp parameters from ST 2110-10:2022
+        uint32_t maxudp; // if omitted (zero), assume the Standard UP Size Limit
+        sdp::timestamp_mode tsmode; // if omitted (empty), assume sdp::timestamp_modes::NEW
+        uint32_t tsdelay;
+
+        video_raw_parameters() : depth(), width(), height(), interlace(), segmented(), troff(), cmax(), maxudp(), tsdelay() {}
+
+        video_raw_parameters(
+            sdp::sampling sampling,
+            uint32_t depth,
+            uint32_t width,
+            uint32_t height,
+            nmos::rational exactframerate,
+            bool interlace,
+            bool segmented,
+            sdp::transfer_characteristic_system tcs,
+            sdp::colorimetry colorimetry,
+            sdp::range range,
+            nmos::rational par,
+            sdp::packing_mode pm,
+            sdp::smpte_standard_number ssn,
+            sdp::type_parameter tp,
+            uint32_t troff,
+            uint32_t cmax,
+            uint32_t maxudp,
+            sdp::timestamp_mode tsmode,
+            uint32_t tsdelay
+        )
+            : sampling(std::move(sampling))
+            , depth(depth)
+            , width(width)
             , height(height)
             , exactframerate(exactframerate)
             , interlace(interlace)
             , segmented(segmented)
-            , sampling(sampling)
-            , depth(depth)
-            , tcs(tcs)
-            , colorimetry(colorimetry)
-            , tp(tp)
+            , tcs(std::move(tcs))
+            , colorimetry(std::move(colorimetry))
+            , range(std::move(range))
+            , par(par)
+            , pm(std::move(pm))
+            , ssn(std::move(ssn))
+            , tp(std::move(tp))
+            , troff(troff)
+            , cmax(cmax)
+            , maxudp(maxudp)
+            , tsmode(tsmode)
+            , tsdelay(tsdelay)
+        {}
+
+        // deprecated
+        video_raw_parameters(uint32_t width, uint32_t height, const nmos::rational& exactframerate, bool interlace, bool segmented, const sdp::sampling& sampling, uint32_t depth, const sdp::transfer_characteristic_system& tcs, const sdp::colorimetry& colorimetry, const sdp::type_parameter& tp)
+            : video_raw_parameters(sampling, depth, width, height, exactframerate, interlace, segmented, tcs, colorimetry, {}, {}, sdp::packing_modes::general, sdp::smpte_standard_numbers::ST2110_20_2017, tp, {}, {}, {}, {}, {})
         {}
     };
 
@@ -340,21 +391,41 @@ namespace nmos
         // fmtp indicates channel-order (e.g. "SMPTE2110.(ST)")
         utility::string_t channel_order;
 
+        // additional fmtp parameters from ST 2110-10:2022
+        sdp::timestamp_mode tsmode; // if omitted (empty), assume sdp::timestamp_modes::NEW
+        uint32_t tsdelay;
+
         // ptime
         double packet_time;
 
-        audio_L_parameters() : channel_count(), bit_depth(), sample_rate(), packet_time() {}
-        audio_L_parameters(uint32_t channel_count, uint32_t bit_depth, uint64_t sample_rate, const utility::string_t& channel_order, double packet_time)
+        audio_L_parameters() : channel_count(), bit_depth(), sample_rate(), tsdelay(), packet_time() {}
+
+        audio_L_parameters(
+            uint32_t channel_count,
+            uint32_t bit_depth,
+            uint64_t sample_rate,
+            utility::string_t channel_order,
+            sdp::timestamp_mode tsmode,
+            uint32_t tsdelay,
+            double packet_time
+        )
             : channel_count(channel_count)
             , bit_depth(bit_depth)
             , sample_rate(sample_rate)
-            , channel_order(channel_order)
+            , channel_order(std::move(channel_order))
+            , tsmode(std::move(tsmode))
+            , tsdelay(tsdelay)
             , packet_time(packet_time)
+        {}
+
+        // deprecated
+        audio_L_parameters(uint32_t channel_count, uint32_t bit_depth, uint64_t sample_rate, const utility::string_t& channel_order, double packet_time)
+            : audio_L_parameters(channel_count, bit_depth, sample_rate, channel_order, {}, {}, packet_time)
         {}
     };
 
     // Additional "video/smpte291" data payload parameters
-    // See SMPTE ST 2110-40:2018
+    // See SMPTE ST 2110-40:2022
     // and https://www.iana.org/assignments/media-types/video/smpte291
     // and https://tools.ietf.org/html/rfc8331
     struct video_smpte291_parameters
@@ -363,10 +434,45 @@ namespace nmos
         std::vector<nmos::did_sdid> did_sdids;
         // fmtp optionally indicates VPID Code of the source interface
         nmos::vpid_code vpid_code;
+        // fmtp is required to indicate frame rate, since ST 2110-40:2022
+        nmos::rational exactframerate;
+        // fmtp optionally indicates TM, since ST 2110-40:2022
+        sdp::transmission_model tm; // if omitted (empty), assume sdp::transmission_models::CTM
+        // fmtp is required to indicate SSN, since ST 2110-40:2022
+        sdp::smpte_standard_number ssn;
 
-        video_smpte291_parameters(const std::vector<nmos::did_sdid>& did_sdids = {}, nmos::vpid_code vpid_code = {})
-            : did_sdids(did_sdids)
+        // additional fmtp parameters from ST 2110-21:2022
+        uint32_t troff; // if omitted (zero), assume default
+
+        // additional fmtp parameters from ST 2110-10:2022
+        sdp::timestamp_mode tsmode; // if omitted (empty), assume sdp::timestamp_modes::NEW
+        uint32_t tsdelay;
+
+        video_smpte291_parameters() : vpid_code(), troff(), tsdelay() {}
+
+        video_smpte291_parameters(
+            std::vector<nmos::did_sdid> did_sdids,
+            nmos::vpid_code vpid_code,
+            nmos::rational exactframerate,
+            sdp::transmission_model tm,
+            sdp::smpte_standard_number ssn,
+            uint32_t troff,
+            sdp::timestamp_mode tsmode,
+            uint32_t tsdelay
+        )
+            : did_sdids(std::move(did_sdids))
             , vpid_code(vpid_code)
+            , exactframerate(exactframerate)
+            , tm(std::move(tm))
+            , ssn(std::move(ssn))
+            , troff(troff)
+            , tsmode(std::move(tsmode))
+            , tsdelay(tsdelay)
+        {}
+
+        // deprecated
+        video_smpte291_parameters(const std::vector<nmos::did_sdid>& did_sdids, const nmos::vpid_code& vpid_code = {})
+            : video_smpte291_parameters(did_sdids, vpid_code, {}, {}, {}, {}, {}, {})
         {}
     };
 
@@ -374,11 +480,23 @@ namespace nmos
     // See SMPTE ST 2022-8:2019
     struct video_SMPTE2022_6_parameters
     {
+        // additional fmtp parameters from ST 2110-21:2017
         sdp::type_parameter tp;
+        uint32_t troff; // if omitted (zero), assume default
 
-        video_SMPTE2022_6_parameters() {}
+        video_SMPTE2022_6_parameters() : troff() {}
+
+        video_SMPTE2022_6_parameters(
+            sdp::type_parameter tp,
+            uint32_t troff
+        )
+            : tp(std::move(tp))
+            , troff(troff)
+        {}
+
+        // deprecated
         video_SMPTE2022_6_parameters(const sdp::type_parameter& tp)
-            : tp(tp)
+            : video_SMPTE2022_6_parameters(tp, {})
         {}
     };
 
@@ -397,7 +515,7 @@ namespace nmos
     audio_L_parameters get_audio_L_parameters(const sdp_parameters& sdp_params);
 
     // Construct additional "video/smpte291" parameters from the IS-04 resources, using default values for unspecified items
-    video_smpte291_parameters make_video_smpte291_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, bst::optional<nmos::vpid_code> vpid_code);
+    video_smpte291_parameters make_video_smpte291_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, bst::optional<nmos::vpid_code> vpid_code, bst::optional<sdp::transmission_model> tm = bst::nullopt);
     // Construct SDP parameters for "video/smpte291", with sensible defaults for unspecified fields
     sdp_parameters make_video_smpte291_sdp_parameters(const utility::string_t& session_name, const video_smpte291_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
     // Get additional "video/smpte291" parameters from the SDP parameters
@@ -523,6 +641,12 @@ namespace nmos
         // See ST 2110-20:2017 Section 7.2 Required Media Type Parameters
         utility::string_t make_exactframerate(const nmos::rational& exactframerate);
         nmos::rational parse_exactframerate(const utility::string_t& exactframerate);
+
+        // Pixel Aspect Ratio
+        // "PAR shall be signaled as a ratio of two integer decimal numbers separated by a "colon" character (e.g. "12:11")."
+        // See ST 2110-20:2017 Section 7.3 Media Type Parameters with default values
+        utility::string_t make_pixel_aspect_ratio(const nmos::rational& par);
+        nmos::rational parse_pixel_aspect_ratio(const utility::string_t& par);
 
         // Payload identifiers 96-127 are used for payloads defined dynamically during a session
         // 96 and 97 are suitable for video and audio encodings not covered by the IANA registry

--- a/Development/nmos/st2110_21_sender_type.h
+++ b/Development/nmos/st2110_21_sender_type.h
@@ -1,0 +1,22 @@
+#ifndef NMOS_ST2110_21_SENDER_TYPE_H
+#define NMOS_ST2110_21_SENDER_TYPE_H
+
+#include "nmos/string_enum.h"
+
+namespace nmos
+{
+    // ST 2110-21 Sender Type
+    // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#st-2110-21-sender-type
+    DEFINE_STRING_ENUM(st2110_21_sender_type)
+    namespace st2110_21_sender_types
+    {
+        // Narrow Senders (Type N)
+        const st2110_21_sender_type type_N{ U("2110TPN") };
+        // Narrow Linear Senders (Type NL)
+        const st2110_21_sender_type type_NL{ U("2110TPNL") };
+        // Wide Senders (Type W)
+        const st2110_21_sender_type type_W{ U("2110TPW") };
+    }
+}
+
+#endif

--- a/Development/nmos/test/video_jxsv_test.cpp
+++ b/Development/nmos/test/video_jxsv_test.cpp
@@ -1,0 +1,58 @@
+// The first "test" is of course whether the header compiles standalone
+#include "nmos/video_jxsv.h"
+
+#include "bst/test/test.h"
+#include "nmos/json_fields.h"
+#include "sdp/sdp.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testSdpParametersRoundtripVideoJpegXs)
+{
+    using web::json::value;
+
+    // typical SDP data for JPEG XS, based on BCP-006-01 example file
+    // see https://specs.amwa.tv/bcp-006-01/branches/v1.0-dev/examples/jpeg-xs.html
+    const std::string test_sdp = R"(v=0
+o=- 1443716955 1443716955 IN IP4 192.168.1.2
+s=SMPTE ST2110-22 JPEG XS
+t=0 0
+m=video 30000 RTP/AVP 112
+c=IN IP4 224.1.1.1/64
+b=AS:116000
+a=ts-refclk:localmac=40-a3-6b-a0-2b-d2
+a=mediaclk:direct=0
+a=source-filter: incl IN IP4 224.1.1.1 192.168.1.2
+a=rtpmap:112 jxsv/90000
+a=fmtp:112 packetmode=0; profile=High444.12; level=1k-1; sublevel=Sublev3bpp; depth=10; width=1280; height=720; exactframerate=60000/1001; sampling=YCbCr-4:2:2; colorimetry=BT709; TCS=SDR; RANGE=FULL; SSN=ST2110-22:2019; TP=2110TPN
+)";
+
+    auto test_description = sdp::parse_session_description(test_sdp);
+    const auto test_params = nmos::parse_session_description(test_description);
+
+    auto& s = test_params.first;
+    auto& t = test_params.second;
+
+    const auto params = nmos::get_video_jxsv_parameters(s);
+
+    auto s2 = nmos::make_sdp_parameters(s.session_name, params, s.rtpmap.payload_type, s.group.media_stream_ids, s.ts_refclk);
+    // nmos::make_sdp_parameters always generates a new origin (o=) line and the connection data (c=) ttl value is hard-coded
+    s2.origin = s.origin;
+    s2.connection_data.ttl = s.connection_data.ttl;
+
+    auto t2 = t;
+    t2[0][nmos::fields::interface_ip] = value::string(U("192.168.1.2"));
+
+    auto session_description = nmos::make_session_description(s2, t2);
+
+    auto test_sdp2 = sdp::make_session_description(session_description);
+    std::istringstream expected(test_sdp), actual(test_sdp2);
+    do
+    {
+        std::string expected_line, actual_line;
+        std::getline(expected, expected_line);
+        std::getline(actual, actual_line);
+        // CR cannot appear in a raw string literal, so remove it from the actual line
+        if (!actual_line.empty() && '\r' == actual_line.back()) actual_line.pop_back();
+        BST_CHECK_EQUAL(expected_line, actual_line);
+    } while (!expected.fail() && !actual.fail());
+}

--- a/Development/nmos/video_jxsv.cpp
+++ b/Development/nmos/video_jxsv.cpp
@@ -1,0 +1,194 @@
+#include "nmos/video_jxsv.h"
+
+#include <map>
+#include "nmos/capabilities.h"
+#include "nmos/format.h"
+#include "nmos/interlace_mode.h"
+#include "nmos/json_fields.h"
+
+namespace nmos
+{
+    // Construct additional "video/jxsv" parameters from the IS-04 resources
+    video_jxsv_parameters make_video_jxsv_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender)
+    {
+        video_jxsv_parameters params;
+
+        params.packet_transmission_mode = nmos::packet_transmission_mode{ nmos::fields::packet_transmission_mode(sender) };
+
+        params.profile = nmos::profile{ nmos::fields::profile(flow) };
+        params.level = nmos::level{  nmos::fields::level(flow) };
+        params.sublevel = nmos::sublevel{ nmos::fields::sublevel(flow) };
+
+        // cf. nmos::make_video_raw_parameters
+
+        params.tp = sdp::type_parameter{ nmos::fields::st2110_21_sender_type(sender) };
+
+        // colorimetry map directly to flow_video json "colorspace"
+        params.colorimetry = sdp::colorimetry{ nmos::fields::colorspace(flow) };
+
+        // use flow json "components" to work out sampling
+        const auto& components = nmos::fields::components(flow);
+        params.sampling = details::make_sampling(components);
+        params.width = nmos::fields::frame_width(flow);
+        params.height = nmos::fields::frame_height(flow);
+        params.depth = nmos::fields::bit_depth(components.at(0));
+
+        // also maps directly
+        params.tcs = sdp::transfer_characteristic_system{ nmos::fields::transfer_characteristic(flow) };
+
+        const auto& interlace_mode = nmos::fields::interlace_mode(flow);
+        params.interlace = !interlace_mode.empty() && nmos::interlace_modes::progressive.name != interlace_mode;
+        params.segmented = !interlace_mode.empty() && nmos::interlace_modes::interlaced_psf.name == interlace_mode;
+
+        // grain_rate is optional in the flow, but if it's not there, for a video flow, it must be in the source
+        const auto& grain_rate = nmos::fields::grain_rate(flow.has_field(nmos::fields::grain_rate) ? flow : source);
+        params.exactframerate = nmos::rational(nmos::fields::numerator(grain_rate), nmos::fields::denominator(grain_rate));
+
+        return params;
+    }
+
+    // Construct SDP parameters for "video/jxsv", with sensible defaults for unspecified fields
+    sdp_parameters make_video_jxsv_sdp_parameters(const utility::string_t& session_name, const video_jxsv_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk)
+    {
+        // a=rtpmap:<payload type> <encoding name>/<clock rate>[/<encoding parameters>]
+        sdp_parameters::rtpmap_t rtpmap = { payload_type, U("jxsv"), 90000 };
+
+        // a=fmtp:<format> <format specific parameters>
+        // following the order of parameters given in RFC 9134
+        // See https://tools.ietf.org/html/rfc4566#section-6
+        // and https://tools.ietf.org/html/rfc9134#section-7
+        const uint32_t k = nmos::packet_transmission_modes::codestream == params.packet_transmission_mode ? 0 : 1;
+        const uint32_t t = nmos::packet_transmission_modes::slice_out_of_order == params.packet_transmission_mode ? 0 : 1;
+        sdp_parameters::fmtp_t fmtp = {
+            { sdp::fields::packetmode, utility::ostringstreamed(k) }
+        };
+        if (1 != t) fmtp.push_back({ sdp::fields::transmode, utility::ostringstreamed(t) });
+        if (!params.profile.empty()) fmtp.push_back({ sdp::fields::profile, params.profile.name });
+        if (!params.level.empty()) fmtp.push_back({ sdp::fields::level, params.level.name });
+        if (!params.sublevel.empty()) fmtp.push_back({ sdp::fields::sublevel, params.sublevel.name });
+
+        // cf. nmos::make_video_raw_sdp_parameters
+
+        if (0 != params.depth) fmtp.push_back({ sdp::fields::depth, utility::ostringstreamed(params.depth) });
+        if (0 != params.width) fmtp.push_back({ sdp::fields::width, utility::ostringstreamed(params.width) });
+        if (0 != params.height) fmtp.push_back({ sdp::fields::height, utility::ostringstreamed(params.height) });
+        if (0 != params.exactframerate) fmtp.push_back({ sdp::fields::exactframerate, nmos::details::make_exactframerate(params.exactframerate) });
+        if (params.interlace) fmtp.push_back({ sdp::fields::interlace, {} });
+        if (params.segmented) fmtp.push_back({ sdp::fields::segmented, {} });
+        if (!params.sampling.empty()) fmtp.push_back({ sdp::fields::sampling, params.sampling.name });
+        if (!params.colorimetry.empty()) fmtp.push_back({ sdp::fields::colorimetry, params.colorimetry.name });
+        if (!params.tcs.empty()) fmtp.push_back({ sdp::fields::transfer_characteristic_system, params.tcs.name });
+        if (!params.tp.empty()) fmtp.push_back({ sdp::fields::type_parameter, params.tp.name });
+
+        return{ session_name, sdp::media_types::video, rtpmap, fmtp, {}, {}, {}, {}, media_stream_ids, ts_refclk };
+    }
+
+    // Get additional "video/jxsv" parameters from the SDP parameters
+    video_jxsv_parameters get_video_jxsv_parameters(const sdp_parameters& sdp_params)
+    {
+        video_jxsv_parameters params;
+
+        if (sdp_params.fmtp.empty()) return params;
+
+        const auto k = details::find_fmtp(sdp_params.fmtp, sdp::fields::packetmode);
+        if (sdp_params.fmtp.end() != k) throw details::sdp_processing_error("missing format parameter: packetmode");
+
+        // optional
+        const auto t = details::find_fmtp(sdp_params.fmtp, sdp::fields::transmode);
+
+        params.packet_transmission_mode = 0 == utility::istringstreamed<uint32_t>(k->second)
+            ? nmos::packet_transmission_modes::codestream
+            : sdp_params.fmtp.end() != t && 1 != utility::istringstreamed<uint32_t>(t->second)
+                ? nmos::packet_transmission_modes::slice_sequential
+                : nmos::packet_transmission_modes::slice_out_of_order;
+
+        // optional
+        const auto profile = details::find_fmtp(sdp_params.fmtp, sdp::fields::profile);
+        if (sdp_params.fmtp.end() != profile) params.profile = nmos::profile{ profile->second };
+
+        // optional
+        const auto level = details::find_fmtp(sdp_params.fmtp, sdp::fields::level);
+        if (sdp_params.fmtp.end() != level) params.level = nmos::level{ level->second };
+
+        // optional
+        const auto sublevel = details::find_fmtp(sdp_params.fmtp, sdp::fields::sublevel);
+        if (sdp_params.fmtp.end() != sublevel) params.sublevel = nmos::sublevel{ sublevel->second };
+
+        // optional
+        const auto depth = details::find_fmtp(sdp_params.fmtp, sdp::fields::depth);
+        if (sdp_params.fmtp.end() != depth) params.depth = utility::istringstreamed<uint32_t>(depth->second);
+
+        // optional
+        const auto width = details::find_fmtp(sdp_params.fmtp, sdp::fields::width);
+        if (sdp_params.fmtp.end() != width) params.width = utility::istringstreamed<uint32_t>(width->second);
+
+        // optional
+        const auto height = details::find_fmtp(sdp_params.fmtp, sdp::fields::height);
+        if (sdp_params.fmtp.end() != height) params.height = utility::istringstreamed<uint32_t>(height->second);
+
+        // optional
+        const auto exactframerate = details::find_fmtp(sdp_params.fmtp, sdp::fields::exactframerate);
+        if (sdp_params.fmtp.end() != exactframerate) params.exactframerate = nmos::details::parse_exactframerate(exactframerate->second);
+
+        // optional
+        const auto interlace = details::find_fmtp(sdp_params.fmtp, sdp::fields::interlace);
+        params.interlace = sdp_params.fmtp.end() != interlace;
+
+        // optional
+        const auto segmented = details::find_fmtp(sdp_params.fmtp, sdp::fields::segmented);
+        params.segmented = sdp_params.fmtp.end() != segmented;
+
+        // optional
+        const auto sampling = details::find_fmtp(sdp_params.fmtp, sdp::fields::sampling);
+        if (sdp_params.fmtp.end() != sampling)  params.sampling = sdp::sampling{ sampling->second };
+
+        const auto colorimetry = details::find_fmtp(sdp_params.fmtp, sdp::fields::colorimetry);
+        if (sdp_params.fmtp.end() != colorimetry) params.colorimetry = sdp::colorimetry{ colorimetry->second };
+
+        // optional
+        const auto tcs = details::find_fmtp(sdp_params.fmtp, sdp::fields::transfer_characteristic_system);
+        if (sdp_params.fmtp.end() != tcs) params.tcs = sdp::transfer_characteristic_system{ tcs->second };
+
+        const auto tp = details::find_fmtp(sdp_params.fmtp, sdp::fields::type_parameter);
+        if (sdp_params.fmtp.end() != tp) params.tp = sdp::type_parameter{ tp->second };
+
+        return params;
+    }
+
+    namespace details
+    {
+        const video_jxsv_parameters* get_jxsv(const format_parameters* format) { return get<video_jxsv_parameters>(format); }
+
+        // NMOS Parameter Registers - Capabilities register
+        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/
+#define CAPS_ARGS const sdp_parameters& sdp, const format_parameters& format, const web::json::value& con
+        static const std::map<utility::string_t, std::function<bool(CAPS_ARGS)>> jxsv_constraints
+        {
+            { nmos::caps::format::media_type, [](CAPS_ARGS) { return nmos::match_string_constraint(get_media_type(sdp).name, con); } },
+            { nmos::caps::format::grain_rate, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return !jxsv || nmos::rational{} == jxsv->exactframerate || nmos::match_rational_constraint(jxsv->exactframerate, con); } },
+            { nmos::caps::format::profile, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return jxsv && nmos::match_string_constraint(jxsv->profile.name, con); } },
+            { nmos::caps::format::level, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return jxsv && nmos::match_string_constraint(jxsv->level.name, con); } },
+            { nmos::caps::format::sublevel, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return jxsv && nmos::match_string_constraint(jxsv->sublevel.name, con); } },
+            { nmos::caps::format::frame_height, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return jxsv && nmos::match_integer_constraint(jxsv->height, con); } },
+            { nmos::caps::format::frame_width, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return jxsv && nmos::match_integer_constraint(jxsv->width, con); } },
+            { nmos::caps::format::color_sampling, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return jxsv && nmos::match_string_constraint(jxsv->sampling.name, con); } },
+            { nmos::caps::format::interlace_mode, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return jxsv && nmos::details::match_interlace_mode_constraint(jxsv->interlace, jxsv->segmented, con); } },
+            { nmos::caps::format::colorspace, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return jxsv && nmos::match_string_constraint(jxsv->colorimetry.name, con); } },
+            { nmos::caps::format::transfer_characteristic, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return jxsv && nmos::match_string_constraint(!jxsv->tcs.empty() ? jxsv->tcs.name : sdp::transfer_characteristic_systems::SDR.name, con); } },
+            { nmos::caps::format::component_depth, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return jxsv && nmos::match_integer_constraint(jxsv->depth, con); } },
+            { nmos::caps::transport::st2110_21_sender_type, [](CAPS_ARGS) { auto jxsv = get_jxsv(&format); return nmos::match_string_constraint(jxsv->tp.name, con); } }
+        };
+#undef CAPS_ARGS
+    }
+
+    // Validate SDP parameters for "video/jxsv" against IS-04 receiver capabilities
+    // cf. nmos::validate_sdp_parameters
+    void validate_video_jxsv_sdp_parameters(const web::json::value& receiver, const nmos::sdp_parameters& sdp_params)
+    {
+        // this function can only be used to validate SDP data for "video/jxsv"; logic error otherwise
+        const auto media_type = get_media_type(sdp_params);
+        if (nmos::media_types::video_jxsv != media_type) throw std::invalid_argument("unexpected media type/encoding name");
+
+        nmos::details::validate_sdp_parameters(details::jxsv_constraints, sdp_params, nmos::formats::video, get_video_jxsv_parameters(sdp_params), receiver);
+    }
+}

--- a/Development/nmos/video_jxsv.cpp
+++ b/Development/nmos/video_jxsv.cpp
@@ -107,28 +107,38 @@ namespace nmos
 
         // cf. nmos::make_video_raw_parameters
 
-        params.tp = sdp::type_parameter{ nmos::fields::st2110_21_sender_type(sender) };
-
-        // colorimetry map directly to flow_video json "colorspace"
-        params.colorimetry = sdp::colorimetry{ nmos::fields::colorspace(flow) };
-
-        // use flow json "components" to work out sampling
         const auto& components = nmos::fields::components(flow);
         params.sampling = details::make_sampling(components);
+        params.depth = nmos::fields::bit_depth(components.at(0));
         params.width = nmos::fields::frame_width(flow);
         params.height = nmos::fields::frame_height(flow);
-        params.depth = nmos::fields::bit_depth(components.at(0));
 
-        // also maps directly
-        params.tcs = sdp::transfer_characteristic_system{ nmos::fields::transfer_characteristic(flow) };
+        // grain_rate is optional in the flow, but if it's not there, for a video flow, it must be in the source
+        const auto& grain_rate = nmos::fields::grain_rate(flow.has_field(nmos::fields::grain_rate) ? flow : source);
+        params.exactframerate = nmos::parse_rational(grain_rate);
 
         const auto& interlace_mode = nmos::fields::interlace_mode(flow);
         params.interlace = !interlace_mode.empty() && nmos::interlace_modes::progressive.name != interlace_mode;
         params.segmented = !interlace_mode.empty() && nmos::interlace_modes::interlaced_psf.name == interlace_mode;
 
-        // grain_rate is optional in the flow, but if it's not there, for a video flow, it must be in the source
-        const auto& grain_rate = nmos::fields::grain_rate(flow.has_field(nmos::fields::grain_rate) ? flow : source);
-        params.exactframerate = nmos::rational(nmos::fields::numerator(grain_rate), nmos::fields::denominator(grain_rate));
+        // map directly
+        params.tcs = sdp::transfer_characteristic_system{ nmos::fields::transfer_characteristic(flow) };
+        params.colorimetry = sdp::colorimetry{ nmos::fields::colorspace(flow) };
+
+        // hm, RANGE and PAR not currently indicated in IS-04 so omit these
+
+        // hm, not sure how to decide between ST 2110-22:2019 and ST 2110-22:2022
+        params.ssn = sdp::smpte_standard_numbers::ST2110_22_2022;
+
+        // hm, TP is equivalent to the new sender attribute, but for now, support default value
+        params.tp = sender.has_field(nmos::fields::st2110_21_sender_type)
+            ? sdp::type_parameter{ nmos::fields::st2110_21_sender_type(sender) }
+            : sdp::type_parameters::type_N;
+
+        // hm, ST 2110-21 TROFF and CMAX not indicated in IS-04 so omit these
+        // hm, ST 2110-10 MAXUDP, TSMODE and TSDELAY not indicated in IS-04 so omit these
+
+        // bandwidth
 
         params.bit_rate = nmos::fields::bit_rate(sender);
 
@@ -152,9 +162,6 @@ namespace nmos
         if (!params.profile.empty()) fmtp.push_back({ sdp::video_jxsv::fields::profile, params.profile.name });
         if (!params.level.empty()) fmtp.push_back({ sdp::video_jxsv::fields::level, params.level.name });
         if (!params.sublevel.empty()) fmtp.push_back({ sdp::video_jxsv::fields::sublevel, params.sublevel.name });
-
-        // cf. nmos::make_video_raw_sdp_parameters
-
         if (0 != params.depth) fmtp.push_back({ sdp::fields::depth, utility::ostringstreamed(params.depth) });
         if (0 != params.width) fmtp.push_back({ sdp::fields::width, utility::ostringstreamed(params.width) });
         if (0 != params.height) fmtp.push_back({ sdp::fields::height, utility::ostringstreamed(params.height) });
@@ -164,7 +171,16 @@ namespace nmos
         if (!params.sampling.empty()) fmtp.push_back({ sdp::fields::sampling, params.sampling.name });
         if (!params.colorimetry.empty()) fmtp.push_back({ sdp::fields::colorimetry, params.colorimetry.name });
         if (!params.tcs.empty()) fmtp.push_back({ sdp::fields::transfer_characteristic_system, params.tcs.name });
+        if (!params.range.empty()) fmtp.push_back({ sdp::fields::range, params.range.name });
+
+        // additional parameters introduced by SMPTE specs since then...
+        if (!params.ssn.empty()) fmtp.push_back({ sdp::fields::smpte_standard_number, params.ssn.name });
         if (!params.tp.empty()) fmtp.push_back({ sdp::fields::type_parameter, params.tp.name });
+        if (0 != params.troff) fmtp.push_back({ sdp::fields::TROFF, utility::ostringstreamed(params.troff) });
+        if (0 != params.cmax) fmtp.push_back({ sdp::fields::CMAX, utility::ostringstreamed(params.cmax) });
+        if (0 != params.maxudp) fmtp.push_back({ sdp::fields::max_udp_packet_size, utility::ostringstreamed(params.maxudp) });
+        if (!params.tsmode.empty()) fmtp.push_back({ sdp::fields::timestamp_mode, params.tsmode.name });
+        if (0 != params.tsdelay) fmtp.push_back({ sdp::fields::timestamp_delay, utility::ostringstreamed(params.tsdelay) });
 
         return{ session_name, sdp::media_types::video, rtpmap, fmtp, params.bit_rate, {}, {}, {}, media_stream_ids, ts_refclk };
     }
@@ -197,6 +213,10 @@ namespace nmos
         if (sdp_params.fmtp.end() != sublevel) params.sublevel = sdp::video_jxsv::sublevel{ sublevel->second };
 
         // optional
+        const auto sampling = details::find_fmtp(sdp_params.fmtp, sdp::fields::sampling);
+        if (sdp_params.fmtp.end() != sampling)  params.sampling = sdp::sampling{ sampling->second };
+
+        // optional
         const auto depth = details::find_fmtp(sdp_params.fmtp, sdp::fields::depth);
         if (sdp_params.fmtp.end() != depth) params.depth = utility::istringstreamed<uint32_t>(depth->second);
 
@@ -221,24 +241,47 @@ namespace nmos
         params.segmented = sdp_params.fmtp.end() != segmented;
 
         // optional
-        const auto sampling = details::find_fmtp(sdp_params.fmtp, sdp::fields::sampling);
-        if (sdp_params.fmtp.end() != sampling)  params.sampling = sdp::sampling{ sampling->second };
+        const auto tcs = details::find_fmtp(sdp_params.fmtp, sdp::fields::transfer_characteristic_system);
+        if (sdp_params.fmtp.end() != tcs) params.tcs = sdp::transfer_characteristic_system{ tcs->second };
 
         // optional
         const auto colorimetry = details::find_fmtp(sdp_params.fmtp, sdp::fields::colorimetry);
         if (sdp_params.fmtp.end() != colorimetry) params.colorimetry = sdp::colorimetry{ colorimetry->second };
 
         // optional
-        const auto tcs = details::find_fmtp(sdp_params.fmtp, sdp::fields::transfer_characteristic_system);
-        if (sdp_params.fmtp.end() != tcs) params.tcs = sdp::transfer_characteristic_system{ tcs->second };
+        const auto range = details::find_fmtp(sdp_params.fmtp, sdp::fields::range);
+        if (sdp_params.fmtp.end() != range) params.range = sdp::range{ range->second };
+
+        // optional
+        const auto ssn = details::find_fmtp(sdp_params.fmtp, sdp::fields::smpte_standard_number);
+        if (sdp_params.fmtp.end() != ssn) params.ssn = sdp::smpte_standard_number{ ssn->second };
 
         // optional
         const auto tp = details::find_fmtp(sdp_params.fmtp, sdp::fields::type_parameter);
         if (sdp_params.fmtp.end() != tp) params.tp = sdp::type_parameter{ tp->second };
 
         // optional
-        if (sdp::bandwidth_types::application_specific == sdp_params.bandwidth.bandwidth_type)
-            params.bit_rate = sdp_params.bandwidth.bandwidth;
+        const auto troff = details::find_fmtp(sdp_params.fmtp, sdp::fields::TROFF);
+        if (sdp_params.fmtp.end() != troff) params.troff = utility::istringstreamed<uint32_t>(troff->second);
+
+        // optional
+        const auto cmax = details::find_fmtp(sdp_params.fmtp, sdp::fields::CMAX);
+        if (sdp_params.fmtp.end() != cmax) params.cmax = utility::istringstreamed<uint32_t>(cmax->second);
+
+        // optional
+        const auto maxudp = details::find_fmtp(sdp_params.fmtp, sdp::fields::max_udp_packet_size);
+        if (sdp_params.fmtp.end() != maxudp) params.maxudp = utility::istringstreamed<uint32_t>(maxudp->second);
+
+        // optional
+        const auto tsmode = details::find_fmtp(sdp_params.fmtp, sdp::fields::timestamp_mode);
+        if (sdp_params.fmtp.end() != tsmode) params.tsmode = sdp::timestamp_mode{ tsmode->second };
+
+        // optional
+        const auto tsdelay = details::find_fmtp(sdp_params.fmtp, sdp::fields::timestamp_delay);
+        if (sdp_params.fmtp.end() != tsdelay) params.tsdelay = utility::istringstreamed<uint32_t>(tsdelay->second);
+
+        // optional
+        if (sdp::bandwidth_types::application_specific == sdp_params.bandwidth.bandwidth_type) params.bit_rate = sdp_params.bandwidth.bandwidth;
 
         return params;
     }

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -6,19 +6,101 @@
 
 namespace sdp
 {
-    namespace fields
+    namespace video_jxsv
     {
-        // See https://www.iana.org/assignments/media-types/video/jxsv
-        // and https://tools.ietf.org/html/rfc9134#section-7
+        namespace fields
+        {
+            // See https://www.iana.org/assignments/media-types/video/jxsv
+            // and https://tools.ietf.org/html/rfc9134#section-7
+
+            // pacKetization mode (K) bit
+            const web::json::field<uint32_t> packetmode{ U("packetmode") }; // cf. sdp::video_jxsv::packetization_mode
+            // Transmission mode (T) bit
+            const web::json::field_with_default<uint32_t> transmode{ U("transmode"), 1 }; // sequential, cf. sdp::video_jxsv::transmission_mode
+
+            const web::json::field_as_string profile{ U("profile") }; // cf. sdp::video_jxsv::profile
+            const web::json::field_as_string level{ U("level") }; // cf. sdp::video_jxsv::level
+            const web::json::field_as_string sublevel{ U("sublevel") }; // cf. sdp::video_jxsv::sublevel
+        }
 
         // pacKetization mode (K) bit
-        const web::json::field<uint32_t> packetmode{ U("packetmode") };
-        // Transmission mode (T) bit
-        const web::json::field_with_default<uint32_t> transmode{ U("transmode"), 1 };
+        // See https://tools.ietf.org/html/rfc9134
+        enum packetization_mode
+        {
+            codestream = 0,
+            slice = 1
+        };
 
-        const web::json::field_as_string profile{ U("profile") };
-        const web::json::field_as_string level{ U("level") };
-        const web::json::field_as_string sublevel{ U("sublevel") };
+        // Transmission mode (T) bit
+        // See https://tools.ietf.org/html/rfc9134
+        enum transmission_mode
+        {
+            out_of_order = 0,
+            sequential = 1
+        };
+
+        // JPEG XS Profile
+        // "The JPEG XS profile [ISO21122-2] in use. Any white space Unicode character in the profile name SHALL be omitted."
+        // See https://tools.ietf.org/html/rfc9134
+        DEFINE_STRING_ENUM(profile)
+        namespace profiles
+        {
+            const profile HighBayer{ U("HighBayer") };
+            const profile MainBayer{ U("MainBayer") };
+            const profile LightBayer{ U("LightBayer") };
+            const profile High4444_12{ U("High4444.12") };
+            const profile Main4444_12{ U("Main4444.12") };
+            const profile High444_12{ U("High444.12") };
+            const profile Main444_12{ U("Main444.12") };
+            const profile Light444_12{ U("Light444.12") };
+            const profile Main422_10{ U("Main422.10") };
+            const profile Light422_10{ U("Light422.10") };
+            const profile Light_Subline422_10{ U("Light-Subline422.10") };
+            const profile MLS_12{ U("MLS.12") };
+            const profile High420_12{ U("High420.12") };
+            const profile Main420_12{ U("Main420.12") };
+        }
+
+        // JPEG XS Level
+        // "The JPEG XS level [ISO21122-2] in use. Any white space Unicode character in the level name SHALL be omitted."
+        // See https://tools.ietf.org/html/rfc9134
+        DEFINE_STRING_ENUM(level)
+        namespace levels
+        {
+            const level Level1k_1{ U("1k-1") };
+            const level Bayer2k_1{ U("Bayer2k-1") };
+            const level Level2k_1{ U("2k-1") };
+            const level Bayer4k_1{ U("Bayer4k-1") };
+            const level Level4k_1{ U("4k-1") };
+            const level Bayer8k_1{ U("Bayer8k-1") };
+            const level Level4k_2{ U("4k-2") };
+            const level Bayer8k_2{ U("Bayer8k-2") };
+            const level Level4k_3{ U("4k-3") };
+            const level Bayer8k_3{ U("Bayer8k-3") };
+            const level Level8k_1{ U("8k-1") };
+            const level Bayer16k_1{ U("Bayer16k-1") };
+            const level Level8k_2{ U("8k-2") };
+            const level Bayer16k_2{ U("Bayer16k-2") };
+            const level Level8k_3{ U("8k-3") };
+            const level Bayer16k_3{ U("Bayer16k-3") };
+            const level Level10k_1{ U("10k-1") };
+            const level Bayer20k_1{ U("Bayer20k-1") };
+        }
+
+        // JPEG XS Sublevel
+        // "The JPEG XS sublevel [ISO21122-2] in use. Any white space Unicode character in the sublevel name SHALL be omitted."
+        // See https://tools.ietf.org/html/rfc9134
+        DEFINE_STRING_ENUM(sublevel)
+        namespace sublevels
+        {
+            const sublevel Full{ U("Full") };
+            const sublevel Sublev12bpp{ U("Sublev12bpp") };
+            const sublevel Sublev9bpp{ U("Sublev9bpp") };
+            const sublevel Sublev6bpp{ U("Sublev6bpp") };
+            const sublevel Sublev4bpp{ U("Sublev4bpp") };
+            const sublevel Sublev3bpp{ U("Sublev3bpp") };
+            const sublevel Sublev2bpp{ U("Sublev2bpp") };
+        }
     }
 }
 
@@ -182,10 +264,11 @@ namespace nmos
     struct video_jxsv_parameters
     {
         // fmtp indicates format
-        nmos::packet_transmission_mode packet_transmission_mode;
-        nmos::profile profile;
-        nmos::level level;
-        nmos::sublevel sublevel;
+        sdp::video_jxsv::packetization_mode packetmode;
+        sdp::video_jxsv::transmission_mode transmode;
+        sdp::video_jxsv::profile profile; // nmos::profile has compatible values
+        sdp::video_jxsv::level level; // nmos::level has compatible values
+        sdp::video_jxsv::sublevel sublevel; // nmos::sublevel has compatible values
         uint32_t depth;
         uint32_t width;
         uint32_t height;
@@ -197,13 +280,14 @@ namespace nmos
         sdp::transfer_characteristic_system tcs; // nmos::transfer_characteristic is compatible
         sdp::type_parameter tp; // nmos::st2110_21_sender_type is compatible
 
-        video_jxsv_parameters() : depth(), width(), height(), interlace(), segmented() {}
+        video_jxsv_parameters() : packetmode(sdp::video_jxsv::codestream), transmode(sdp::video_jxsv::sequential), depth(), width(), height(), interlace(), segmented() {}
 
         video_jxsv_parameters(
-            nmos::packet_transmission_mode packet_transmission_mode,
-            nmos::profile profile,
-            nmos::level level,
-            nmos::sublevel sublevel,
+            sdp::video_jxsv::packetization_mode packetmode,
+            sdp::video_jxsv::transmission_mode transmode,
+            sdp::video_jxsv::profile profile,
+            sdp::video_jxsv::level level,
+            sdp::video_jxsv::sublevel sublevel,
             uint32_t depth,
             uint32_t width,
             uint32_t height,
@@ -215,7 +299,8 @@ namespace nmos
             sdp::transfer_characteristic_system tcs,
             sdp::type_parameter tp
         )
-            : packet_transmission_mode(std::move(packet_transmission_mode))
+            : packetmode(packetmode)
+            , transmode(transmode)
             , profile(std::move(profile))
             , level(std::move(level))
             , sublevel(std::move(sublevel))

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -258,19 +258,6 @@ namespace nmos
     std::pair<sdp::video_jxsv::packetization_mode, sdp::video_jxsv::transmission_mode> make_packet_transmission_mode(const nmos::packet_transmission_mode& mode);
     nmos::packet_transmission_mode parse_packet_transmission_mode(sdp::video_jxsv::packetization_mode packetmode, sdp::video_jxsv::transmission_mode transmode);
 
-    // ST 2110-21 Sender Type
-    // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#st-2110-21-sender-type
-    DEFINE_STRING_ENUM(st2110_21_sender_type)
-    namespace st2110_21_sender_types
-    {
-        // Narrow Senders (Type N)
-        const st2110_21_sender_type type_N{ U("2110TPN") };
-        // Narrow Linear Senders (Type NL)
-        const st2110_21_sender_type type_NL{ U("2110TPNL") };
-        // Wide Senders (Type W)
-        const st2110_21_sender_type type_W{ U("2110TPW") };
-    }
-
     // Additional "video/jxsv" parameters
     // See https://www.iana.org/assignments/media-types/video/jxsv
     // and https://tools.ietf.org/html/rfc9134

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -2,6 +2,7 @@
 #define NMOS_VIDEO_JXSV_H
 
 #include "nmos/media_type.h"
+#include "nmos/node_resources.h"
 #include "nmos/sdp_utils.h"
 
 namespace sdp
@@ -355,6 +356,26 @@ namespace nmos
 
     // Calculate the format bit rate (kilobits/second) from the specified frame rate, dimensions and bits per pixel
     uint64_t get_video_jxsv_bit_rate(const nmos::rational& grain_rate, uint32_t frame_width, uint32_t frame_height, double bits_per_pixel);
+
+    // See https://specs.amwa.tv/bcp-006-01/branches/v1.0-dev/docs/NMOS_With_JPEG_XS.html#flows
+    // cf. nmos::make_coded_video_flow
+    nmos::resource make_video_jxsv_flow(
+        const nmos::id& id,
+        const nmos::id& source_id,
+        const nmos::id& device_id,
+        const nmos::rational& grain_rate,
+        unsigned int frame_width,
+        unsigned int frame_height,
+        const nmos::interlace_mode& interlace_mode,
+        const nmos::colorspace& colorspace,
+        const nmos::transfer_characteristic& transfer_characteristic,
+        const sdp::sampling& color_sampling,
+        unsigned int bit_depth,
+        const nmos::profile& profile,
+        const nmos::level& level,
+        const nmos::sublevel& sublevel,
+        double bits_per_pixel,
+        const nmos::settings& settings);
 }
 
 #endif

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -338,6 +338,16 @@ namespace nmos
 
     // Validate SDP parameters for "video/jxsv" against IS-04 receiver capabilities
     void validate_video_jxsv_sdp_parameters(const web::json::value& receiver, const nmos::sdp_parameters& sdp_params);
+
+    // Calculate the format bit rate (kilobits/second) from the specified frame rate, dimensions and bits per pixel
+    uint64_t get_video_jxsv_bit_rate(const nmos::rational& grain_rate, uint32_t frame_width, uint32_t frame_height, double bits_per_pixel);
+
+    namespace details
+    {
+        // Check the specified SDP bandwidth parameter against the specified transport bit rate (kilobits/second) constraint
+        // See ST 2110-22:2022
+        bool match_transport_bit_rate_constraint(const nmos::sdp_parameters::bandwidth_t& bandwidth, const web::json::value& constraint);
+    }
 }
 
 #endif

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -1,0 +1,252 @@
+#ifndef NMOS_VIDEO_JXSV_H
+#define NMOS_VIDEO_JXSV_H
+
+#include "nmos/media_type.h"
+#include "nmos/sdp_utils.h"
+
+namespace sdp
+{
+    namespace fields
+    {
+        // See https://www.iana.org/assignments/media-types/video/jxsv
+        // and https://tools.ietf.org/html/rfc9134#section-7
+
+        // pacKetization mode (K) bit
+        const web::json::field<uint32_t> packetmode{ U("packetmode") };
+        // Transmission mode (T) bit
+        const web::json::field_with_default<uint32_t> transmode{ U("transmode"), 1 };
+
+        const web::json::field_as_string profile{ U("profile") };
+        const web::json::field_as_string level{ U("level") };
+        const web::json::field_as_string sublevel{ U("sublevel") };
+    }
+}
+
+namespace nmos
+{
+    namespace media_types
+    {
+        // JPEG XS
+        // See https://www.iana.org/assignments/media-types/video/jxsv
+        // and https://tools.ietf.org/html/rfc9134
+        const media_type video_jxsv{ U("video/jxsv") };
+    }
+
+    namespace fields
+    {
+        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#bit-rate
+        // and https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#bit-rate
+        const web::json::field_as_integer bit_rate{ U("bit_rate") };
+
+        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#profile
+        const web::json::field_as_string profile{ U("profile") };
+
+        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#level
+        const web::json::field_as_string level{ U("level") };
+
+        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#sublevel
+        const web::json::field_as_string sublevel{ U("sublevel") };
+
+        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#packet-transmission-mode
+        const web::json::field_as_string_or packet_transmission_mode{ U("packet_transmission_mode"), U("codestream") };
+
+        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#st-2110-21-sender-type
+        const web::json::field_as_string st2110_21_sender_type{ U("st2110_21_sender_type") };
+    }
+
+    namespace caps
+    {
+        namespace format
+        {
+            // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#format-bit-rate
+            const web::json::field_as_value_or bit_rate{ U("urn:x-nmos:cap:format:bit_rate"), {} }; // number
+
+            // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#profile
+            const web::json::field_as_value_or profile{ U("urn:x-nmos:cap:format:profile"), {} }; // string
+
+            // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#level
+            const web::json::field_as_value_or level{ U("urn:x-nmos:cap:format:level"), {} }; // string
+
+            // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#sublevel
+            const web::json::field_as_value_or sublevel{ U("urn:x-nmos:cap:format:sublevel"), {} }; // string
+        }
+
+        namespace transport
+        {
+            // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#transport-bit-rate
+            const web::json::field_as_value_or bit_rate{ U("urn:x-nmos:cap:transport:bit_rate"), {} }; // number
+        }
+    }
+
+    // Profile
+    // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#profile
+    DEFINE_STRING_ENUM(profile)
+    namespace profiles
+    {
+        // JPEG XS Profile
+        // "The JPEG XS profile [ISO21122-2] in use. Any white space Unicode character in the profile name SHALL be omitted."
+        // See https://tools.ietf.org/html/rfc9134
+        // and https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/flow_video_jxsv_register.html
+        const profile HighBayer{ U("HighBayer") };
+        const profile MainBayer{ U("MainBayer") };
+        const profile LightBayer{ U("LightBayer") };
+        const profile High4444_12{ U("High4444.12") };
+        const profile Main4444_12{ U("Main4444.12") };
+        const profile High444_12{ U("High444.12") };
+        const profile Main444_12{ U("Main444.12") };
+        const profile Light444_12{ U("Light444.12") };
+        const profile Main422_10{ U("Main422.10") };
+        const profile Light422_10{ U("Light422.10") };
+        const profile Light_Subline422_10{ U("Light-Subline422.10") };
+        const profile MLS_12{ U("MLS.12") };
+        const profile High420_12{ U("High420.12") };
+        const profile Main420_12{ U("Main420.12") };
+    }
+
+    // Level
+    // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#level
+    DEFINE_STRING_ENUM(level)
+    namespace levels
+    {
+        // JPEG XS Level
+        // "The JPEG XS level [ISO21122-2] in use. Any white space Unicode character in the level name SHALL be omitted."
+        // See https://tools.ietf.org/html/rfc9134
+        // and https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/flow_video_jxsv_register.html
+        const level Level1k_1{ U("1k-1") };
+        const level Bayer2k_1{ U("Bayer2k-1") };
+        const level Level2k_1{ U("2k-1") };
+        const level Bayer4k_1{ U("Bayer4k-1") };
+        const level Level4k_1{ U("4k-1") };
+        const level Bayer8k_1{ U("Bayer8k-1") };
+        const level Level4k_2{ U("4k-2") };
+        const level Bayer8k_2{ U("Bayer8k-2") };
+        const level Level4k_3{ U("4k-3") };
+        const level Bayer8k_3{ U("Bayer8k-3") };
+        const level Level8k_1{ U("8k-1") };
+        const level Bayer16k_1{ U("Bayer16k-1") };
+        const level Level8k_2{ U("8k-2") };
+        const level Bayer16k_2{ U("Bayer16k-2") };
+        const level Level8k_3{ U("8k-3") };
+        const level Bayer16k_3{ U("Bayer16k-3") };
+        const level Level10k_1{ U("10k-1") };
+        const level Bayer20k_1{ U("Bayer20k-1") };
+    }
+
+    // Sublevel
+    // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/#sublevel
+    DEFINE_STRING_ENUM(sublevel)
+    namespace sublevels
+    {
+        // JPEG XS Sublevel
+        // "The JPEG XS sublevel [ISO21122-2] in use. Any white space Unicode character in the sublevel name SHALL be omitted."
+        // See https://tools.ietf.org/html/rfc9134
+        // and https://specs.amwa.tv/nmos-parameter-registers/branches/main/flow-attributes/flow_video_jxsv_register.html
+        const sublevel Full{ U("Full") };
+        const sublevel Sublev12bpp{ U("Sublev12bpp") };
+        const sublevel Sublev9bpp{ U("Sublev9bpp") };
+        const sublevel Sublev6bpp{ U("Sublev6bpp") };
+        const sublevel Sublev4bpp{ U("Sublev4bpp") };
+        const sublevel Sublev3bpp{ U("Sublev3bpp") };
+        const sublevel Sublev2bpp{ U("Sublev2bpp") };
+    }
+
+    // Packet Transmission Mode
+    // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#packet-transmission-mode
+    DEFINE_STRING_ENUM(packet_transmission_mode)
+    namespace packet_transmission_modes
+    {
+        // JPEG XS packetization and transmission mode
+        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#packet-transmission-mode
+        // and https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/sender_register.html
+        const packet_transmission_mode codestream{ U("codestream") };
+        const packet_transmission_mode slice_sequential{ U("slice_sequential") };
+        const packet_transmission_mode slice_out_of_order{ U("slice_out_of_order") };
+    }
+
+    // ST 2110-21 Sender Type
+    // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#st-2110-21-sender-type
+    DEFINE_STRING_ENUM(st2110_21_sender_type)
+    namespace st2110_21_sender_types
+    {
+        // Narrow Senders (Type N)
+        const st2110_21_sender_type type_N{ U("2110TPN") };
+        // Narrow Linear Senders (Type NL)
+        const st2110_21_sender_type type_NL{ U("2110TPNL") };
+        // Wide Senders (Type W)
+        const st2110_21_sender_type type_W{ U("2110TPW") };
+    }
+
+    // Additional "video/jxsv" parameters
+    // See https://www.iana.org/assignments/media-types/video/jxsv
+    // and https://tools.ietf.org/html/rfc9134
+    struct video_jxsv_parameters
+    {
+        // fmtp indicates format
+        nmos::packet_transmission_mode packet_transmission_mode;
+        nmos::profile profile;
+        nmos::level level;
+        nmos::sublevel sublevel;
+        uint32_t depth;
+        uint32_t width;
+        uint32_t height;
+        nmos::rational exactframerate;
+        bool interlace;
+        bool segmented;
+        sdp::sampling sampling;
+        sdp::colorimetry colorimetry; // nmos::colorspace is compatible
+        sdp::transfer_characteristic_system tcs; // nmos::transfer_characteristic is compatible
+        sdp::type_parameter tp; // nmos::st2110_21_sender_type is compatible
+
+        video_jxsv_parameters() : depth(), width(), height(), interlace(), segmented() {}
+
+        video_jxsv_parameters(
+            nmos::packet_transmission_mode packet_transmission_mode,
+            nmos::profile profile,
+            nmos::level level,
+            nmos::sublevel sublevel,
+            uint32_t depth,
+            uint32_t width,
+            uint32_t height,
+            nmos::rational exactframerate,
+            bool interlace,
+            bool segmented,
+            sdp::sampling sampling,
+            sdp::colorimetry colorimetry,
+            sdp::transfer_characteristic_system tcs,
+            sdp::type_parameter tp
+        )
+            : packet_transmission_mode(std::move(packet_transmission_mode))
+            , profile(std::move(profile))
+            , level(std::move(level))
+            , sublevel(std::move(sublevel))
+            , depth(depth)
+            , width(width)
+            , height(height)
+            , exactframerate(exactframerate)
+            , interlace(interlace)
+            , segmented(segmented)
+            , sampling(std::move(sampling))
+            , colorimetry(std::move(colorimetry))
+            , tcs(std::move(tcs))
+            , tp(std::move(tp))
+        {}
+    };
+
+    // Construct additional "video/jxsv" parameters from the IS-04 resources
+    video_jxsv_parameters make_video_jxsv_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender);
+    // Construct SDP parameters for "video/jxsv"
+    sdp_parameters make_video_jxsv_sdp_parameters(const utility::string_t& session_name, const video_jxsv_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
+    // Get additional "video/jxsv" parameters from the SDP parameters
+    video_jxsv_parameters get_video_jxsv_parameters(const sdp_parameters& sdp_params);
+
+    // Construct SDP parameters for "video/jxsv"
+    inline sdp_parameters make_sdp_parameters(const utility::string_t& session_name, const video_jxsv_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {})
+    {
+        return make_video_jxsv_sdp_parameters(session_name, params, payload_type, media_stream_ids, ts_refclk);
+    }
+
+    // Validate SDP parameters for "video/jxsv" against IS-04 receiver capabilities
+    void validate_video_jxsv_sdp_parameters(const web::json::value& receiver, const nmos::sdp_parameters& sdp_params);
+}
+
+#endif

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -135,9 +135,6 @@ namespace nmos
 
         // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#packet-transmission-mode
         const web::json::field_as_string_or packet_transmission_mode{ U("packet_transmission_mode"), U("codestream") };
-
-        // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#st-2110-21-sender-type
-        const web::json::field_as_string st2110_21_sender_type{ U("st2110_21_sender_type") };
     }
 
     namespace caps
@@ -285,21 +282,32 @@ namespace nmos
         sdp::video_jxsv::profile profile; // nmos::profile has compatible values
         sdp::video_jxsv::level level; // nmos::level has compatible values
         sdp::video_jxsv::sublevel sublevel; // nmos::sublevel has compatible values
+        sdp::sampling sampling;
         uint32_t depth;
         uint32_t width;
         uint32_t height;
         nmos::rational exactframerate;
         bool interlace;
         bool segmented;
-        sdp::sampling sampling;
-        sdp::colorimetry colorimetry; // nmos::colorspace is compatible
         sdp::transfer_characteristic_system tcs; // nmos::transfer_characteristic is compatible
-        sdp::type_parameter tp; // nmos::st2110_21_sender_type is compatible
+        sdp::colorimetry colorimetry; // nmos::colorspace is compatible
+        sdp::range range; // if omitted (empty), assume sdp::ranges::NARROW
+        sdp::smpte_standard_number ssn;
+
+        // additional fmtp parameters from ST 2110-21:2022
+        sdp::type_parameter tp;
+        uint32_t troff; // if omitted (zero), assume default
+        uint32_t cmax; // if omitted (zero), assume max defined for tp
+
+        // additional fmtp parameters from ST 2110-10:2022
+        uint32_t maxudp; // if omitted (zero), assume the Standard UP Size Limit
+        sdp::timestamp_mode tsmode; // if omitted (empty), assume sdp::timestamp_modes::NEW
+        uint32_t tsdelay;
 
         // bandwidth
         uint64_t bit_rate; // transport bit rate
 
-        video_jxsv_parameters() : packetmode(sdp::video_jxsv::codestream), transmode(sdp::video_jxsv::sequential), depth(), width(), height(), interlace(), segmented(), bit_rate() {}
+        video_jxsv_parameters() : depth(), width(), height(), interlace(), segmented(), troff(), cmax(), maxudp(), tsdelay() {}
 
         video_jxsv_parameters(
             sdp::video_jxsv::packetization_mode packetmode,
@@ -307,16 +315,23 @@ namespace nmos
             sdp::video_jxsv::profile profile,
             sdp::video_jxsv::level level,
             sdp::video_jxsv::sublevel sublevel,
+            sdp::sampling sampling,
             uint32_t depth,
             uint32_t width,
             uint32_t height,
             nmos::rational exactframerate,
             bool interlace,
             bool segmented,
-            sdp::sampling sampling,
-            sdp::colorimetry colorimetry,
             sdp::transfer_characteristic_system tcs,
+            sdp::colorimetry colorimetry,
+            sdp::range range,
+            sdp::smpte_standard_number ssn,
             sdp::type_parameter tp,
+            uint32_t troff,
+            uint32_t cmax,
+            uint32_t maxudp,
+            sdp::timestamp_mode tsmode,
+            uint32_t tsdelay,
             uint64_t bit_rate
         )
             : packetmode(packetmode)
@@ -324,16 +339,23 @@ namespace nmos
             , profile(std::move(profile))
             , level(std::move(level))
             , sublevel(std::move(sublevel))
+            , sampling(std::move(sampling))
             , depth(depth)
             , width(width)
             , height(height)
             , exactframerate(exactframerate)
             , interlace(interlace)
             , segmented(segmented)
-            , sampling(std::move(sampling))
-            , colorimetry(std::move(colorimetry))
             , tcs(std::move(tcs))
+            , colorimetry(std::move(colorimetry))
+            , range(std::move(range))
+            , ssn(std::move(ssn))
             , tp(std::move(tp))
+            , troff(troff)
+            , cmax(cmax)
+            , maxudp(maxudp)
+            , tsmode(std::move(tsmode))
+            , tsdelay(tsdelay)
             , bit_rate(bit_rate)
         {}
     };

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -157,6 +157,9 @@ namespace nmos
         {
             // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#transport-bit-rate
             const web::json::field_as_value_or bit_rate{ U("urn:x-nmos:cap:transport:bit_rate"), {} }; // number
+
+            // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/#packet-transmission-mode
+            const web::json::field_as_value_or packet_transmission_mode{ U("urn:x-nmos:cap:transport:packet_transmission_mode"), {} }; // string
         }
     }
 
@@ -244,6 +247,9 @@ namespace nmos
         const packet_transmission_mode slice_sequential{ U("slice_sequential") };
         const packet_transmission_mode slice_out_of_order{ U("slice_out_of_order") };
     }
+
+    std::pair<sdp::video_jxsv::packetization_mode, sdp::video_jxsv::transmission_mode> make_packet_transmission_mode(const nmos::packet_transmission_mode& mode);
+    nmos::packet_transmission_mode parse_packet_transmission_mode(sdp::video_jxsv::packetization_mode packetmode, sdp::video_jxsv::transmission_mode transmode);
 
     // ST 2110-21 Sender Type
     // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/sender-attributes/#st-2110-21-sender-type

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -87,6 +87,9 @@ namespace sdp
             const level Bayer20k_1{ U("Bayer20k-1") };
         }
 
+        // Calculate the lowest possible JPEG XS level from the specified frame rate and dimensions
+        level get_level(const nmos::rational& frame_rate, uint32_t frame_width, uint32_t frame_height);
+
         // JPEG XS Sublevel
         // "The JPEG XS sublevel [ISO21122-2] in use. Any white space Unicode character in the sublevel name SHALL be omitted."
         // See https://tools.ietf.org/html/rfc9134
@@ -215,6 +218,12 @@ namespace nmos
         const level Bayer16k_3{ U("Bayer16k-3") };
         const level Level10k_1{ U("10k-1") };
         const level Bayer20k_1{ U("Bayer20k-1") };
+    }
+
+    // Calculate the lowest possible JPEG XS level from the specified frame rate and dimensions
+    inline nmos::level get_video_jxsv_level(const nmos::rational& grain_rate, uint32_t frame_width, uint32_t frame_height)
+    {
+        return nmos::level{ sdp::video_jxsv::get_level(grain_rate, frame_width, frame_height).name };
     }
 
     // Sublevel

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -295,7 +295,10 @@ namespace nmos
         sdp::transfer_characteristic_system tcs; // nmos::transfer_characteristic is compatible
         sdp::type_parameter tp; // nmos::st2110_21_sender_type is compatible
 
-        video_jxsv_parameters() : packetmode(sdp::video_jxsv::codestream), transmode(sdp::video_jxsv::sequential), depth(), width(), height(), interlace(), segmented() {}
+        // bandwidth
+        uint64_t bit_rate; // transport bit rate
+
+        video_jxsv_parameters() : packetmode(sdp::video_jxsv::codestream), transmode(sdp::video_jxsv::sequential), depth(), width(), height(), interlace(), segmented(), bit_rate() {}
 
         video_jxsv_parameters(
             sdp::video_jxsv::packetization_mode packetmode,
@@ -312,7 +315,8 @@ namespace nmos
             sdp::sampling sampling,
             sdp::colorimetry colorimetry,
             sdp::transfer_characteristic_system tcs,
-            sdp::type_parameter tp
+            sdp::type_parameter tp,
+            uint64_t bit_rate
         )
             : packetmode(packetmode)
             , transmode(transmode)
@@ -329,6 +333,7 @@ namespace nmos
             , colorimetry(std::move(colorimetry))
             , tcs(std::move(tcs))
             , tp(std::move(tp))
+            , bit_rate(bit_rate)
         {}
     };
 
@@ -350,13 +355,6 @@ namespace nmos
 
     // Calculate the format bit rate (kilobits/second) from the specified frame rate, dimensions and bits per pixel
     uint64_t get_video_jxsv_bit_rate(const nmos::rational& grain_rate, uint32_t frame_width, uint32_t frame_height, double bits_per_pixel);
-
-    namespace details
-    {
-        // Check the specified SDP bandwidth parameter against the specified transport bit rate (kilobits/second) constraint
-        // See ST 2110-22:2022
-        bool match_transport_bit_rate_constraint(const nmos::sdp_parameters::bandwidth_t& bandwidth, const web::json::value& constraint);
-    }
 }
 
 #endif

--- a/Development/sdp/json.h
+++ b/Development/sdp/json.h
@@ -500,7 +500,7 @@ namespace sdp
 
     // Colorimetry
     // See https://tools.ietf.org/html/rfc4175
-    // and SMPTE ST 2110-20:2017 Section 7.5 Permitted values of Colorimetry
+    // and SMPTE ST 2110-20:2022 Section 7.5 Permitted values of Colorimetry
     // and AMWA IS-04 v1.2 "colorspace"
     DEFINE_STRING_ENUM(colorimetry)
     namespace colorimetries
@@ -524,6 +524,8 @@ namespace sdp
         const colorimetry UNSPECIFIED{ U("UNSPECIFIED") };
         // ISO 11664-1 CIE 1931 standard colorimetric system
         const colorimetry XYZ{ U("XYZ") };
+        // Colorimetry value signaled for key signals as specified in SMPTE RP 157
+        const colorimetry ALPHA{ U("ALPHA") };
     }
 
     // Packing Mode
@@ -538,11 +540,14 @@ namespace sdp
     }
 
     // SMPTE Standard Number
-    // See SMPTE ST 2110-20:2017 Section 7.2 Required Media Type Parameters
+    // See SMPTE ST 2110-20:2022 Section 7.2 Required Media Type Parameters
     DEFINE_STRING_ENUM(smpte_standard_number)
     namespace smpte_standard_numbers
     {
         const smpte_standard_number ST2110_20_2017{ U("ST2110-20:2017") };
+        // "Senders implementing this standard shall signal the value ST2110-20:2017 unless the colorimetry value ALPHA
+        // or the TCS value ST2115LOGS3 are used, in which case the value ST2110-20:2022 shall be signaled."
+        const smpte_standard_number ST2110_20_2022{ U("ST2110-20:2022") };
     }
 
     // TP (Media Type Parameter)
@@ -586,6 +591,8 @@ namespace sdp
         // Hmm, the JPEG XS payload mapping includes "video streams whose transfer characteristics are signaled by the payload as specified in ISO/IEC 21122-3".
         // See https://tools.ietf.org/html/draft-ietf-payload-rtp-jpegxs-09#section-6
         const transfer_characteristic_system UNSPECIFIED{ U("UNSPECIFIED") };
+        // Video streams of high dynamic range video that utilize the "Camera Log S3" (i.e. S-Log3) transfer characteristic specified in SMPTE ST 2115.
+        const transfer_characteristic_system ST2115LOGS3{ U("ST2115LOGS3") };
     }
 
     // RANGE

--- a/Development/sdp/json.h
+++ b/Development/sdp/json.h
@@ -409,14 +409,14 @@ namespace sdp
         // and VSF TR-05:2018
 
         // ST 2110-20:2017 Section 7.2 Required Media Type Parameters
-        const web::json::field_as_string sampling{ U("sampling") };
+        const web::json::field_as_string sampling{ U("sampling") }; // see sdp::sampling
         const web::json::field<uint32_t> width{ U("width") };
         const web::json::field<uint32_t> height{ U("height") };
         const web::json::field<uint32_t> depth{ U("depth") };
         const web::json::field_as_string exactframerate{ U("exactframerate") };
-        const web::json::field_as_string colorimetry{ U("colorimetry") };
-        const web::json::field_as_string packing_mode{ U("PM") };
-        const web::json::field_as_string smpte_standard_number{ U("SSN") };
+        const web::json::field_as_string colorimetry{ U("colorimetry") }; // see sdp::colorimetry
+        const web::json::field_as_string packing_mode{ U("PM") }; // see sdp::packing_mode
+        const web::json::field_as_string smpte_standard_number{ U("SSN") }; // see sdp::smpte_standard_number
 
         // ST 2110-20:2017 Section 7.3 Media Type Parameters with default values
         const web::json::field_as_bool_or interlace{ U("interlace"), false };
@@ -426,11 +426,11 @@ namespace sdp
         // hm, for the following optional parameters, it seems important to distinguish
         // an omitted parameter from an explicitly specified default value...
         // "If the TCS value is not specified, receivers shall assume the value SDR" per ST 2110-20:2017 Section 7.6
-        const web::json::field_as_string transfer_characteristic_system{ U("TCS") };
+        const web::json::field_as_string transfer_characteristic_system{ U("TCS") }; // see sdp::transfer_characteristic_system
         // "In the absence of [the RANGE] parameter, NARROW shall be the assumed value" per ST 2110-20:2017 Section 7.3
-        // Hmm, the JPEG XS payload mapping says that "when paired with the UNSPECIFIED colo[ri]metry, FULL SHALL be the default assumed value"
-        // See https://tools.ietf.org/html/draft-ietf-payload-rtp-jpegxs-09#section-6
-        const web::json::field_as_string range{ U("RANGE") };
+        // Hmm, the JPEG XS payload mapping says that "when paired with the UNSPECIFIED colorimetry, FULL SHALL be the default assumed value"
+        // See https://tools.ietf.org/html/rfc9134#section-7
+        const web::json::field_as_string range{ U("RANGE") }; // see sdp::range
         // "If [MAXUDP is] absent, it indicates that the Standard UDP Size Limit [i.e. 1460 octets] is in use."
         const web::json::field<uint32_t> max_udp_packet_size{ U("MAXUDP") };
         // "When it is signaled, PAR shall be signaled as a ratio of two integer decimal numbers separated by a colon character (e.g. 12:11).
@@ -439,23 +439,18 @@ namespace sdp
         const web::json::field_as_string pixel_aspect_ratio{ U("PAR") };
 
         // See SMPTE ST 2110-21:2017 Section 8 Session Description Considerations
-        const web::json::field_as_string type_parameter{ U("TP") };
+
+        // ST 2110-21:2017 Section 8.1 Required Parameters
+        const web::json::field_as_string type_parameter{ U("TP") }; // see sdp::type_parameter
 
         // See SMPTE ST 2110-30:2017
         // and https://tools.ietf.org/html/rfc3190
-        const web::json::field_as_string channel_order{ U("channel-order") }; // "<convention>.<order>", e.g. "SMPTE2110.(ST)"
+        const web::json::field_as_string channel_order{ U("channel-order") }; // "<convention>.<order>", e.g. "SMPTE2110.(ST)", see nmos/channels.h
 
         // See SMPTE ST 2110-40:2018
         // and https://tools.ietf.org/html/rfc8331
-        const web::json::field_as_string DID_SDID{ U("DID_SDID") }; // e.g. "{0x41,0x01}"
-        const web::json::field<uint32_t> VPID_Code{ U("VPID_Code") }; // 1..255
-
-        // See the JPEG XS payload mapping
-        const web::json::field<uint32_t> transmission_mode{ U("transmode") }; // the T bit (0 for out-of-order-allowed or 1 for sequential)
-        const web::json::field<uint32_t> packet_mode{ U("packetmode") }; // the K bit (0 for codestream or 1 for slice)
-        const web::json::field_as_string profile{ U("profile") }; // e.g. 'Main-444.12' or 'High-444.12'
-        const web::json::field_as_string level{ U("level") }; // e.g. '2k-1' or '4k-1'
-        const web::json::field_as_string sublevel{ U("sublevel") }; // e.g. 'Sublev3bpp' or 'Sublev6pp'
+        const web::json::field_as_string DID_SDID{ U("DID_SDID") }; // e.g. "{0x41,0x01}", see nmos::did_sdid
+        const web::json::field<uint32_t> VPID_Code{ U("VPID_Code") }; // 1..255, see nmos::vpid_code
     }
 }
 
@@ -493,8 +488,8 @@ namespace sdp
         // Key signal represented as a single component
         // e.g. as specified in SMPTE RP 157
         const sampling KEY{ U("KEY") };
-        // Hmm, only the JPEG XS payload mapping includes this value, for "sampling signaled by the payload"
-        // See https://tools.ietf.org/html/draft-ietf-payload-rtp-jpegxs-09#section-6
+        // Hmm, the JPEG XS payload mapping adds this value, for "sampling signaled by the payload"
+        // See https://tools.ietf.org/html/rfc9134#section-7
         const sampling UNSPECIFIED{ U("UNSPECIFIED") };
     }
 
@@ -520,7 +515,6 @@ namespace sdp
         // SMPTE ST 2065-3 Academy Density Exchange Encoding (ADX)
         const colorimetry ST2065_3{ U("ST2065-3") };
         // Colorimetry that is not specified and must be manually coordinated between sender and receiver
-        // Hmm, the JPEG XS payload mapping adds that it may be "signaled in the payload by the Color Specification Box of ISO/IEC 21122-3"
         const colorimetry UNSPECIFIED{ U("UNSPECIFIED") };
         // ISO 11664-1 CIE 1931 standard colorimetric system
         const colorimetry XYZ{ U("XYZ") };
@@ -564,7 +558,7 @@ namespace sdp
     }
 
     // TCS (Transfer Characteristic System)
-    // See SMPTE ST 2110-20:2017 Section 7.6 Permitted values of TCS
+    // See SMPTE ST 2110-20:2022 Section 7.6 Permitted values of TCS
     // and AMWA IS-04 v1.2 "transfer_characteristic"
     DEFINE_STRING_ENUM(transfer_characteristic_system)
     namespace transfer_characteristic_systems
@@ -588,8 +582,6 @@ namespace sdp
         // Video streams of density encoded samples, such as those defined in SMPTE ST 2065-3.
         const transfer_characteristic_system DENSITY{ U("DENSITY") };
         // Video streams whose transfer characteristics are not specified. The transfer characteristics must be manually coordinated between sender and receiver.
-        // Hmm, the JPEG XS payload mapping includes "video streams whose transfer characteristics are signaled by the payload as specified in ISO/IEC 21122-3".
-        // See https://tools.ietf.org/html/draft-ietf-payload-rtp-jpegxs-09#section-6
         const transfer_characteristic_system UNSPECIFIED{ U("UNSPECIFIED") };
         // Video streams of high dynamic range video that utilize the "Camera Log S3" (i.e. S-Log3) transfer characteristic specified in SMPTE ST 2115.
         const transfer_characteristic_system ST2115LOGS3{ U("ST2115LOGS3") };


### PR DESCRIPTION
JPEG XS support, per [[Work In Progress] BCP-006-01](https://specs.amwa.tv/bcp-006-01/branches/v1.0-dev).

I propose waiting until we add e.g. `video/H264` or similar before moving the common things out of _nmos/video_jxsv.h_ into common headers.

~The few missing/new ST 2110 format-specific parameters to add, and updates for ST 2110-xx:2022, can be done as a separate PR; I'm fed up waiting for SMPTE/IEEE.~ (Done.)