### PR TITLE
Enabling client and server sockets binding on specified network interfaces.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -577,6 +577,8 @@ jobs:
         apt-get install -y software-properties-common
         apt-get --allow-unauthenticated update -q
         apt-get --allow-unauthenticated install -y curl g++ git make patch zlib1g-dev libssl-dev bsdmainutils dnsutils unzip
+        # ubuntu-14.04 ca-certificates are out of date
+        git config --global http.sslVerify false
         curl -sS https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tar.xz | tar -xJ
         cd Python-3.6.9
         ./configure

--- a/.github/workflows/src/build-test.yml
+++ b/.github/workflows/src/build-test.yml
@@ -127,6 +127,8 @@ jobs:
         apt-get install -y software-properties-common
         apt-get --allow-unauthenticated update -q
         apt-get --allow-unauthenticated install -y curl g++ git make patch zlib1g-dev libssl-dev bsdmainutils dnsutils unzip
+        # ubuntu-14.04 ca-certificates are out of date
+        git config --global http.sslVerify false
         curl -sS https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tar.xz | tar -xJ
         cd Python-3.6.9
         ./configure

--- a/Development/cpprest/host_utils.cpp
+++ b/Development/cpprest/host_utils.cpp
@@ -5,6 +5,7 @@
 #include <boost/asio/ip/host_name.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/range/adaptor/filtered.hpp>
+#include <boost/range/algorithm.hpp>
 #include "cpprest/asyncrt_utils.h" // for utility::conversions
 
 #if defined(_WIN32)
@@ -327,6 +328,16 @@ namespace web
                     addresses.push_back(utility::conversions::to_string_t(re.endpoint().address().to_string()));
                 }
                 return addresses; // empty if host_name cannot be resolved
+            }
+
+            // get the associated network interface name from an IP address
+            utility::string_t get_interface_name(const utility::string_t& address, const std::vector<web::hosts::experimental::host_interface>& host_interfaces)
+            {
+                const auto interface = boost::range::find_if(host_interfaces, [&](const web::hosts::experimental::host_interface& interface)
+                {
+                    return interface.addresses.end() != boost::range::find(interface.addresses, address);
+                });
+                return host_interfaces.end() != interface ? interface->name : utility::string_t {};
             }
         }
     }

--- a/Development/cpprest/host_utils.cpp
+++ b/Development/cpprest/host_utils.cpp
@@ -5,7 +5,8 @@
 #include <boost/asio/ip/host_name.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/range/adaptor/filtered.hpp>
-#include <boost/range/algorithm.hpp>
+#include <boost/range/algorithm/find.hpp>
+#include <boost/range/algorithm/find_if.hpp>
 #include "cpprest/asyncrt_utils.h" // for utility::conversions
 
 #if defined(_WIN32)
@@ -337,7 +338,7 @@ namespace web
                 {
                     return interface.addresses.end() != boost::range::find(interface.addresses, address);
                 });
-                return host_interfaces.end() != interface ? interface->name : utility::string_t {};
+                return host_interfaces.end() != interface ? interface->name : utility::string_t{};
             }
         }
     }

--- a/Development/cpprest/host_utils.h
+++ b/Development/cpprest/host_utils.h
@@ -30,6 +30,9 @@ namespace web
 
             std::vector<utility::string_t> host_names(const utility::string_t& address);
             std::vector<utility::string_t> host_addresses(const utility::string_t& host_name);
+
+            // get the associated network interface name from an IP address
+            utility::string_t get_interface_name(const utility::string_t& address, const std::vector<web::hosts::experimental::host_interface>& host_interfaces = web::hosts::experimental::host_interfaces());
         }
     }
 }

--- a/Development/cpprest/uri_schemes.h
+++ b/Development/cpprest/uri_schemes.h
@@ -27,8 +27,7 @@ namespace web
     // Check if the URI is secure
     inline bool get_secure(const web::uri& uri)
     {
-        const auto scheme = uri.scheme();
-        return (scheme == uri_schemes::wss || scheme == uri_schemes::https);
+        return uri_schemes::https == uri.scheme() || uri_schemes::wss == uri.scheme();
     }
 }
 

--- a/Development/cpprest/uri_schemes.h
+++ b/Development/cpprest/uri_schemes.h
@@ -1,6 +1,7 @@
 #ifndef CPPREST_URI_SCHEMES_H
 #define CPPREST_URI_SCHEMES_H
 
+#include "cpprest/base_uri.h"
 #include "cpprest/details/basic_types.h"
 
 namespace web
@@ -22,6 +23,13 @@ namespace web
 
     inline utility::string_t http_scheme(bool secure) { return secure ? uri_schemes::https : uri_schemes::http; }
     inline utility::string_t ws_scheme(bool secure) { return secure ? uri_schemes::wss : uri_schemes::ws; }
+
+    // Check if the URI is secure
+    inline bool get_secure(const web::uri& uri)
+    {
+        const auto scheme = uri.scheme();
+        return (scheme == uri_schemes::wss || scheme == uri_schemes::https);
+    }
 }
 
 #endif

--- a/Development/cpprest/uri_schemes.h
+++ b/Development/cpprest/uri_schemes.h
@@ -1,7 +1,6 @@
 #ifndef CPPREST_URI_SCHEMES_H
 #define CPPREST_URI_SCHEMES_H
 
-#include "cpprest/base_uri.h"
 #include "cpprest/details/basic_types.h"
 
 namespace web
@@ -24,10 +23,9 @@ namespace web
     inline utility::string_t http_scheme(bool secure) { return secure ? uri_schemes::https : uri_schemes::http; }
     inline utility::string_t ws_scheme(bool secure) { return secure ? uri_schemes::wss : uri_schemes::ws; }
 
-    // Check if the URI is secure
-    inline bool is_secure(const web::uri& uri)
+    inline bool is_secure_uri_scheme(const utility::string_t& scheme)
     {
-        return uri_schemes::https == uri.scheme() || uri_schemes::wss == uri.scheme();
+        return uri_schemes::https == scheme || uri_schemes::wss == scheme;
     }
 }
 

--- a/Development/cpprest/uri_schemes.h
+++ b/Development/cpprest/uri_schemes.h
@@ -25,7 +25,7 @@ namespace web
     inline utility::string_t ws_scheme(bool secure) { return secure ? uri_schemes::wss : uri_schemes::ws; }
 
     // Check if the URI is secure
-    inline bool get_secure(const web::uri& uri)
+    inline bool is_secure(const web::uri& uri)
     {
         return uri_schemes::https == uri.scheme() || uri_schemes::wss == uri.scheme();
     }

--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -191,7 +191,12 @@
     //"settings_port": 3209,
     //"logging_port": 5106,
 
-    // addresses [registry, node]: addresses on which to listen for each API, or empty string for the wildcard address
+    // addresses [registry, node]: IP addresses on which to listen for each API, or empty string for the wildcard address
+
+    // server_address [registry, node]: if specified, this becomes the default address on which to listen for each API instead of the wildcard address
+    //"server_address": "",
+
+    // addresses [registry, node]: IP addresses on which to listen for specific APIs
 
     //"settings_address": "127.0.0.1",
     //"logging_address": "",
@@ -199,9 +204,6 @@
     // client_address [registry, node]: IP address of the network interface to bind client connections
     // for now, only supporting HTTP/HTTPS client connections on Linux
     //"client_address": "",
-
-    // server_address [registry, node]: IP address of the network interface to bind server connections
-    //"server_address": "",
 
     // logging_limit [registry, node]: maximum number of log events cached for the Logging API
     //"logging_limit": 1234,

--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -191,6 +191,13 @@
     //"settings_port": 3209,
     //"logging_port": 5106,
 
+    // client_address [registry, node]: IP address of the network interface to bind client connections for Linux
+    // only supprting HTTP/HTTPS client connections, no ws/wss support yet
+    //"client_address": "",
+
+    // server_address [registry, node]: IP address of the network interface to bind server connections
+    //"server_address": "",
+
     // addresses [registry, node]: addresses on which to listen for each API, or empty string for the wildcard address
 
     //"settings_address": "127.0.0.1",

--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -192,7 +192,7 @@
     //"logging_port": 5106,
 
     // client_address [registry, node]: IP address of the network interface to bind client connections for Linux
-    // only supprting HTTP/HTTPS client connections, no ws/wss support yet
+    // only supporting HTTP/HTTPS client connections, no ws/wss support yet
     //"client_address": "",
 
     // server_address [registry, node]: IP address of the network interface to bind server connections

--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -191,17 +191,17 @@
     //"settings_port": 3209,
     //"logging_port": 5106,
 
-    // client_address [registry, node]: IP address of the network interface to bind client connections for Linux
-    // only supporting HTTP/HTTPS client connections, no ws/wss support yet
-    //"client_address": "",
-
-    // server_address [registry, node]: IP address of the network interface to bind server connections
-    //"server_address": "",
-
     // addresses [registry, node]: addresses on which to listen for each API, or empty string for the wildcard address
 
     //"settings_address": "127.0.0.1",
     //"logging_address": "",
+
+    // client_address [registry, node]: IP address of the network interface to bind client connections
+    // for now, only supporting HTTP/HTTPS client connections on Linux
+    //"client_address": "",
+
+    // server_address [registry, node]: IP address of the network interface to bind server connections
+    //"server_address": "",
 
     // logging_limit [registry, node]: maximum number of log events cached for the Logging API
     //"logging_limit": 1234,

--- a/Development/nmos-cpp-registry/config.json
+++ b/Development/nmos-cpp-registry/config.json
@@ -109,6 +109,13 @@
     //"mdns_port": 3208,
     //"schemas_port": 3208,
 
+    // client_address [registry, node]: IP address of the network interface to bind client connections for Linux
+    // only supprting HTTP/HTTPS client connections, no ws/wss support yet
+    //"client_address": "",
+
+    // server_address [registry, node]: IP address of the network interface to bind server connections
+    //"server_address": "",
+
     // addresses [registry, node]: addresses on which to listen for each API, or empty string for the wildcard address
 
     //"settings_address": "127.0.0.1",

--- a/Development/nmos-cpp-registry/config.json
+++ b/Development/nmos-cpp-registry/config.json
@@ -109,12 +109,17 @@
     //"mdns_port": 3208,
     //"schemas_port": 3208,
 
-    // addresses [registry, node]: addresses on which to listen for each API, or empty string for the wildcard address
+    // addresses [registry, node]: IP addresses on which to listen for each API, or empty string for the wildcard address
+
+    // server_address [registry, node]: if specified, this becomes the default address on which to listen for each API instead of the wildcard address
+    //"server_address": "",
+
+    // addresses [registry, node]: IP addresses on which to listen for specific APIs
 
     //"settings_address": "127.0.0.1",
     //"logging_address": "",
 
-    // addresses [registry]: addresses on which to listen for each API, or empty string for the wildcard address
+    // addresses [registry]: IP addresses on which to listen for specific APIs
 
     //"admin_address": "",
     //"mdns_address": "",
@@ -123,9 +128,6 @@
     // client_address [registry, node]: IP address of the network interface to bind client connections
     // for now, only supporting HTTP/HTTPS client connections on Linux
     //"client_address": "",
-
-    // server_address [registry, node]: IP address of the network interface to bind server connections
-    //"server_address": "",
 
     // query_ws_paging_default/query_ws_paging_limit [registry]: default/maximum number of events per message when using the Query WebSocket API (a client may request a lower limit)
     //"query_ws_paging_default": 10,

--- a/Development/nmos-cpp-registry/config.json
+++ b/Development/nmos-cpp-registry/config.json
@@ -110,7 +110,7 @@
     //"schemas_port": 3208,
 
     // client_address [registry, node]: IP address of the network interface to bind client connections for Linux
-    // only supprting HTTP/HTTPS client connections, no ws/wss support yet
+    // only supporting HTTP/HTTPS client connections, no ws/wss support yet
     //"client_address": "",
 
     // server_address [registry, node]: IP address of the network interface to bind server connections

--- a/Development/nmos-cpp-registry/config.json
+++ b/Development/nmos-cpp-registry/config.json
@@ -109,8 +109,8 @@
     //"mdns_port": 3208,
     //"schemas_port": 3208,
 
-    // client_address [registry, node]: IP address of the network interface to bind client connections for Linux
-    // only supporting HTTP/HTTPS client connections, no ws/wss support yet
+    // client_address [registry, node]: IP address of the network interface to bind client connections
+    // for now, only supporting HTTP/HTTPS client connections on Linux
     //"client_address": "",
 
     // server_address [registry, node]: IP address of the network interface to bind server connections

--- a/Development/nmos-cpp-registry/config.json
+++ b/Development/nmos-cpp-registry/config.json
@@ -109,13 +109,6 @@
     //"mdns_port": 3208,
     //"schemas_port": 3208,
 
-    // client_address [registry, node]: IP address of the network interface to bind client connections
-    // for now, only supporting HTTP/HTTPS client connections on Linux
-    //"client_address": "",
-
-    // server_address [registry, node]: IP address of the network interface to bind server connections
-    //"server_address": "",
-
     // addresses [registry, node]: addresses on which to listen for each API, or empty string for the wildcard address
 
     //"settings_address": "127.0.0.1",
@@ -126,6 +119,13 @@
     //"admin_address": "",
     //"mdns_address": "",
     //"schemas_address": "",
+
+    // client_address [registry, node]: IP address of the network interface to bind client connections
+    // for now, only supporting HTTP/HTTPS client connections on Linux
+    //"client_address": "",
+
+    // server_address [registry, node]: IP address of the network interface to bind server connections
+    //"server_address": "",
 
     // query_ws_paging_default/query_ws_paging_limit [registry]: default/maximum number of events per message when using the Query WebSocket API (a client may request a lower limit)
     //"query_ws_paging_default": 10,

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -117,7 +117,7 @@ namespace nmos
         {
             // get the associated network interface name from IP address
             const auto interface_name = get_interface_name(client_address);
-            if (interface_name.empty())
+            if (!client_address.empty() && interface_name.empty())
             {
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << "No network interface found for " << client_address << " to bind for the HTTP client connection";
             }
@@ -145,7 +145,7 @@ namespace nmos
         {
             // get the associated network interface name from IP address
             const auto interface_name = get_interface_name(client_address);
-            if (interface_name.empty())
+            if (!client_address.empty() && interface_name.empty())
             {
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << "No network interface found for " << client_address << " to bind for the websocket client connection";
             }

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -88,7 +88,8 @@ namespace nmos
                 socket_fd = socket->lowest_layer().native_handle();
             }
             // SO_BINDTODEVICE not defined in windows & mac
-            return (setsockopt(socket_fd, SOL_SOCKET, SO_BINDTODEVICE, utility::us2s(interface_name).c_str(), interface_name.length()) == 0);
+            const auto interface_name_ = utility::us2s(interface_name);
+            return setsockopt(socket_fd, SOL_SOCKET, SO_BINDTODEVICE, interface_name_.data(), interface_name_.length()) == 0;
         }
 #endif
 

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -83,8 +83,8 @@ namespace nmos
         }
 
 #if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
-        // bind socket to a specific network interface, only supporting Linux and Boost.Asio
-#if !defined(_WIN32)
+        // bind socket to a specific network interface, only supporting Linux
+#if defined(linux) || defined(__linux) || defined(__linux__)
         inline bool bind_to_device(const utility::string_t& interface_name, bool secure, void* native_handle)
         {
             int socket_fd;
@@ -108,7 +108,7 @@ namespace nmos
                 }
                 socket_fd = socket->lowest_layer().native_handle();
             }
-            // SO_BINDTODEVICE not defined in windows
+            // SO_BINDTODEVICE not defined in windows & mac
             return (setsockopt(socket_fd, SOL_SOCKET, SO_BINDTODEVICE, utility::us2s(interface_name).c_str(), interface_name.length()) == 0);
         }
 #endif
@@ -126,7 +126,7 @@ namespace nmos
             {
                 if (!interface_name.empty())
                 {
-#if !defined(_WIN32)
+#if defined(linux) || defined(__linux) || defined(__linux__)
                     if (!bind_to_device(interface_name, secure, native_handle))
                     {
                         char error[1024];
@@ -154,7 +154,7 @@ namespace nmos
             {
                 if (!interface_name.empty())
                 {
-#if !defined(_WIN32)
+#if defined(linux) || defined(__linux) || defined(__linux__)
                     if (!bind_to_device(interface_name, secure, native_handle))
                     {
                         char error[1024];

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -61,25 +61,14 @@ namespace nmos
             };
         }
 #endif
-        // get the associated network interface name from the IP address
-        inline utility::string_t get_interface_name(const utility::string_t& address)
+        // get the associated network interface name from an IP address
+        inline utility::string_t get_interface_name(const utility::string_t& address, const std::vector<web::hosts::experimental::host_interface>& host_interfaces = web::hosts::experimental::host_interfaces())
         {
-            utility::string_t interface_name;
-            if (!address.empty())
+            const auto interface = boost::range::find_if(interfaces, [&](const web::hosts::experimental::host_interface& interface)
             {
-                const auto interfaces = web::hosts::experimental::host_interfaces();
-
-                auto find_interface = [&]()
-                {
-                    return boost::range::find_if(interfaces, [&](const web::hosts::experimental::host_interface& interface)
-                    {
-                        return interface.addresses.end() != boost::range::find(interface.addresses, address);
-                    });
-                };
-                const auto interface = find_interface();
-                if (interfaces.end() != interface) { interface_name = interface->name; }
-            }
-            return interface_name;
+                return interface.addresses.end() != boost::range::find(interface.addresses, address);
+            });
+            return interfaces.end() != interface ? interface->name : utility::string_t{};
         }
 
 #if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -99,22 +99,22 @@ namespace nmos
             if (!client_address.empty() && interface_name.empty())
             {
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << "No network interface found for " << client_address << " to bind for the HTTP client connection";
+
+                // no-op
+                return [](web::http::client::native_handle) {};
             }
 
             return [interface_name, secure, &gate](web::http::client::native_handle native_handle)
             {
-                if (!interface_name.empty())
-                {
 #if defined(__linux__)
-                    if (!bind_to_device(interface_name, secure, native_handle))
-                    {
-                        char error[1024];
-                        slog::log<slog::severities::error>(gate, SLOG_FLF) << "Unable to bind HTTP client connection to " << interface_name << ", bind_to_device reported error : " << strerror_r(errno, error, sizeof(error));
-                    }
-#else
-                    slog::log<slog::severities::error>(gate, SLOG_FLF) << "Bind HTTP client connection to " << interface_name << " not supported";
-#endif
+                if (!bind_to_device(interface_name, secure, native_handle))
+                {
+                    char error[1024];
+                    slog::log<slog::severities::error>(gate, SLOG_FLF) << "Unable to bind HTTP client connection to " << interface_name << ", bind_to_device reported error : " << strerror_r(errno, error, sizeof(error));
                 }
+#else
+                slog::log<slog::severities::error>(gate, SLOG_FLF) << "Bind HTTP client connection to " << interface_name << " not supported";
+#endif
             };
         }
 
@@ -127,22 +127,22 @@ namespace nmos
             if (!client_address.empty() && interface_name.empty())
             {
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << "No network interface found for " << client_address << " to bind for the websocket client connection";
+
+                // no-op
+                return [](web::websockets::client::native_handle) {};
             }
 
             return [interface_name, secure, &gate](web::websockets::client::native_handle native_handle)
             {
-                if (!interface_name.empty())
-                {
 #if defined(__linux__)
-                    if (!bind_to_device(interface_name, secure, native_handle))
-                    {
-                        char error[1024];
-                        slog::log<slog::severities::error>(gate, SLOG_FLF) << "Unable to bind websocket client connection to " << interface_name << ", bind_to_device reported error : " << strerror_r(errno, error, sizeof(error));
-                    }
-#else
-                    slog::log<slog::severities::error>(gate, SLOG_FLF) << "Bind websocket client connection to " << interface_name << " not supported";
-#endif
+                if (!bind_to_device(interface_name, secure, native_handle))
+                {
+                    char error[1024];
+                    slog::log<slog::severities::error>(gate, SLOG_FLF) << "Unable to bind websocket client connection to " << interface_name << ", bind_to_device reported error : " << strerror_r(errno, error, sizeof(error));
                 }
+#else
+                slog::log<slog::severities::error>(gate, SLOG_FLF) << "Bind websocket client connection to " << interface_name << " not supported";
+#endif
             };
         }
 #endif

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -6,7 +6,6 @@
 #include "boost/asio.hpp"
 #endif
 #include "boost/asio/ssl/set_cipher_list.hpp"
-#include "boost/range/algorithm.hpp"
 #include "cpprest/host_utils.h"
 #endif
 #include "cpprest/basic_utils.h"
@@ -61,15 +60,6 @@ namespace nmos
             };
         }
 #endif
-        // get the associated network interface name from an IP address
-        inline utility::string_t get_interface_name(const utility::string_t& address, const std::vector<web::hosts::experimental::host_interface>& host_interfaces = web::hosts::experimental::host_interfaces())
-        {
-            const auto interface = boost::range::find_if(interfaces, [&](const web::hosts::experimental::host_interface& interface)
-            {
-                return interface.addresses.end() != boost::range::find(interface.addresses, address);
-            });
-            return interfaces.end() != interface ? interface->name : utility::string_t{};
-        }
 
 #if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
         // bind socket to a specific network interface, only supporting Linux
@@ -105,7 +95,7 @@ namespace nmos
         inline std::function<void(web::http::client::native_handle)> make_client_nativehandle_options(const utility::string_t& client_address, bool secure, slog::base_gate& gate)
         {
             // get the associated network interface name from IP address
-            const auto interface_name = get_interface_name(client_address);
+            const auto interface_name = web::hosts::experimental::get_interface_name(client_address);
             if (!client_address.empty() && interface_name.empty())
             {
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << "No network interface found for " << client_address << " to bind for the HTTP client connection";
@@ -133,7 +123,7 @@ namespace nmos
         inline std::function<void(web::websockets::client::native_handle)> make_ws_client_nativehandle_options(const utility::string_t& client_address, bool secure, slog::base_gate& gate)
         {
             // get the associated network interface name from IP address
-            const auto interface_name = get_interface_name(client_address);
+            const auto interface_name = web::hosts::experimental::get_interface_name(client_address);
             if (!client_address.empty() && interface_name.empty())
             {
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << "No network interface found for " << client_address << " to bind for the websocket client connection";

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -63,7 +63,7 @@ namespace nmos
 
 #if !defined(_WIN32) || !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
         // bind socket to a specific network interface, only supporting Linux
-#if defined(linux) || defined(__linux) || defined(__linux__)
+#if defined(__linux__)
         inline bool bind_to_device(const utility::string_t& interface_name, bool secure, void* native_handle)
         {
             int socket_fd;
@@ -105,7 +105,7 @@ namespace nmos
             {
                 if (!interface_name.empty())
                 {
-#if defined(linux) || defined(__linux) || defined(__linux__)
+#if defined(__linux__)
                     if (!bind_to_device(interface_name, secure, native_handle))
                     {
                         char error[1024];
@@ -133,7 +133,7 @@ namespace nmos
             {
                 if (!interface_name.empty())
                 {
-#if defined(linux) || defined(__linux) || defined(__linux__)
+#if defined(__linux__)
                     if (!bind_to_device(interface_name, secure, native_handle))
                     {
                         char error[1024];

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -87,7 +87,7 @@ namespace nmos
 #if !defined(_WIN32)
         inline bool bind_to_device(const utility::string_t& interface_name, bool secure, void* native_handle)
         {
-            boost::asio::basic_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>::native_handle_type socket_fd;
+            int socket_fd;
             if (secure)
             {
                 auto socket = (boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>*)native_handle;

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -183,7 +183,7 @@ namespace nmos
         if (secure) config.set_validate_certificates(nmos::experimental::fields::validate_certificates(settings));
 #if !defined(_WIN32) || !defined(__cplusplus_winrt)
         if (secure) config.set_ssl_context_callback(details::make_client_ssl_context_callback<web::websockets::client::websocket_exception>(settings, load_ca_certificates, gate));
-#ifdef CPPRESTSDK_BIND_WEBSOCKET_CLIENT
+#ifdef CPPRESTSDK_ENABLE_BIND_WEBSOCKET_CLIENT
         config.set_nativehandle_options(details::make_ws_client_nativehandle_options(nmos::experimental::fields::client_address(settings), secure, gate));
 #endif
 #endif

--- a/Development/nmos/client_utils.h
+++ b/Development/nmos/client_utils.h
@@ -11,10 +11,16 @@ namespace slog { class base_gate; }
 // Utility types, constants and functions for implementing NMOS REST API clients
 namespace nmos
 {
+    // construct client config based on settings and specified secure flag, e.g. using the specified proxy and the OCSP client
+    // with the remaining options defaulted, e.g. request timeout
+    web::http::client::http_client_config make_http_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, bool secure, slog::base_gate& gate);
     // construct client config based on settings, e.g. using the specified proxy
     // with the remaining options defaulted, e.g. request timeout
     web::http::client::http_client_config make_http_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, slog::base_gate& gate);
 
+    // construct client config based on settings and specified secure flag, e.g. using the specified proxy
+    // with the remaining options defaulted
+    web::websockets::client::websocket_client_config make_websocket_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, bool secure, slog::base_gate& gate);
     // construct client config based on settings, e.g. using the specified proxy
     // with the remaining options defaulted
     web::websockets::client::websocket_client_config make_websocket_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, slog::base_gate& gate);

--- a/Development/nmos/client_utils.h
+++ b/Development/nmos/client_utils.h
@@ -11,16 +11,16 @@ namespace slog { class base_gate; }
 // Utility types, constants and functions for implementing NMOS REST API clients
 namespace nmos
 {
-    // construct client config based on settings and specified secure flag, e.g. using the specified proxy and the OCSP client
+    // construct client config based on specified secure flag and settings, e.g. using the specified proxy and OCSP config
     // with the remaining options defaulted, e.g. request timeout
-    web::http::client::http_client_config make_http_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, bool secure, slog::base_gate& gate);
-    // construct client config based on settings, e.g. using the specified proxy
+    web::http::client::http_client_config make_http_client_config(bool secure, const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, slog::base_gate& gate);
+    // construct client config based on settings, e.g. using the specified proxy and OCSP config
     // with the remaining options defaulted, e.g. request timeout
     web::http::client::http_client_config make_http_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, slog::base_gate& gate);
 
-    // construct client config based on settings and specified secure flag, e.g. using the specified proxy
+    // construct client config based on specified secure flag and settings, e.g. using the specified proxy
     // with the remaining options defaulted
-    web::websockets::client::websocket_client_config make_websocket_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, bool secure, slog::base_gate& gate);
+    web::websockets::client::websocket_client_config make_websocket_client_config(bool secure, const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, slog::base_gate& gate);
     // construct client config based on settings, e.g. using the specified proxy
     // with the remaining options defaulted
     web::websockets::client::websocket_client_config make_websocket_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, slog::base_gate& gate);

--- a/Development/nmos/node_server.cpp
+++ b/Development/nmos/node_server.cpp
@@ -35,7 +35,7 @@ namespace nmos
 
             const auto hsts = nmos::experimental::get_hsts(node_model.settings);
 
-            const auto server_address = nmos::experimental::get_server_address(node_model.settings);
+            const auto server_address = nmos::experimental::fields::server_address(node_model.settings);
 
             // Configure the Settings API
 

--- a/Development/nmos/node_server.cpp
+++ b/Development/nmos/node_server.cpp
@@ -35,6 +35,8 @@ namespace nmos
 
             const auto hsts = nmos::experimental::get_hsts(node_model.settings);
 
+            const auto server_address = nmos::experimental::get_server_address(node_model.settings);
+
             // Configure the Settings API
 
             const host_port settings_address(nmos::experimental::fields::settings_address(node_model.settings), nmos::experimental::fields::settings_port(node_model.settings));
@@ -70,8 +72,8 @@ namespace nmos
 
             for (auto& api_router : node_server.api_routers)
             {
-                // default empty string means the wildcard address
-                const auto& host = !api_router.first.first.empty() ? api_router.first.first : web::http::experimental::listener::host_wildcard;
+                // empty string and empty server IP address means the wildcard address
+                const auto& host = !api_router.first.first.empty() ? api_router.first.first : !server_address.empty() ? server_address : web::http::experimental::listener::host_wildcard;
                 // map the configured client port to the server port on which to listen
                 // hmm, this should probably also take account of the address
                 node_server.http_listeners.push_back(nmos::make_api_listener(server_secure, host, nmos::experimental::server_port(api_router.first.second, node_model.settings), api_router.second, http_config, hsts, gate));
@@ -84,8 +86,8 @@ namespace nmos
 
             for (auto& ws_handler : node_server.ws_handlers)
             {
-                // default empty string means the wildcard address
-                const auto& host = !ws_handler.first.first.empty() ? ws_handler.first.first : web::websockets::experimental::listener::host_wildcard;
+                // empty string and empty server IP address means the wildcard address
+                const auto& host = !ws_handler.first.first.empty() ? ws_handler.first.first : !server_address.empty() ? server_address : web::websockets::experimental::listener::host_wildcard;
                 // map the configured client port to the server port on which to listen
                 // hmm, this should probably also take account of the address
                 node_server.ws_listeners.push_back(nmos::make_ws_api_listener(server_secure, host, nmos::experimental::server_port(ws_handler.first.second, node_model.settings), ws_handler.second.first, websocket_config, gate));

--- a/Development/nmos/node_server.cpp
+++ b/Development/nmos/node_server.cpp
@@ -72,7 +72,7 @@ namespace nmos
 
             for (auto& api_router : node_server.api_routers)
             {
-                // empty string and empty server IP address means the wildcard address
+                // if IP address isn't specified for this router, use default server address or wildcard address
                 const auto& host = !api_router.first.first.empty() ? api_router.first.first : !server_address.empty() ? server_address : web::http::experimental::listener::host_wildcard;
                 // map the configured client port to the server port on which to listen
                 // hmm, this should probably also take account of the address
@@ -86,7 +86,7 @@ namespace nmos
 
             for (auto& ws_handler : node_server.ws_handlers)
             {
-                // empty string and empty server IP address means the wildcard address
+                // if IP address isn't specified for this router, use default server address or wildcard address
                 const auto& host = !ws_handler.first.first.empty() ? ws_handler.first.first : !server_address.empty() ? server_address : web::websockets::experimental::listener::host_wildcard;
                 // map the configured client port to the server port on which to listen
                 // hmm, this should probably also take account of the address

--- a/Development/nmos/ocsp_behaviour.cpp
+++ b/Development/nmos/ocsp_behaviour.cpp
@@ -346,7 +346,7 @@ namespace nmos
                 if (!state.client)
                 {
                     const auto ocsp_uri = ocsp_uris.front();
-                    state.client.reset(new web::http::client::http_client(ocsp_uri, make_ocsp_client_config(model.settings, state.load_ca_certificates, get_secure(ocsp_uri), gate)));
+                    state.client.reset(new web::http::client::http_client(ocsp_uri, make_ocsp_client_config(model.settings, state.load_ca_certificates, is_secure(ocsp_uri), gate)));
                 }
 
                 auto token = cancellation_source.get_token();

--- a/Development/nmos/ocsp_behaviour.cpp
+++ b/Development/nmos/ocsp_behaviour.cpp
@@ -142,9 +142,9 @@ namespace nmos
 
     namespace details
     {
-        web::http::client::http_client_config make_ocsp_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, bool secure, slog::base_gate& gate)
+        web::http::client::http_client_config make_ocsp_client_config(bool secure, const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, slog::base_gate& gate)
         {
-            auto config = nmos::make_http_client_config(settings, std::move(load_ca_certificates), secure, gate);
+            auto config = nmos::make_http_client_config(secure, settings, std::move(load_ca_certificates), gate);
             config.set_timeout(std::chrono::seconds(nmos::experimental::fields::ocsp_request_max(settings)));
             return config;
         }
@@ -346,7 +346,8 @@ namespace nmos
                 if (!state.client)
                 {
                     const auto ocsp_uri = ocsp_uris.front();
-                    state.client.reset(new web::http::client::http_client(ocsp_uri, make_ocsp_client_config(model.settings, state.load_ca_certificates, is_secure(ocsp_uri), gate)));
+                    const auto secure = web::is_secure_uri_scheme(ocsp_uri.scheme());
+                    state.client.reset(new web::http::client::http_client(ocsp_uri, make_ocsp_client_config(secure, model.settings, state.load_ca_certificates, gate)));
                 }
 
                 auto token = cancellation_source.get_token();

--- a/Development/nmos/ocsp_behaviour.cpp
+++ b/Development/nmos/ocsp_behaviour.cpp
@@ -1,6 +1,7 @@
 #include "nmos/ocsp_behaviour.h"
 
 #include "pplx/pplx_utils.h" // for pplx::complete_at
+#include "cpprest/uri_schemes.h"
 #include "nmos/client_utils.h"
 #include "nmos/model.h"
 #include "nmos/ocsp_state.h"
@@ -141,9 +142,9 @@ namespace nmos
 
     namespace details
     {
-        web::http::client::http_client_config make_ocsp_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, slog::base_gate& gate)
+        web::http::client::http_client_config make_ocsp_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, bool secure, slog::base_gate& gate)
         {
-            auto config = nmos::make_http_client_config(settings, std::move(load_ca_certificates), gate);
+            auto config = nmos::make_http_client_config(settings, std::move(load_ca_certificates), secure, gate);
             config.set_timeout(std::chrono::seconds(nmos::experimental::fields::ocsp_request_max(settings)));
             return config;
         }
@@ -345,7 +346,7 @@ namespace nmos
                 if (!state.client)
                 {
                     const auto ocsp_uri = ocsp_uris.front();
-                    state.client.reset(new web::http::client::http_client(ocsp_uri, make_ocsp_client_config(model.settings, state.load_ca_certificates, gate)));
+                    state.client.reset(new web::http::client::http_client(ocsp_uri, make_ocsp_client_config(model.settings, state.load_ca_certificates, get_secure(ocsp_uri), gate)));
                 }
 
                 auto token = cancellation_source.get_token();

--- a/Development/nmos/registry_server.cpp
+++ b/Development/nmos/registry_server.cpp
@@ -45,6 +45,8 @@ namespace nmos
 
             const auto hsts = nmos::experimental::get_hsts(registry_model.settings);
 
+            const auto server_address = nmos::experimental::get_server_address(registry_model.settings);
+
             // Configure the DNS-SD Browsing API
 
             const host_port mdns_address(nmos::experimental::fields::mdns_address(registry_model.settings), nmos::experimental::fields::mdns_port(registry_model.settings));
@@ -111,8 +113,8 @@ namespace nmos
 
             for (auto& api_router : registry_server.api_routers)
             {
-                // default empty string means the wildcard address
-                const auto& host = !api_router.first.first.empty() ? api_router.first.first : web::http::experimental::listener::host_wildcard;
+                // empty string and empty server IP address means the wildcard address
+                const auto& host = !api_router.first.first.empty() ? api_router.first.first : !server_address.empty() ? server_address : web::http::experimental::listener::host_wildcard;
                 // map the configured client port to the server port on which to listen
                 // hmm, this should probably also take account of the address
                 registry_server.http_listeners.push_back(nmos::make_api_listener(server_secure, host, nmos::experimental::server_port(api_router.first.second, registry_model.settings), api_router.second, http_config, hsts, gate));
@@ -125,8 +127,8 @@ namespace nmos
 
             for (auto& ws_handler : registry_server.ws_handlers)
             {
-                // default empty string means the wildcard address
-                const auto& host = !ws_handler.first.first.empty() ? ws_handler.first.first : web::websockets::experimental::listener::host_wildcard;
+                //empty string and empty server IP address means the wildcard address
+                const auto& host = !ws_handler.first.first.empty() ? ws_handler.first.first : !server_address.empty() ? server_address : web::websockets::experimental::listener::host_wildcard;
                 // map the configured client port to the server port on which to listen
                 // hmm, this should probably also take account of the address
                 registry_server.ws_listeners.push_back(nmos::make_ws_api_listener(server_secure, host, nmos::experimental::server_port(ws_handler.first.second, registry_model.settings), ws_handler.second.first, websocket_config, gate));

--- a/Development/nmos/registry_server.cpp
+++ b/Development/nmos/registry_server.cpp
@@ -45,7 +45,7 @@ namespace nmos
 
             const auto hsts = nmos::experimental::get_hsts(registry_model.settings);
 
-            const auto server_address = nmos::experimental::get_server_address(registry_model.settings);
+            const auto server_address = nmos::experimental::fields::server_address(registry_model.settings);
 
             // Configure the DNS-SD Browsing API
 

--- a/Development/nmos/registry_server.cpp
+++ b/Development/nmos/registry_server.cpp
@@ -113,7 +113,7 @@ namespace nmos
 
             for (auto& api_router : registry_server.api_routers)
             {
-                // empty string and empty server IP address means the wildcard address
+                // if IP address isn't specified for this router, use default server address or wildcard address
                 const auto& host = !api_router.first.first.empty() ? api_router.first.first : !server_address.empty() ? server_address : web::http::experimental::listener::host_wildcard;
                 // map the configured client port to the server port on which to listen
                 // hmm, this should probably also take account of the address
@@ -127,7 +127,7 @@ namespace nmos
 
             for (auto& ws_handler : registry_server.ws_handlers)
             {
-                //empty string and empty server IP address means the wildcard address
+                // if IP address isn't specified for this router, use default server address or wildcard address
                 const auto& host = !ws_handler.first.first.empty() ? ws_handler.first.first : !server_address.empty() ? server_address : web::websockets::experimental::listener::host_wildcard;
                 // map the configured client port to the server port on which to listen
                 // hmm, this should probably also take account of the address

--- a/Development/nmos/settings.cpp
+++ b/Development/nmos/settings.cpp
@@ -55,14 +55,8 @@ namespace nmos
                 }
             }
 
-            // if the "server_address" settings is presented, use it for the node's "api endpoints" and "href", and device's "controls href"
-            const auto server_address = experimental::get_server_address(settings);
-            if (!server_address.empty())
-            {
-                web::json::insert(settings, std::make_pair(nmos::fields::host_address, server_address));
-            }
             // if the "host_address" setting was omitted, use the first of the "host_addresses"
-            else if (settings.has_field(nmos::fields::host_addresses))
+            if (settings.has_field(nmos::fields::host_addresses))
             {
                 web::json::insert(settings, std::make_pair(nmos::fields::host_address, nmos::fields::host_addresses(settings)[0]));
             }
@@ -158,12 +152,7 @@ namespace nmos
         {
             hosts.push_back(get_host_name(settings));
         }
-        const auto server_address = experimental::get_server_address(settings);
-        if (!server_address.empty())
-        {
-            hosts.push_back(server_address);
-        }
-        else if (0 != (mode & nmos::experimental::href_mode_addresses))
+        if (0 != (mode & nmos::experimental::href_mode_addresses))
         {
             const auto at_least_one_host_address = web::json::value_of({ web::json::value::string(nmos::fields::host_address(settings)) });
             const auto& host_addresses = settings.has_field(nmos::fields::host_addresses) ? nmos::fields::host_addresses(settings) : at_least_one_host_address.as_array();
@@ -200,28 +189,6 @@ namespace nmos
             if (nmos::experimental::fields::server_secure(settings) && nmos::experimental::fields::hsts_max_age(settings) > 0)
                 return web::http::experimental::hsts{ (uint32_t)nmos::experimental::fields::hsts_max_age(settings), nmos::experimental::fields::hsts_include_sub_domains(settings) };
             return bst::nullopt;
-        }
-
-        // Get server IP address of the interface to bind server connections
-        utility::string_t get_server_address(const settings& settings)
-        {
-            const auto server_address = nmos::experimental::fields::server_address(settings);
-            if (!server_address.empty())
-            {
-                // verify the server address match one of the interface addresses
-                const auto interfaces = web::hosts::experimental::host_interfaces();
-
-                auto find_interface = [&]()
-                {
-                    return boost::range::find_if(interfaces, [&](const web::hosts::experimental::host_interface& interface)
-                    {
-                        return interface.addresses.end() != boost::range::find(interface.addresses, server_address);
-                    });
-                };
-                const auto interface = find_interface();
-                if (interfaces.end() != interface) { return server_address; }
-            }
-            return {};
         }
     }
 

--- a/Development/nmos/settings.cpp
+++ b/Development/nmos/settings.cpp
@@ -1,7 +1,6 @@
 #include "nmos/settings.h"
 
 #include <boost/range/adaptor/filtered.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/range/algorithm/find_first_of.hpp>
 #include <boost/version.hpp>
 #include <openssl/opensslv.h>

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -52,6 +52,9 @@ namespace nmos
     {
         // Get HTTP Strict-Transport-Security settings
         bst::optional<web::http::experimental::hsts> get_hsts(const settings& settings);
+
+        // Get server IP address of the network interface for binding the server connections
+        utility::string_t get_server_address(const settings& settings);
     }
 
     // Get a summary of the build configuration, including versions of dependencies
@@ -239,6 +242,13 @@ namespace nmos
             const web::json::field_as_integer_or admin_port{ U("admin_port"), 3208 };
             const web::json::field_as_integer_or mdns_port{ U("mdns_port"), 3208 };
             const web::json::field_as_integer_or schemas_port{ U("schemas_port"), 3208 };
+
+            // client_address [registry, node]: IP address of the network interface to bind client connections for Linux
+            // only supprting HTTP/HTTPS client connections, no ws/wss support yet
+            const web::json::field_as_string_or client_address{ U("client_address"), U("") };
+
+            // server_address [registry, node]: IP address of the network interface to bind server connections
+            const web::json::field_as_string_or server_address{ U("server_address"), U("") };
 
             // addresses [registry, node]: addresses on which to listen for each API, or empty string for the wildcard address
 

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -243,13 +243,6 @@ namespace nmos
             const web::json::field_as_integer_or mdns_port{ U("mdns_port"), 3208 };
             const web::json::field_as_integer_or schemas_port{ U("schemas_port"), 3208 };
 
-            // client_address [registry, node]: IP address of the network interface to bind client connections for Linux
-            // only supporting HTTP/HTTPS client connections, no ws/wss support yet
-            const web::json::field_as_string_or client_address{ U("client_address"), U("") };
-
-            // server_address [registry, node]: IP address of the network interface to bind server connections
-            const web::json::field_as_string_or server_address{ U("server_address"), U("") };
-
             // addresses [registry, node]: addresses on which to listen for each API, or empty string for the wildcard address
 
             const web::json::field_as_string_or settings_address{ U("settings_address"), U("") };
@@ -260,6 +253,13 @@ namespace nmos
             const web::json::field_as_string_or admin_address{ U("admin_address"), U("") };
             const web::json::field_as_string_or mdns_address{ U("mdns_address"), U("") };
             const web::json::field_as_string_or schemas_address{ U("schemas_address"), U("") };
+
+            // client_address [registry, node]: IP address of the network interface to bind client connections
+            // for now, only supporting HTTP/HTTPS client connections on Linux
+            const web::json::field_as_string_or client_address{ U("client_address"), U("") };
+
+            // server_address [registry, node]: IP address of the network interface to bind server connections
+            const web::json::field_as_string_or server_address{ U("server_address"), U("") };
 
             // query_ws_paging_default/query_ws_paging_limit [registry]: default/maximum number of events per message when using the Query WebSocket API (a client may request a lower limit)
             const web::json::field_as_integer_or query_ws_paging_default{ U("query_ws_paging_default"), 10 };

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -52,9 +52,6 @@ namespace nmos
     {
         // Get HTTP Strict-Transport-Security settings
         bst::optional<web::http::experimental::hsts> get_hsts(const settings& settings);
-
-        // Get server IP address of the network interface for binding the server connections
-        utility::string_t get_server_address(const settings& settings);
     }
 
     // Get a summary of the build configuration, including versions of dependencies
@@ -243,12 +240,17 @@ namespace nmos
             const web::json::field_as_integer_or mdns_port{ U("mdns_port"), 3208 };
             const web::json::field_as_integer_or schemas_port{ U("schemas_port"), 3208 };
 
-            // addresses [registry, node]: addresses on which to listen for each API, or empty string for the wildcard address
+            // addresses [registry, node]: IP addresses on which to listen for each API, or empty string for the wildcard address
+
+            // server_address [registry, node]: if specified, this becomes the default address on which to listen for each API instead of the wildcard address
+            const web::json::field_as_string_or server_address{ U("server_address"), U("") };
+
+            // addresses [registry, node]: IP addresses on which to listen for specific APIs
 
             const web::json::field_as_string_or settings_address{ U("settings_address"), U("") };
             const web::json::field_as_string_or logging_address{ U("logging_address"), U("") };
 
-            // addresses [registry]: addresses on which to listen for each API, or empty string for the wildcard address
+            // addresses [registry]: IP addresses on which to listen for specific APIs
 
             const web::json::field_as_string_or admin_address{ U("admin_address"), U("") };
             const web::json::field_as_string_or mdns_address{ U("mdns_address"), U("") };
@@ -257,9 +259,6 @@ namespace nmos
             // client_address [registry, node]: IP address of the network interface to bind client connections
             // for now, only supporting HTTP/HTTPS client connections on Linux
             const web::json::field_as_string_or client_address{ U("client_address"), U("") };
-
-            // server_address [registry, node]: IP address of the network interface to bind server connections
-            const web::json::field_as_string_or server_address{ U("server_address"), U("") };
 
             // query_ws_paging_default/query_ws_paging_limit [registry]: default/maximum number of events per message when using the Query WebSocket API (a client may request a lower limit)
             const web::json::field_as_integer_or query_ws_paging_default{ U("query_ws_paging_default"), 10 };

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -244,7 +244,7 @@ namespace nmos
             const web::json::field_as_integer_or schemas_port{ U("schemas_port"), 3208 };
 
             // client_address [registry, node]: IP address of the network interface to bind client connections for Linux
-            // only supprting HTTP/HTTPS client connections, no ws/wss support yet
+            // only supporting HTTP/HTTPS client connections, no ws/wss support yet
             const web::json::field_as_string_or client_address{ U("client_address"), U("") };
 
             // server_address [registry, node]: IP address of the network interface to bind server connections


### PR DESCRIPTION
Currently, there is no support for the client websocket binding, it is due to missing implementation in the cpprestsdk. I have been attempting to patch the cpprestsdk to add this feature, unfortunately, when I tested the client websocket binding, it was still using the available network interface instead the one specified.
 
Even if that work, we have no idea how long will cpprestsdk merge the patch.
 
So for now, we are leaving the client websocket binding out. Users can specify the binding interface via the `client_address` and the `server_address` in the settings JSON.
where
`client_address` - IP address of the network interface to bind client connections for Linux (no websocket support)
`server_address` - IP address of the network interface to bind server connections