### PR TITLE
Fix SSN for ST2110-40:2023 to be ST2110-40:2021

### DIFF
--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -341,7 +341,7 @@ namespace nmos
         // hm, TM not indicated in IS-04
         if (tm) params.tm = *tm;
 
-        params.ssn = params.tm.empty() ? sdp::smpte_standard_numbers::ST2110_40_2018 : sdp::smpte_standard_numbers::ST2110_40_2022;
+        params.ssn = params.tm.empty() ? sdp::smpte_standard_numbers::ST2110_40_2018 : sdp::smpte_standard_numbers::ST2110_40_2023;
 
         // hm, ST 2110-21 TROFF not indicated in IS-04 so omit this
         // hm, ST 2110-10 TSMODE and TSDELAY not indicated in IS-04 so omit these

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -425,7 +425,7 @@ namespace nmos
     };
 
     // Additional "video/smpte291" data payload parameters
-    // See SMPTE ST 2110-40:2022
+    // See SMPTE ST 2110-40:2023
     // and https://www.iana.org/assignments/media-types/video/smpte291
     // and https://tools.ietf.org/html/rfc8331
     struct video_smpte291_parameters
@@ -434,11 +434,11 @@ namespace nmos
         std::vector<nmos::did_sdid> did_sdids;
         // fmtp optionally indicates VPID Code of the source interface
         nmos::vpid_code vpid_code;
-        // fmtp is required to indicate frame rate, since ST 2110-40:2022
+        // fmtp is required to indicate frame rate, since ST 2110-40:2023
         nmos::rational exactframerate;
-        // fmtp optionally indicates TM, since ST 2110-40:2022
+        // fmtp optionally indicates TM, since ST 2110-40:2023
         sdp::transmission_model tm; // if omitted (empty), assume sdp::transmission_models::CTM
-        // fmtp is required to indicate SSN, since ST 2110-40:2022
+        // fmtp is required to indicate SSN, since ST 2110-40:2023
         sdp::smpte_standard_number ssn;
 
         // additional fmtp parameters from ST 2110-21:2022

--- a/Development/sdp/json.h
+++ b/Development/sdp/json.h
@@ -497,7 +497,7 @@ namespace sdp
         // and https://tools.ietf.org/html/rfc3190
         const web::json::field_as_string channel_order{ U("channel-order") }; // "<convention>.<order>", e.g. "SMPTE2110.(ST)", see nmos/channels.h
 
-        // See SMPTE ST 2110-40:2022
+        // See SMPTE ST 2110-40:2023
         // and https://tools.ietf.org/html/rfc8331
         const web::json::field_as_string DID_SDID{ U("DID_SDID") }; // e.g. "{0x41,0x01}", see nmos::did_sdid
         const web::json::field<uint32_t> VPID_Code{ U("VPID_Code") }; // 1..255, see nmos::vpid_code
@@ -600,7 +600,7 @@ namespace sdp
     // SMPTE Standard Number
     // See SMPTE ST 2110-20:2022 Section 7.2 Required Media Type Parameters
     // and SMPTE ST 2110-22:2022 Section 7.2 Format-specific Parameters
-    // and SMPTE ST 2110-40:2022 Section 7 Session Description Protocol (SDP)
+    // and SMPTE ST 2110-40:2023 Section 7 Session Description Protocol (SDP)
     DEFINE_STRING_ENUM(smpte_standard_number)
     namespace smpte_standard_numbers
     {
@@ -617,9 +617,11 @@ namespace sdp
 
         const smpte_standard_number ST2110_40_2018{ U("ST2110-40:2018") };
         // "Senders implementing this standard shall signal the value ST2110-40:2018 unless they are signaling TM, in
-        // which case they shall signal the value ST2110-40:2022."
+        // which case they shall signal the value ST2110-40:2021."
         // Note that SSN was not actually specified in ST 2110-40:2018...
-        const smpte_standard_number ST2110_40_2022{ U("ST2110-40:2022") };
+        // ...and yes, the publication of the ST 2110-40 revision was delayed two calendar years but the SSN value
+        // has not thus far been corrected!
+        const smpte_standard_number ST2110_40_2023{ U("ST2110-40:2021") };
     }
 
     // TP (Media Type Parameter)
@@ -676,7 +678,7 @@ namespace sdp
     }
 
     // TM (Transmission Model)
-    // See SMPTE ST 2110-40:2022 Section 7 Session Description Protocol (SDP)
+    // See SMPTE ST 2110-40:2023 Section 7 Session Description Protocol (SDP)
     DEFINE_STRING_ENUM(transmission_model)
     namespace transmission_models
     {


### PR DESCRIPTION
Although this revision should have been published in 2022 and the SSN should have been updated to match, neither of those things actually happened...

https://ieeexplore.ieee.org/document/10064369