### PR TITLE
Add "service_name_prefix" to settings

### DIFF
--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -114,6 +114,9 @@
     //"discovery_backoff_max": 30,
     //"discovery_backoff_factor": 1.5,
 
+    // service_name_prefix [registry, node]: used as the name prefix of the advertised services (e.g. "nmos-cpp_node" or "nmos-cpp_query")
+    //"service_name_prefix": "nmos-cpp"
+
     // registry_address [node]: IP address or host name used to construct request URLs for registry APIs (if not discovered via DNS-SD)
     //"registry_address": ip-address-string,
 

--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -114,7 +114,7 @@
     //"discovery_backoff_max": 30,
     //"discovery_backoff_factor": 1.5,
 
-    // service_name_prefix [registry, node]: used as the name prefix of the advertised services (e.g. "nmos-cpp_node" or "nmos-cpp_query")
+    // service_name_prefix [registry, node]: used as a prefix in the advertised service names ("<prefix>_<api>_<host>:<port>", e.g. "nmos-cpp_node_127-0-0-1:3212")
     //"service_name_prefix": "nmos-cpp"
 
     // registry_address [node]: IP address or host name used to construct request URLs for registry APIs (if not discovered via DNS-SD)

--- a/Development/nmos-cpp-registry/config.json
+++ b/Development/nmos-cpp-registry/config.json
@@ -43,7 +43,7 @@
     //"discovery_backoff_max": 30,
     //"discovery_backoff_factor": 1.5,
 
-    // service_name_prefix [registry, node]: used as the name prefix of the advertised services (e.g. "nmos-cpp_node" or "nmos-cpp_query")
+    // service_name_prefix [registry, node]: used as a prefix in the advertised service names ("<prefix>_<api>_<host>:<port>", e.g. "nmos-cpp_node_127-0-0-1:3212")
     //"service_name_prefix": "nmos-cpp"
 
     // port numbers [registry, node]: ports to which clients should connect for each API

--- a/Development/nmos-cpp-registry/config.json
+++ b/Development/nmos-cpp-registry/config.json
@@ -43,6 +43,9 @@
     //"discovery_backoff_max": 30,
     //"discovery_backoff_factor": 1.5,
 
+    // service_name_prefix [registry, node]: used as the name prefix of the advertised services (e.g. "nmos-cpp_node" or "nmos-cpp_query")
+    //"service_name_prefix": "nmos-cpp"
+
     // port numbers [registry, node]: ports to which clients should connect for each API
 
     // http_port [registry, node]: if specified, this becomes the default port for each HTTP API and the next higher port becomes the default for each WebSocket API

--- a/Development/nmos/mdns.cpp
+++ b/Development/nmos/mdns.cpp
@@ -110,7 +110,7 @@ namespace nmos
         // IS-09 System API does not use authorization
         // See https://github.com/AMWA-TV/is-09/issues/21
         if (nmos::service_types::system == service) return false;
-       
+
         const auto client_authorization = false;
         return client_authorization;
     }
@@ -294,9 +294,9 @@ namespace nmos
                 return{};
             }
 
-            inline std::string service_base_name(const nmos::service_type& service)
+            inline std::string service_base_name(const nmos::service_type& service, const nmos::settings& settings)
             {
-                return "nmos-cpp_" + service_api(service);
+                return nmos::fields::service_name_prefix(settings) + "_" + service_api(service);
             }
 
             inline std::set<nmos::api_version> service_versions(const nmos::service_type& service, const nmos::settings& settings)
@@ -312,7 +312,7 @@ namespace nmos
         {
             // this just serves as an example of a possible service naming strategy
             // replacing '.' with '-', since although '.' is legal in service names, some DNS-SD implementations just don't like it
-            return boost::algorithm::replace_all_copy(details::service_base_name(service) + "_" + utility::us2s(nmos::get_host(settings)) + ":" + utility::us2s(utility::ostringstreamed(details::service_port(service, settings))), ".", "-");
+            return boost::algorithm::replace_all_copy(details::service_base_name(service, settings) + "_" + utility::us2s(nmos::get_host(settings)) + ":" + utility::us2s(utility::ostringstreamed(details::service_port(service, settings))), ".", "-");
         }
 
         // helper function for registering addresses when the host name is explicitly configured
@@ -695,7 +695,7 @@ namespace nmos
             // use a short timeout that's long enough to ensure the daemon's cache is exhausted
             // when no cancellation token is specified
             const auto timeout = token.is_cancelable() ? nmos::fields::discovery_backoff_max(settings) : 1;
-            
+
             return resolve_service(discovery, mode, service, browse_domain, versions, priorities, protocols, authorization, true, std::chrono::seconds(timeout), token);
         }
     }

--- a/Development/nmos/mdns.cpp
+++ b/Development/nmos/mdns.cpp
@@ -296,7 +296,7 @@ namespace nmos
 
             inline std::string service_base_name(const nmos::service_type& service, const nmos::settings& settings)
             {
-                return nmos::fields::service_name_prefix(settings) + "_" + service_api(service);
+                return utility::us2s(nmos::fields::service_name_prefix(settings)) + "_" + service_api(service);
             }
 
             inline std::set<nmos::api_version> service_versions(const nmos::service_type& service, const nmos::settings& settings)

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -114,7 +114,7 @@ namespace nmos
         const web::json::field_as_integer_or discovery_backoff_max{ U("discovery_backoff_max"), 30 };
         const web::json::field_with_default<double> discovery_backoff_factor{ U("discovery_backoff_factor"), 1.5 };
 
-        // service_name_prefix [registry, node]: used as the name prefix of the advertised services (e.g. "nmos-cpp_node" or "nmos-cpp_query")
+        // service_name_prefix [registry, node]: used as a prefix in the advertised service names ("<prefix>_<api>_<host>:<port>", e.g. "nmos-cpp_node_127-0-0-1:3212")
         const web::json::field_as_string_or service_name_prefix{ U("service_name_prefix"), U("nmos-cpp") };
 
         // registry_address [node]: IP address or host name used to construct request URLs for registry APIs (if not discovered via DNS-SD)

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -114,6 +114,9 @@ namespace nmos
         const web::json::field_as_integer_or discovery_backoff_max{ U("discovery_backoff_max"), 30 };
         const web::json::field_with_default<double> discovery_backoff_factor{ U("discovery_backoff_factor"), 1.5 };
 
+        // service_name_prefix [registry, node]: used as the name prefix of the advertised services (e.g. "nmos-cpp_node" or "nmos-cpp_query")
+        const web::json::field_as_string_or service_name_prefix{ U("service_name_prefix"), U("nmos-cpp") };
+
         // registry_address [node]: IP address or host name used to construct request URLs for registry APIs (if not discovered via DNS-SD)
         const web::json::field_as_string registry_address{ U("registry_address") };
 


### PR DESCRIPTION
Hi @lo-simon, @jonathan-r-thorpe.

I like the default DNS-SD service name, it saves time for record resolving but the static `nmos-cpp` prefix make me a bit upset. Could you please review this PR making this prefix customizable?