### PR TITLE
websocket_listener should set SO_REUSEADDR like http_listener

### DIFF
--- a/Development/cpprest/ws_listener_impl.cpp
+++ b/Development/cpprest/ws_listener_impl.cpp
@@ -313,6 +313,7 @@ namespace web
                                 if (!init)
                                 {
                                     server.init_asio();
+                                    server.set_reuse_addr(true);
                                     init = true;
                                 }
                                 else


### PR DESCRIPTION
Should resolve #320.

Not sure how to extend tests to cover this...
https://github.com/sony/nmos-cpp/blob/3fd76fcd406b9a2e7211f6d9c0d51b42be41e905/Development/cpprest/test/ws_listener_test.cpp#L6