### PR TITLE
Fix rql::details::rql_exception 

### DIFF
--- a/Development/rql/rql.h
+++ b/Development/rql/rql.h
@@ -32,6 +32,9 @@ namespace rql
     typedef std::function<bool(web::json::value& results, const web::json::value& key)> extractor;
     typedef std::unordered_map<utility::string_t, std::function<web::json::value(const evaluator& eval, const web::json::value& args)>> operators;
 
+    void validate_query(const web::json::value& query); // with default call-operators
+    void validate_query(const web::json::value& query, const operators& operators);
+
     struct evaluator
     {
         explicit evaluator(extractor extract); // with default call-operators


### PR DESCRIPTION
`rql::details::rql_exception` was previously thrown during evaluation when an unimplemented operator was encountered; if Query API subscriptions were created that used an unrecognized call-operator, this could result in an exception during subsequent `nmos::insert_resource_events` and therefore registrations to be rejected with a `501` Not Implemented, and uncaught exceptions when new WebSocket connections were opened for that subscription. This solves this by validating the call-operators immediately after the `rql::parse_query` so that such subscriptions are rejected (appropriately, with `501` Not Implemented), and (belt and braces) returning false, i.e. no match, if an exception is encountered during evaluation.