### PR TITLE
Fix nmos::match_rational_constraint and add support for pattern constraints for string parameter constraints

### DIFF
--- a/Development/cmake/NmosCppTest.cmake
+++ b/Development/cmake/NmosCppTest.cmake
@@ -40,6 +40,7 @@ set(NMOS_CPP_TEST_MDNS_TEST_HEADERS
 
 set(NMOS_CPP_TEST_NMOS_TEST_SOURCES
     nmos/test/api_utils_test.cpp
+    nmos/test/capabilities_test.cpp
     nmos/test/channels_test.cpp
     nmos/test/did_sdid_test.cpp
     nmos/test/event_type_test.cpp

--- a/Development/nmos/capabilities.cpp
+++ b/Development/nmos/capabilities.cpp
@@ -1,16 +1,18 @@
 #include "nmos/capabilities.h"
 
 #include <boost/range/adaptor/transformed.hpp>
+#include "cpprest/regex_utils.h"
 #include "nmos/json_fields.h"
 
 namespace nmos
 {
-    web::json::value make_caps_string_constraint(const std::vector<utility::string_t>& enum_values)
+    web::json::value make_caps_string_constraint(const std::vector<utility::string_t>& enum_values, const utility::string_t& pattern)
     {
         using web::json::value_of;
         using web::json::value_from_elements;
         return value_of({
-            { !enum_values.empty() ? nmos::fields::constraint_enum.key : U(""), value_from_elements(enum_values) }
+            { !enum_values.empty() ? nmos::fields::constraint_enum.key : U(""), value_from_elements(enum_values) },
+            { !pattern.empty() ? nmos::fields::constraint_pattern.key : U(""), pattern }
         });
     }
 
@@ -58,9 +60,8 @@ namespace nmos
 
     namespace details
     {
-        // cf. nmos::details::make_constraints_schema in nmos/connection_api.cpp 
-        template <typename T, typename Parse>
-        bool match_constraint(const T& value, const web::json::value& constraint, Parse parse)
+        template <typename T, typename Parse = web::json::details::value_as<T>>
+        bool match_enum_constraint(const T& value, const web::json::value& constraint, Parse parse = {})
         {
             if (constraint.has_field(nmos::fields::constraint_enum))
             {
@@ -73,6 +74,12 @@ namespace nmos
                     return false;
                 }
             }
+            return true;
+        }
+
+        template <typename T, typename Parse = web::json::details::value_as<T>>
+        bool match_minimum_maximum_constraint(const T& value, const web::json::value& constraint, Parse parse = {})
+        {
             if (constraint.has_field(nmos::fields::constraint_minimum))
             {
                 const auto& minimum = nmos::fields::constraint_minimum(constraint);
@@ -91,45 +98,78 @@ namespace nmos
             }
             return true;
         }
+
+        template <typename T>
+        bool match_pattern_constraint(const T& value, const web::json::value& constraint)
+        {
+            if (constraint.has_field(nmos::fields::constraint_pattern))
+            {
+                const utility::regex_t regex(nmos::fields::constraint_pattern(constraint));
+                utility::smatch_t match;
+                // throws bst::regex_error if pattern is invalid
+                if (!bst::regex_search(value, match, regex))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 
     bool match_string_constraint(const utility::string_t& value, const web::json::value& constraint)
     {
-        return details::match_constraint(value, constraint, [](const web::json::value& enum_value)
-        {
-            return enum_value.as_string();
-        });
+        return details::match_enum_constraint(value, constraint)
+            && details::match_pattern_constraint(value, constraint);
     }
 
     bool match_integer_constraint(int64_t value, const web::json::value& constraint)
     {
-        return details::match_constraint(value, constraint, [&value](const web::json::value& enum_value)
-        {
-            return enum_value.as_integer();
-        });
+        return details::match_enum_constraint(value, constraint)
+            && details::match_minimum_maximum_constraint(value, constraint);
     }
 
     bool match_number_constraint(double value, const web::json::value& constraint)
     {
-        return details::match_constraint(value, constraint, [&value](const web::json::value& enum_value)
-        {
-            return enum_value.as_double();
-        });
+        return details::match_enum_constraint(value, constraint)
+            && details::match_minimum_maximum_constraint(value, constraint);
     }
 
     bool match_boolean_constraint(bool value, const web::json::value& constraint)
     {
-        return details::match_constraint(value, constraint, [&value](const web::json::value& enum_value)
-        {
-            return enum_value.as_bool();
-        });
+        return details::match_enum_constraint(value, constraint);
     }
 
     bool match_rational_constraint(const nmos::rational& value, const web::json::value& constraint)
     {
-        return details::match_constraint(value, constraint, [&value](const web::json::value& enum_value)
+        return details::match_enum_constraint(value, constraint, &nmos::parse_rational)
+            && details::match_minimum_maximum_constraint(value, constraint, &nmos::parse_rational);
+    }
+
+    bool match_constraint(const web::json::value& value, const web::json::value& constraint)
+    {
+        if (value.is_string())
         {
-            return nmos::parse_rational(enum_value);
-        });
+            return match_string_constraint(value.as_string(), constraint);
+        }
+        else if (value.is_integer())
+        {
+            return match_integer_constraint(value.as_number().to_int64(), constraint);
+        }
+        else if (value.is_double())
+        {
+            return match_number_constraint(value.as_double(), constraint);
+        }
+        else if (value.is_boolean())
+        {
+            return match_boolean_constraint(value.as_bool(), constraint);
+        }
+        else if (nmos::is_rational(value))
+        {
+            return match_rational_constraint(nmos::parse_rational(value), constraint);
+        }
+        else
+        {
+            throw web::json::json_exception("not a valid constraint target type");
+        }
     }
 }

--- a/Development/nmos/capabilities.cpp
+++ b/Development/nmos/capabilities.cpp
@@ -99,8 +99,7 @@ namespace nmos
             return true;
         }
 
-        template <typename T>
-        bool match_pattern_constraint(const T& value, const web::json::value& constraint)
+        bool match_pattern_constraint(const utility::string_t& value, const web::json::value& constraint)
         {
             if (constraint.has_field(nmos::fields::constraint_pattern))
             {

--- a/Development/nmos/capabilities.h
+++ b/Development/nmos/capabilities.h
@@ -20,7 +20,7 @@ namespace nmos
     template <> nmos::rational inline no_maximum() { return 0; }
 
     // See https://specs.amwa.tv/bcp-004-01/releases/v1.0.0/docs/1.0._Receiver_Capabilities.html#string-constraint-keywords
-    web::json::value make_caps_string_constraint(const std::vector<utility::string_t>& enum_values = {});
+    web::json::value make_caps_string_constraint(const std::vector<utility::string_t>& enum_values = {}, const utility::string_t& pattern = {});
 
     // See https://specs.amwa.tv/bcp-004-01/releases/v1.0.0/docs/1.0._Receiver_Capabilities.html#integer-and-number-constraint-keywords
     web::json::value make_caps_integer_constraint(const std::vector<int64_t>& enum_values = {}, int64_t minimum = no_minimum<int64_t>(), int64_t maximum = no_maximum<int64_t>());
@@ -39,6 +39,7 @@ namespace nmos
     bool match_number_constraint(double value, const web::json::value& constraint);
     bool match_boolean_constraint(bool value, const web::json::value& constraint);
     bool match_rational_constraint(const nmos::rational& value, const web::json::value& constraint);
+    bool match_constraint(const web::json::value& value, const web::json::value& constraint);
 
     // NMOS Parameter Registers - Capabilities register
     // See https://specs.amwa.tv/nmos-parameter-registers/branches/main/capabilities/

--- a/Development/nmos/json_fields.h
+++ b/Development/nmos/json_fields.h
@@ -124,8 +124,8 @@ namespace nmos
 
         // for connection_api
         const web::json::field_as_value endpoint_constraints{ U("constraints") }; // array
-        const web::json::field<double> constraint_maximum{ U("maximum") }; // integer, number
-        const web::json::field<double> constraint_minimum{ U("minimum") }; // integer, number
+        const web::json::field_as_value constraint_maximum{ U("maximum") }; // integer, number or rational
+        const web::json::field_as_value constraint_minimum{ U("minimum") }; // integer, number or rational
         const web::json::field_as_value constraint_enum{ U("enum") }; // array
         const web::json::field_as_string constraint_pattern{ U("pattern") }; // regex
         const web::json::field_as_string_or constraint_description{ U("description"), {} }; // string

--- a/Development/nmos/rational.cpp
+++ b/Development/nmos/rational.cpp
@@ -11,6 +11,12 @@ namespace nmos
         });
     }
 
+    bool is_rational(const web::json::value& value)
+    {
+        // denominator has a default of 1 so may be omitted
+        return value.has_integer_field(nmos::fields::numerator);
+    }
+
     rational parse_rational(const web::json::value& value)
     {
         return{

--- a/Development/nmos/rational.h
+++ b/Development/nmos/rational.h
@@ -31,6 +31,8 @@ namespace nmos
         return make_rational({ numerator, denominator });
     }
 
+    bool is_rational(const web::json::value& value);
+
     rational parse_rational(const web::json::value& value);
 }
 

--- a/Development/nmos/test/capabilities_test.cpp
+++ b/Development/nmos/test/capabilities_test.cpp
@@ -1,0 +1,58 @@
+// The first "test" is of course whether the header compiles standalone
+#include "nmos/capabilities.h"
+
+#include "bst/test/test.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testMatchConstraint)
+{
+    using web::json::value;
+
+    BST_REQUIRE(nmos::match_string_constraint(U("purr"), nmos::make_caps_string_constraint()));
+    BST_REQUIRE(nmos::match_integer_constraint(42, nmos::make_caps_integer_constraint({})));
+    BST_REQUIRE(nmos::match_number_constraint(4.2, nmos::make_caps_number_constraint({})));
+    BST_REQUIRE(nmos::match_boolean_constraint(true, nmos::make_caps_boolean_constraint({})));
+    BST_REQUIRE(nmos::match_rational_constraint(nmos::rates::rate29_97, nmos::make_caps_rational_constraint()));
+
+    BST_REQUIRE(nmos::match_string_constraint(U("purr"), nmos::make_caps_string_constraint({ U("meow"), U("purr"), U("hiss") }, U("^(meow|purr|hiss)$"))));
+    BST_REQUIRE(!nmos::match_string_constraint(U("purr"), nmos::make_caps_string_constraint({ U("meow"), U("hiss") })));
+    BST_REQUIRE(nmos::match_string_constraint(U("purr"), nmos::make_caps_string_constraint({}, U("^(meow|purr|hiss)$"))));
+    BST_REQUIRE(!nmos::match_string_constraint(U("bark"), nmos::make_caps_string_constraint({}, U("^(meow|purr|hiss)$"))));
+
+    BST_REQUIRE(nmos::match_integer_constraint(42, nmos::make_caps_integer_constraint({ 37, 42, 57 }, 37, 57)));
+    BST_REQUIRE(!nmos::match_integer_constraint(42, nmos::make_caps_integer_constraint({ 37, 57 })));
+    for (auto i : { 37, 42, 57 })
+        BST_REQUIRE(nmos::match_integer_constraint(i, nmos::make_caps_integer_constraint({}, 37, 57)));
+    for (auto i : { -100, 0, 100 })
+        BST_REQUIRE(!nmos::match_integer_constraint(i, nmos::make_caps_integer_constraint({}, 37, 57)));
+    BST_REQUIRE(nmos::match_integer_constraint(0xBADC0FFEE, nmos::make_caps_integer_constraint({}, 0xC0FFEE, 0xC01DC0FFEE)));
+
+    BST_REQUIRE(nmos::match_number_constraint(4.2, nmos::make_caps_number_constraint({ 3.7, 4.2, 5.7 }, 3.7, 5.7)));
+    BST_REQUIRE(!nmos::match_number_constraint(4.2, nmos::make_caps_number_constraint({ 3.7, 5.7 })));
+    for (auto d : { 3.7, 4.2, 5.7 })
+        BST_REQUIRE(nmos::match_number_constraint(d, nmos::make_caps_number_constraint({}, 3.7, 5.7)));
+    for (auto d : { -10.0, 0.0, 10.0 })
+        BST_REQUIRE(!nmos::match_number_constraint(d, nmos::make_caps_number_constraint({}, 3.7, 5.7)));
+
+    BST_REQUIRE(nmos::match_boolean_constraint(true, nmos::make_caps_boolean_constraint({ false, true })));
+    BST_REQUIRE(!nmos::match_boolean_constraint(true, nmos::make_caps_boolean_constraint({ false })));
+
+    BST_REQUIRE(nmos::match_rational_constraint(nmos::rates::rate29_97, nmos::make_caps_rational_constraint({ nmos::rates::rate25, nmos::rates::rate29_97, nmos::rates::rate30 })));
+    BST_REQUIRE(!nmos::match_rational_constraint(nmos::rates::rate29_97, nmos::make_caps_rational_constraint({ nmos::rates::rate25, nmos::rates::rate30 })));
+    for (auto r : { nmos::rates::rate25, nmos::rates::rate29_97, nmos::rates::rate30 })
+       BST_REQUIRE(nmos::match_rational_constraint(r, nmos::make_caps_rational_constraint({}, nmos::rates::rate25, nmos::rates::rate30)));
+    for (auto r : { nmos::rational{}, nmos::rates::rate23_98, nmos::rates::rate59_94 })
+        BST_REQUIRE(!nmos::match_rational_constraint(r, nmos::make_caps_rational_constraint({}, nmos::rates::rate25, nmos::rates::rate30)));
+
+    BST_REQUIRE(nmos::match_constraint(value(U("purr")), nmos::make_caps_string_constraint({ U("meow"), U("purr"), U("hiss") }, U("^(meow|purr|hiss)$"))));
+    BST_REQUIRE(!nmos::match_constraint(value(U("purr")), nmos::make_caps_string_constraint({ U("meow"), U("hiss") })));
+    BST_REQUIRE(nmos::match_constraint(value(42), nmos::make_caps_integer_constraint({ 37, 42, 57 }, 37, 57)));
+    BST_REQUIRE(!nmos::match_constraint(value(42), nmos::make_caps_integer_constraint({ 37, 57 })));
+    BST_REQUIRE(nmos::match_constraint(value(0xBADC0FFEE), nmos::make_caps_integer_constraint({}, 0xC0FFEE, 0xC01DC0FFEE)));
+    BST_REQUIRE(nmos::match_constraint(value(4.2), nmos::make_caps_number_constraint({ 3.7, 4.2, 5.7 }, 3.7, 5.7)));
+    BST_REQUIRE(!nmos::match_constraint(value(4.2), nmos::make_caps_number_constraint({ 3.7, 5.7 })));
+    BST_REQUIRE(nmos::match_constraint(value(true), nmos::make_caps_boolean_constraint({ false, true })));
+    BST_REQUIRE(!nmos::match_constraint(value(true), nmos::make_caps_boolean_constraint({ false })));
+    BST_REQUIRE(nmos::match_constraint(nmos::make_rational(nmos::rates::rate29_97), nmos::make_caps_rational_constraint({ nmos::rates::rate25, nmos::rates::rate29_97, nmos::rates::rate30 })));
+    BST_REQUIRE(!nmos::match_constraint(nmos::make_rational(nmos::rates::rate29_97), nmos::make_caps_rational_constraint({ nmos::rates::rate25, nmos::rates::rate30 })));
+}

--- a/Development/nmos/test/capabilities_test.cpp
+++ b/Development/nmos/test/capabilities_test.cpp
@@ -25,7 +25,7 @@ BST_TEST_CASE(testMatchConstraint)
         BST_REQUIRE(nmos::match_integer_constraint(i, nmos::make_caps_integer_constraint({}, 37, 57)));
     for (auto i : { -100, 0, 100 })
         BST_REQUIRE(!nmos::match_integer_constraint(i, nmos::make_caps_integer_constraint({}, 37, 57)));
-    BST_REQUIRE(nmos::match_integer_constraint(0xBADC0FFEE, nmos::make_caps_integer_constraint({}, 0xC0FFEE, 0xC01DC0FFEE)));
+    BST_REQUIRE(nmos::match_integer_constraint(INT64_C(0xBADC0FFEE), nmos::make_caps_integer_constraint({}, INT64_C(0xC0FFEE), INT64_C(0xC01DC0FFEE))));
 
     BST_REQUIRE(nmos::match_number_constraint(4.2, nmos::make_caps_number_constraint({ 3.7, 4.2, 5.7 }, 3.7, 5.7)));
     BST_REQUIRE(!nmos::match_number_constraint(4.2, nmos::make_caps_number_constraint({ 3.7, 5.7 })));
@@ -48,7 +48,7 @@ BST_TEST_CASE(testMatchConstraint)
     BST_REQUIRE(!nmos::match_constraint(value(U("purr")), nmos::make_caps_string_constraint({ U("meow"), U("hiss") })));
     BST_REQUIRE(nmos::match_constraint(value(42), nmos::make_caps_integer_constraint({ 37, 42, 57 }, 37, 57)));
     BST_REQUIRE(!nmos::match_constraint(value(42), nmos::make_caps_integer_constraint({ 37, 57 })));
-    BST_REQUIRE(nmos::match_constraint(value(0xBADC0FFEE), nmos::make_caps_integer_constraint({}, 0xC0FFEE, 0xC01DC0FFEE)));
+    BST_REQUIRE(nmos::match_constraint(value(INT64_C(0xBADC0FFEE)), nmos::make_caps_integer_constraint({}, INT64_C(0xC0FFEE), INT64_C(0xC01DC0FFEE))));
     BST_REQUIRE(nmos::match_constraint(value(4.2), nmos::make_caps_number_constraint({ 3.7, 4.2, 5.7 }, 3.7, 5.7)));
     BST_REQUIRE(!nmos::match_constraint(value(4.2), nmos::make_caps_number_constraint({ 3.7, 5.7 })));
     BST_REQUIRE(nmos::match_constraint(value(true), nmos::make_caps_boolean_constraint({ false, true })));


### PR DESCRIPTION
Spotted these issues while reviewing PR #271, so thank you, @N-Nagorny!