### PR TITLE
Add nmos::parse_fmtp_channel_order

### DIFF
--- a/Development/nmos/channels.h
+++ b/Development/nmos/channels.h
@@ -113,6 +113,7 @@ namespace nmos
 
     // See SMPTE ST 2110-30:2017 Section 6.2.2 Channel Order Convention
     utility::string_t make_fmtp_channel_order(const std::vector<channel_symbol>& channels);
+    std::vector<nmos::channel_symbol> parse_fmtp_channel_order(const utility::string_t& channel_order);
 }
 
 #endif

--- a/Development/nmos/test/channels_test.cpp
+++ b/Development/nmos/test/channels_test.cpp
@@ -28,3 +28,40 @@ BST_TEST_CASE(testMakeFmtpChannelOrder)
     const std::vector<nmos::channel_symbol> example_3{ M1, M1, M1, M1, L, R, C, LFE };
     BST_REQUIRE_EQUAL(U("SMPTE2110.(M,M,M,M,ST,U02)"), nmos::make_fmtp_channel_order(example_3));
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testParseFmtpChannelOrder)
+{
+    using namespace nmos::channel_symbols;
+
+    // two simple examples
+
+    const std::vector<nmos::channel_symbol> stereo{ L, R };
+    BST_REQUIRE_EQUAL(stereo, nmos::parse_fmtp_channel_order(U("SMPTE2110.(ST)")));
+
+    const std::vector<nmos::channel_symbol> dual_mono{ M1, M2 };
+    BST_REQUIRE_EQUAL(dual_mono, nmos::parse_fmtp_channel_order(U("SMPTE2110.(DM)")));
+
+    // two examples from ST 2110-30:2017 Section 6.2.2 Channel Order Convention
+
+    const std::vector<nmos::channel_symbol> example_1{ L, R, C, LFE, Ls, Rs, L, R };
+    BST_REQUIRE_EQUAL(example_1, nmos::parse_fmtp_channel_order(U("SMPTE2110.(51,ST)")));
+
+    //const std::vector<nmos::channel_symbol> example_2{ M1, M1, M1, M1, L, R, Undefined(1), Undefined(2) };
+    //BST_REQUIRE_EQUAL(example_2, nmos::parse_fmtp_channel_order(U("SMPTE2110.(M,M,M,M,ST,U02)")));
+
+    // bad examples
+
+    const std::vector<nmos::channel_symbol> empty;
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("SMPTE2110.(51,ST)BAD")));
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("SMPTE2110.(51,ST,)")));
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("SMPTE2110.(51,,ST)")));
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("SMPTE2110.(51,BAD)")));
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("SMPTE2110.(51,ST")));
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("SMPTE2110.(51,")));
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("SMPTE2110.(51")));
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("SMPTE2110.(")));
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("SMPTE2110.")));
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("BAD")));
+    BST_REQUIRE_EQUAL(empty, nmos::parse_fmtp_channel_order(U("")));
+}


### PR DESCRIPTION
Resolves #246.

Doesn't handle channel-order that includes 22.2 Surround ('222'), SDI audio group ('SGRP') or Undefined ('U01' to 'U64'), but good enough?