### PR TITLE
Handle SDP fields like 1*DIGIT which accept leading zeros

### DIFF
--- a/Development/sdp/sdp_grammar.cpp
+++ b/Development/sdp/sdp_grammar.cpp
@@ -40,10 +40,33 @@ namespace sdp
         {
             // use web::json::basic_ostream_visitor rather than web::json::value::serialize
             // to avoid, for example, 59.94 being output as 59.939999999999998
-            std::stringstream os;
+            std::ostringstream os;
             return v.as_number(), web::json::visit(web::json::basic_ostream_visitor<char>(os), v), os.str();
         }
-        inline web::json::value s2jn(const std::string& s) { auto v = web::json::value::parse(utility::s2us(s)); return v.as_number(), v; }
+        inline web::json::value s2jn(const std::string& s)
+        {
+            try
+            {
+                // using web::json::value::parse handles ints, doubles, etc.
+                auto v = web::json::value::parse(utility::s2us(s));
+                return v.as_number(), v;
+            }
+            catch (const web::json::json_exception&)
+            {
+                throw sdp_parse_error("expected a number");
+            }
+        }
+
+        // since several fields have the grammar 1*DIGIT which allows leading zeros, use a different parser for these
+        // for now, leading zeros are not roundtrippable
+        inline web::json::value digits2jn(const std::string& s)
+        {
+            uint64_t v;
+            std::istringstream is(s);
+            is >> v;
+            if (is.fail() || !is.eof()) throw sdp_parse_error("expected a sequence of digits");
+            return web::json::value(v);
+        }
 
         // find the first delimiter in str, beginning at pos, and return the substring from pos to the delimiter (or end)
         // set pos to the end of the delimiter
@@ -70,6 +93,8 @@ namespace sdp
         const converter string_converter{ js2s, s2js };
 
         const converter number_converter{ jn2s, s2jn };
+
+        const converter digits_converter{ jn2s, digits2jn };
 
         // <key>[<separator><value>]
         converter key_value_converter(char separator, const std::pair<utility::string_t, converter>& key_converter, const std::pair<utility::string_t, converter>& value_converter)
@@ -199,12 +224,12 @@ namespace sdp
         const converter typed_time_converter
         {
             [](const web::json::value& v) {
-                return jn2s(v.at(sdp::fields::time_value)) + utility::us2s(sdp::fields::time_unit(v));
+                return digits_converter.format(v.at(sdp::fields::time_value)) + utility::us2s(sdp::fields::time_unit(v));
             },
             [](const std::string& s) {
                 return !s.empty() && std::string::npos != time_units.find(s.back())
-                    ? web::json::value_of({ { sdp::fields::time_value, s2jn(s.substr(0, s.size() - 1)) }, { sdp::fields::time_unit, s2js({ s.back() }) } }, keep_order)
-                    : web::json::value_of({ { sdp::fields::time_value, s2jn(s) } }, keep_order);
+                    ? web::json::value_of({ { sdp::fields::time_value, digits_converter.parse(s.substr(0, s.size() - 1)) }, { sdp::fields::time_unit, s2js({ s.back() }) } }, keep_order)
+                    : web::json::value_of({ { sdp::fields::time_value, digits_converter.parse(s) } }, keep_order);
             }
         };
 
@@ -256,7 +281,7 @@ namespace sdp
         const line protocol_version = required_line(
             sdp::fields::protocol_version,
             'v',
-            number_converter
+            digits_converter
         );
 
         // See https://tools.ietf.org/html/rfc4566#section-5.2
@@ -265,8 +290,8 @@ namespace sdp
             'o',
             object_converter({
                 { sdp::fields::user_name, string_converter },
-                { sdp::fields::session_id, number_converter },
-                { sdp::fields::session_version, number_converter },
+                { sdp::fields::session_id, digits_converter },
+                { sdp::fields::session_version, digits_converter },
                 { sdp::fields::network_type, string_converter },
                 { sdp::fields::address_type, string_converter },
                 { sdp::fields::unicast_address, string_converter }
@@ -328,7 +353,7 @@ namespace sdp
             'b',
             object_converter({
                 { sdp::fields::bandwidth_type, string_converter },
-                { sdp::fields::bandwidth, number_converter }
+                { sdp::fields::bandwidth, digits_converter }
             }, ":")
         );
 
@@ -469,7 +494,7 @@ namespace sdp
                         'm',
                         object_converter({
                             { sdp::fields::media_type, string_converter },
-                            { {}, key_value_converter('/', { sdp::fields::port, number_converter }, { sdp::fields::port_count, number_converter }) },
+                            { {}, key_value_converter('/', { sdp::fields::port, digits_converter }, { sdp::fields::port_count, number_converter }) },
                             { sdp::fields::protocol, string_converter },
                             { sdp::fields::formats, strings_converter }
                         })
@@ -720,7 +745,7 @@ namespace sdp
                     {
                         [](const web::json::value& v) {
                             std::string s;
-                            s += number_converter.format(v.at(sdp::fields::local_id));
+                            s += digits_converter.format(v.at(sdp::fields::local_id));
                             if (v.has_field(sdp::fields::direction)) s += "/" + string_converter.format(v.at(sdp::fields::direction));
                             s += " " + string_converter.format(v.at(sdp::fields::uri));
                             if (v.has_field(sdp::fields::extensionattributes)) s += " " + string_converter.format(v.at(sdp::fields::extensionattributes));
@@ -729,7 +754,7 @@ namespace sdp
                         [](const std::string& s) {
                             auto v = web::json::value::object(keep_order);
                             size_t pos = 0;
-                            v[sdp::fields::local_id] = number_converter.parse(substr_find(s, pos, bst::regex{ R"(\D)" }));
+                            v[sdp::fields::local_id] = digits_converter.parse(substr_find(s, pos, bst::regex{ R"(\D)" }));
                             if (s.at(pos - 1) == '/') v[sdp::fields::direction] = string_converter.parse(substr_find(s, pos, " "));
                             v[sdp::fields::uri] = string_converter.parse(substr_find(s, pos, " "));
                             if (std::string::npos != pos) v[sdp::fields::extensionattributes] = string_converter.parse(substr_find(s, pos));
@@ -740,7 +765,7 @@ namespace sdp
                 {
                     sdp::attributes::hkep,
                     object_converter({
-                        { sdp::fields::port, number_converter },
+                        { sdp::fields::port, digits_converter },
                         { sdp::fields::network_type, string_converter },
                         { sdp::fields::address_type, string_converter },
                         { sdp::fields::unicast_address, string_converter },

--- a/Development/sdp/test/sdp_test.cpp
+++ b/Development/sdp/test/sdp_test.cpp
@@ -385,6 +385,42 @@ a=framerate:59.94
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testSdpDigits)
+{
+    const bool keep_order = true;
+
+    const std::string test_sdp = R"(v=000
+o=- 007 0987654321098765432 IN IP4 192.0.2.0
+s=Leading zeros
+b=AS:09876543210
+t=0 0
+m=video 000000000000000000050020 RTP/AVP 0096
+)";
+
+    const std::string expected_sdp = R"(v=0
+o=- 7 987654321098765432 IN IP4 192.0.2.0
+s=Leading zeros
+b=AS:9876543210
+t=0 0
+m=video 50020 RTP/AVP 0096
+)";
+
+    auto session_description = sdp::parse_session_description(test_sdp);
+
+    auto test_sdp2 = sdp::make_session_description(session_description);
+    std::istringstream expected(expected_sdp), actual(test_sdp2);
+    do
+    {
+        std::string expected_line, actual_line;
+        std::getline(expected, expected_line);
+        std::getline(actual, actual_line);
+        // CR cannot appear in a raw string literal, so remove it from the actual line
+        if (!actual_line.empty() && '\r' == actual_line.back()) actual_line.pop_back();
+        BST_CHECK_EQUAL(expected_line, actual_line);
+    } while (!expected.fail() && !actual.fail());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
 BST_TEST_CASE(testSdpParseErrors)
 {
     // an empty SDP file results in "sdp parse error - expected a line for protocol_version at line 1"
@@ -421,6 +457,35 @@ BST_TEST_CASE(testSdpParseErrors)
     BST_REQUIRE_THROW(sdp::parse_session_description(enough + "\r\n"), std::runtime_error);
     // ... even if there's a complete valid line after it
     BST_REQUIRE_THROW(sdp::parse_session_description(enough + "\r\na=foo"), std::runtime_error);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testSdpNumberErrors)
+{
+    const std::string before = "v=0\r\no=- 42 42 IN IP4 10.0.0.1\r\ns= \r\n";
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "t=0 0"));
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "t=0 0\r\na=ptime:0.125"));
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "t=0 0\r\na=ptime:1"));
+    // an invalid time results in "sdp parse error - expected a number at line 4"
+    BST_REQUIRE_THROW(sdp::parse_session_description(before + "t=foo 0"), std::runtime_error);
+    // an invalid packet time results in "sdp parse error - expected a number at line 5"
+    BST_REQUIRE_THROW(sdp::parse_session_description(before + "t=0 0\r\na=ptime:foo"), std::runtime_error);
+    //BST_REQUIRE_THROW(sdp::parse_session_description(before + "t=0 0\r\na=ptime:+1.25e-1"), std::runtime_error);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testSdpDigitsErrors)
+{
+    const std::string after = "\r\no=- 42 42 IN IP4 10.0.0.1\r\ns= \r\nt=0 0\r\n";
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description("v=0" + after));
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description("v=0000000000" + after));
+    // an invalid protocol version results in "sdp parse error - expected a sequence of digits at line 1"
+    BST_REQUIRE_THROW(sdp::parse_session_description("v=" + after), std::runtime_error);
+    BST_REQUIRE_THROW(sdp::parse_session_description("v=foo" + after), std::runtime_error);
+    BST_REQUIRE_THROW(sdp::parse_session_description("v=0foo" + after), std::runtime_error);
+    BST_REQUIRE_THROW(sdp::parse_session_description("v=0.0" + after), std::runtime_error);
+    BST_REQUIRE_THROW(sdp::parse_session_description("v=0x0" + after), std::runtime_error);
+    //BST_REQUIRE_THROW(sdp::parse_session_description("v=+0" + after), std::runtime_error);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Also map json_exception when parsing numbers to sdp_exception.

Based on bug report and work of @maweit in #336.