### PR TITLE
Workaround for Avahi target name with current Conan recipe

### DIFF
--- a/Development/cmake/NmosCppDependencies.cmake
+++ b/Development/cmake/NmosCppDependencies.cmake
@@ -264,7 +264,12 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
             message(STATUS "Found Avahi version " ${Avahi_VERSION})
         endif()
 
-        target_link_libraries(DNSSD INTERFACE Avahi::compat-libdns_sd)
+        if(TARGET Avahi::compat-libdns_sd)
+            target_link_libraries(DNSSD INTERFACE Avahi::compat-libdns_sd)
+        else()
+            # unfortunately some versions of the Conan 'avahi' recipe may produce a lowercase namespace
+            target_link_libraries(DNSSD INTERFACE avahi::compat-libdns_sd)
+        endif()
     else()
         find_package(DNSSD REQUIRED)
         if(NOT DNSSD_VERSION)


### PR DESCRIPTION
May resolve #298.

`avahi/0.8@#10417ed9b1382e1c2b6916db4247dc40` uses CMakeDeps and therefore the target namespace is `avahi::` not `Avahi::`.

@will-leathers-smith-sony, can you try this out? Unfortunately, this _won't_ be tested by GitHub Actions, since the local [_conanfile.txt_](https://github.com/sony/nmos-cpp/blob/master/Development/conanfile.txt) doesn't require the Conan `avahi` package, instead the GitHub Actions [build-test workflow](https://github.com/sony/nmos-cpp/blob/25ffd0b3a8b5a29f3bdf71fd46d3386da789bebb/.github/workflows/build-test.yml#L250) uses `apt-get` to install it.

