### PR TITLE
Upstream json-schema-validator target name is non-namespaced

### DIFF
--- a/Development/cmake/NmosCppDependencies.cmake
+++ b/Development/cmake/NmosCppDependencies.cmake
@@ -197,7 +197,7 @@ if(NMOS_CPP_USE_CONAN)
     endif()
 
     add_library(json_schema_validator INTERFACE)
-    target_link_libraries(json_schema_validator INTERFACE nlohmann_json_schema_validator::nlohmann_json_schema_validator)
+    target_link_libraries(json_schema_validator INTERFACE nlohmann_json_schema_validator)
 else()
     set(JSON_SCHEMA_VALIDATOR_SOURCES
         third_party/nlohmann/json-patch.cpp


### PR DESCRIPTION
Both non-namespaced and namespaced target names work with the Conan _cmake_find_package_ generator, but after we switch over to the _CMakeDeps_ generator the namespaced one may be gone, so better to align with the upstream.

See https://github.com/pboettch/json-schema-validator/blob/2.1.0/CMakeLists.txt