### PR TITLE
Fix tsdelay and troff

### DIFF
--- a/Development/cmake/NmosCppTest.cmake
+++ b/Development/cmake/NmosCppTest.cmake
@@ -49,11 +49,13 @@ set(NMOS_CPP_TEST_NMOS_TEST_SOURCES
     nmos/test/jwt_validation_test.cpp
     nmos/test/paging_utils_test.cpp
     nmos/test/query_api_test.cpp
+    nmos/test/sdp_test_utils.cpp
     nmos/test/sdp_utils_test.cpp
     nmos/test/system_resources_test.cpp
     nmos/test/video_jxsv_test.cpp
     )
 set(NMOS_CPP_TEST_NMOS_TEST_HEADERS
+    nmos/test/sdp_test_utils.h
     )
 
 set(NMOS_CPP_TEST_PPLX_TEST_SOURCES

--- a/Development/conanfile.txt
+++ b/Development/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 boost/1.83.0
-cpprestsdk/2.10.18
+cpprestsdk/2.10.19
 websocketpp/0.8.2
 openssl/1.1.1s
 json-schema-validator/2.3.0

--- a/Development/conanfile.txt
+++ b/Development/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-boost/1.80.0
+boost/1.83.0
 cpprestsdk/2.10.18
 websocketpp/0.8.2
 openssl/1.1.1s

--- a/Development/conanfile.txt
+++ b/Development/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
-boost/1.83.0
-cpprestsdk/2.10.19
+boost/1.80.0
+cpprestsdk/2.10.18
 websocketpp/0.8.2
 openssl/1.1.1s
 json-schema-validator/2.3.0

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -793,11 +793,11 @@ namespace nmos
         // additional parameters introduced by SMPTE specs since then...
         if (!params.range.empty()) fmtp.push_back({ sdp::fields::range, params.range.name });
         if (0 != params.par) fmtp.push_back({ sdp::fields::pixel_aspect_ratio, nmos::details::make_pixel_aspect_ratio(params.par) });
-        if (0 != params.troff) fmtp.push_back({ sdp::fields::TROFF, utility::ostringstreamed(params.troff) });
+        if (params.troff) fmtp.push_back({ sdp::fields::TROFF, utility::ostringstreamed(*params.troff) });
         if (0 != params.cmax) fmtp.push_back({ sdp::fields::CMAX, utility::ostringstreamed(params.cmax) });
         if (0 != params.maxudp) fmtp.push_back({ sdp::fields::max_udp_packet_size, utility::ostringstreamed(params.maxudp) });
         if (!params.tsmode.empty()) fmtp.push_back({ sdp::fields::timestamp_mode, params.tsmode.name });
-        if (0 != params.tsdelay) fmtp.push_back({ sdp::fields::timestamp_delay, utility::ostringstreamed(params.tsdelay) });
+        if (params.tsdelay) fmtp.push_back({ sdp::fields::timestamp_delay, utility::ostringstreamed(*params.tsdelay) });
 
         return{ session_name, sdp::media_types::video, rtpmap, fmtp, {}, {}, {}, {}, media_stream_ids, ts_refclk };
     }
@@ -814,7 +814,7 @@ namespace nmos
         sdp_parameters::fmtp_t fmtp = {};
         if (!params.channel_order.empty()) fmtp.push_back({ sdp::fields::channel_order, params.channel_order });
         if (!params.tsmode.empty()) fmtp.push_back({ sdp::fields::timestamp_mode, params.tsmode.name });
-        if (0 != params.tsdelay) fmtp.push_back({ sdp::fields::timestamp_delay, utility::ostringstreamed(params.tsdelay) });
+        if (params.tsdelay) fmtp.push_back({ sdp::fields::timestamp_delay, utility::ostringstreamed(*params.tsdelay) });
 
         return{ session_name, sdp::media_types::audio, rtpmap, fmtp, {}, params.packet_time, {}, {}, media_stream_ids, ts_refclk };
     }
@@ -836,9 +836,9 @@ namespace nmos
         if (0 != params.exactframerate) fmtp.push_back({ sdp::fields::exactframerate, nmos::details::make_exactframerate(params.exactframerate) });
         if (!params.tm.empty()) fmtp.push_back({ sdp::fields::TM, params.tm.name });
         if (!params.ssn.empty()) fmtp.push_back({ sdp::fields::smpte_standard_number, params.ssn.name });
-        if (0 != params.troff) fmtp.push_back({ sdp::fields::TROFF, utility::ostringstreamed(params.troff) });
+        if (params.troff) fmtp.push_back({ sdp::fields::TROFF, utility::ostringstreamed(*params.troff) });
         if (!params.tsmode.empty()) fmtp.push_back({ sdp::fields::timestamp_mode, params.tsmode.name });
-        if (0 != params.tsdelay) fmtp.push_back({ sdp::fields::timestamp_delay, utility::ostringstreamed(params.tsdelay) });
+        if (params.tsdelay) fmtp.push_back({ sdp::fields::timestamp_delay, utility::ostringstreamed(*params.tsdelay) });
 
         return{ session_name, sdp::media_types::video, rtpmap, fmtp, {}, {}, {}, {}, media_stream_ids, ts_refclk };
     }
@@ -854,7 +854,7 @@ namespace nmos
         // See https://tools.ietf.org/html/rfc4566#section-6
         sdp_parameters::fmtp_t fmtp = {};
         if (!params.tp.empty()) fmtp.push_back({ sdp::fields::type_parameter, params.tp.name });
-        if (0 != params.troff) fmtp.push_back({ sdp::fields::TROFF, utility::ostringstreamed(params.troff) });
+        if (params.troff) fmtp.push_back({ sdp::fields::TROFF, utility::ostringstreamed(*params.troff) });
 
         return{ session_name, sdp::media_types::video, rtpmap, fmtp, {}, {}, {}, {}, media_stream_ids, ts_refclk };
     }

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -316,13 +316,13 @@ namespace nmos
 
         // additional fmtp parameters from ST 2110-21:2022
         sdp::type_parameter tp;
-        uint32_t troff; // if omitted (zero), assume default
+        bst::optional<uint32_t> troff; // if omitted, assume default 
         uint32_t cmax; // if omitted (zero), assume max defined for tp
 
         // additional fmtp parameters from ST 2110-10:2022
         uint32_t maxudp; // if omitted (zero), assume the Standard UP Size Limit
         sdp::timestamp_mode tsmode; // if omitted (empty), assume sdp::timestamp_modes::NEW
-        uint32_t tsdelay;
+        bst::optional<uint32_t> tsdelay;
 
         video_raw_parameters() : depth(), width(), height(), interlace(), segmented(), troff(), cmax(), maxudp(), tsdelay() {}
 
@@ -341,11 +341,11 @@ namespace nmos
             sdp::packing_mode pm,
             sdp::smpte_standard_number ssn,
             sdp::type_parameter tp,
-            uint32_t troff,
+            bst::optional<uint32_t> troff,
             uint32_t cmax,
             uint32_t maxudp,
             sdp::timestamp_mode tsmode,
-            uint32_t tsdelay
+            bst::optional<uint32_t> tsdelay
         )
             : sampling(std::move(sampling))
             , depth(depth)
@@ -393,7 +393,7 @@ namespace nmos
 
         // additional fmtp parameters from ST 2110-10:2022
         sdp::timestamp_mode tsmode; // if omitted (empty), assume sdp::timestamp_modes::NEW
-        uint32_t tsdelay;
+        bst::optional<uint32_t> tsdelay;
 
         // ptime
         double packet_time;
@@ -406,7 +406,7 @@ namespace nmos
             uint64_t sample_rate,
             utility::string_t channel_order,
             sdp::timestamp_mode tsmode,
-            uint32_t tsdelay,
+            bst::optional<uint32_t> tsdelay,
             double packet_time
         )
             : channel_count(channel_count)
@@ -442,11 +442,11 @@ namespace nmos
         sdp::smpte_standard_number ssn;
 
         // additional fmtp parameters from ST 2110-21:2022
-        uint32_t troff; // if omitted (zero), assume default
+        bst::optional<uint32_t> troff; // if omitted, assume default
 
         // additional fmtp parameters from ST 2110-10:2022
         sdp::timestamp_mode tsmode; // if omitted (empty), assume sdp::timestamp_modes::NEW
-        uint32_t tsdelay;
+        bst::optional<uint32_t> tsdelay;
 
         video_smpte291_parameters() : vpid_code(), troff(), tsdelay() {}
 
@@ -456,9 +456,9 @@ namespace nmos
             nmos::rational exactframerate,
             sdp::transmission_model tm,
             sdp::smpte_standard_number ssn,
-            uint32_t troff,
+            bst::optional<uint32_t> troff,
             sdp::timestamp_mode tsmode,
-            uint32_t tsdelay
+            bst::optional<uint32_t> tsdelay
         )
             : did_sdids(std::move(did_sdids))
             , vpid_code(vpid_code)
@@ -482,13 +482,13 @@ namespace nmos
     {
         // additional fmtp parameters from ST 2110-21:2017
         sdp::type_parameter tp;
-        uint32_t troff; // if omitted (zero), assume default
+        bst::optional<uint32_t> troff; // if omitted (zero), assume default
 
         video_SMPTE2022_6_parameters() : troff() {}
 
         video_SMPTE2022_6_parameters(
             sdp::type_parameter tp,
-            uint32_t troff
+            bst::optional<uint32_t> troff
         )
             : tp(std::move(tp))
             , troff(troff)

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -482,7 +482,7 @@ namespace nmos
     {
         // additional fmtp parameters from ST 2110-21:2017
         sdp::type_parameter tp;
-        bst::optional<uint32_t> troff; // if omitted (zero), assume default
+        bst::optional<uint32_t> troff; // if omitted, assume default
 
         video_SMPTE2022_6_parameters() : troff() {}
 

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -316,7 +316,7 @@ namespace nmos
 
         // additional fmtp parameters from ST 2110-21:2022
         sdp::type_parameter tp;
-        bst::optional<uint32_t> troff; // if omitted, assume default 
+        bst::optional<uint32_t> troff; // if omitted, assume default
         uint32_t cmax; // if omitted (zero), assume max defined for tp
 
         // additional fmtp parameters from ST 2110-10:2022

--- a/Development/nmos/test/sdp_test_utils.cpp
+++ b/Development/nmos/test/sdp_test_utils.cpp
@@ -1,0 +1,31 @@
+
+#include "bst/test/test.h"
+#include "nmos/test/sdp_test_utils.h"
+#include "nmos/sdp_utils.h"
+
+namespace sdp_test
+{
+    typedef std::multimap<utility::string_t, utility::string_t> comparable_fmtp_t;
+
+    inline comparable_fmtp_t comparable_fmtp(const nmos::sdp_parameters::fmtp_t& fmtp)
+    {
+        return comparable_fmtp_t{ fmtp.begin(), fmtp.end() };
+    }
+
+    void check_sdp_parameters(const nmos::sdp_parameters& lhs, const nmos::sdp_parameters& rhs)
+    {
+        BST_REQUIRE_EQUAL(lhs.session_name, rhs.session_name);
+        BST_REQUIRE_EQUAL(lhs.rtpmap.payload_type, rhs.rtpmap.payload_type);
+        BST_REQUIRE_EQUAL(lhs.rtpmap.encoding_name, rhs.rtpmap.encoding_name);
+        BST_REQUIRE_EQUAL(lhs.rtpmap.clock_rate, rhs.rtpmap.clock_rate);
+        if (0 != lhs.rtpmap.encoding_parameters)
+            BST_REQUIRE_EQUAL(lhs.rtpmap.encoding_parameters, rhs.rtpmap.encoding_parameters);
+        else
+            BST_REQUIRE((0 == rhs.rtpmap.encoding_parameters || 1 == rhs.rtpmap.encoding_parameters));
+        BST_REQUIRE_EQUAL(comparable_fmtp(lhs.fmtp), comparable_fmtp(rhs.fmtp));
+        BST_REQUIRE_EQUAL(lhs.packet_time, rhs.packet_time);
+        BST_REQUIRE_EQUAL(lhs.max_packet_time, rhs.max_packet_time);
+        BST_REQUIRE_EQUAL(lhs.bandwidth.bandwidth_type, rhs.bandwidth.bandwidth_type);
+        BST_REQUIRE_EQUAL(lhs.bandwidth.bandwidth, rhs.bandwidth.bandwidth);
+    }
+}

--- a/Development/nmos/test/sdp_test_utils.cpp
+++ b/Development/nmos/test/sdp_test_utils.cpp
@@ -1,6 +1,6 @@
+#include "nmos/test/sdp_test_utils.h"
 
 #include "bst/test/test.h"
-#include "nmos/test/sdp_test_utils.h"
 #include "nmos/sdp_utils.h"
 
 namespace sdp_test

--- a/Development/nmos/test/sdp_test_utils.cpp
+++ b/Development/nmos/test/sdp_test_utils.cpp
@@ -3,7 +3,7 @@
 #include "bst/test/test.h"
 #include "nmos/sdp_utils.h"
 
-namespace sdp_test
+namespace nmos
 {
     typedef std::multimap<utility::string_t, utility::string_t> comparable_fmtp_t;
 

--- a/Development/nmos/test/sdp_test_utils.h
+++ b/Development/nmos/test/sdp_test_utils.h
@@ -1,0 +1,14 @@
+#ifndef NMOS_SDP_TEST_UTILS_H
+#define NMOS_SDP_TEST_UTILS_H
+
+namespace nmos
+{
+    struct sdp_parameters;
+}
+
+namespace sdp_test
+{
+    void check_sdp_parameters(const nmos::sdp_parameters& lhs, const nmos::sdp_parameters& rhs);
+}
+
+#endif

--- a/Development/nmos/test/sdp_test_utils.h
+++ b/Development/nmos/test/sdp_test_utils.h
@@ -4,10 +4,7 @@
 namespace nmos
 {
     struct sdp_parameters;
-}
 
-namespace sdp_test
-{
     void check_sdp_parameters(const nmos::sdp_parameters& lhs, const nmos::sdp_parameters& rhs);
 }
 

--- a/Development/nmos/test/sdp_utils_test.cpp
+++ b/Development/nmos/test/sdp_utils_test.cpp
@@ -9,6 +9,7 @@
 #include "nmos/json_fields.h"
 #include "nmos/media_type.h"
 #include "nmos/random.h"
+#include "nmos/test/sdp_test_utils.h"
 #include "sdp/sdp.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -499,31 +500,6 @@ BST_TEST_CASE(testSdpTransportParamsMulticast)
     }
 }
 
-namespace
-{
-    typedef std::multimap<utility::string_t, utility::string_t> comparable_fmtp_t;
-
-    inline comparable_fmtp_t comparable_fmtp(const nmos::sdp_parameters::fmtp_t& fmtp)
-    {
-        return comparable_fmtp_t{ fmtp.begin(), fmtp.end() };
-    }
-
-    void check_sdp_parameters(const nmos::sdp_parameters& lhs, const nmos::sdp_parameters& rhs)
-    {
-        BST_REQUIRE_EQUAL(lhs.session_name, rhs.session_name);
-        BST_REQUIRE_EQUAL(lhs.rtpmap.payload_type, rhs.rtpmap.payload_type);
-        BST_REQUIRE_EQUAL(lhs.rtpmap.encoding_name, rhs.rtpmap.encoding_name);
-        BST_REQUIRE_EQUAL(lhs.rtpmap.clock_rate, rhs.rtpmap.clock_rate);
-        if (0 != lhs.rtpmap.encoding_parameters)
-            BST_REQUIRE_EQUAL(lhs.rtpmap.encoding_parameters, rhs.rtpmap.encoding_parameters);
-        else
-            BST_REQUIRE((0 == rhs.rtpmap.encoding_parameters || 1 == rhs.rtpmap.encoding_parameters));
-        BST_REQUIRE_EQUAL(comparable_fmtp(lhs.fmtp), comparable_fmtp(rhs.fmtp));
-        BST_REQUIRE_EQUAL(lhs.packet_time, rhs.packet_time);
-        BST_REQUIRE_EQUAL(lhs.max_packet_time, rhs.max_packet_time);
-    }
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////
 BST_TEST_CASE(testSdpParametersVideoRaw)
 {
@@ -600,11 +576,11 @@ BST_TEST_CASE(testSdpParametersVideoRaw)
                 { U("PM"), U("2110BPM") },
                 { U("SSN"), U("ST2110-20:2022") },
                 { U("TP"), U("2110TPW") },
-                { U("TROFF"), U("37") },
+                { U("TROFF"), U("0") },
                 { U("CMAX"), U("42") },
                 { U("MAXUDP"), U("57") },
                 { U("TSMODE"), U("SAMP") },
-                { U("TSDELAY"), U("82") }
+                { U("TSDELAY"), U("0") }
             }
         },
         {
@@ -622,20 +598,20 @@ BST_TEST_CASE(testSdpParametersVideoRaw)
             sdp::packing_modes::block,
             sdp::smpte_standard_numbers::ST2110_20_2022,
             sdp::type_parameters::type_W,
-            37,
+            0,
             42,
             57,
             sdp::timestamp_modes::SAMP,
-            82
+            0
         }
     };
 
     for (auto& test : { example, wacky })
     {
         auto made = nmos::make_video_raw_sdp_parameters(test.first.session_name, test.second, test.first.rtpmap.payload_type);
-        check_sdp_parameters(test.first, made);
+        sdp_test::check_sdp_parameters(test.first, made);
         auto roundtripped = nmos::make_video_raw_sdp_parameters(made.session_name, nmos::get_video_raw_parameters(made), made.rtpmap.payload_type);
-        check_sdp_parameters(test.first, roundtripped);
+        sdp_test::check_sdp_parameters(test.first, roundtripped);
     }
 }
 
@@ -681,7 +657,7 @@ BST_TEST_CASE(testSdpParametersAudioL)
             {
                 { U("channel-order"), U("SMPTE2110.(M,M,M,M,ST,U02)") },
                 { U("TSMODE"), U("SAMP") },
-                { U("TSDELAY"), U("82") }
+                { U("TSDELAY"), U("0") }
             },
             {},
             0.333
@@ -692,7 +668,7 @@ BST_TEST_CASE(testSdpParametersAudioL)
             96000,
             U("SMPTE2110.(M,M,M,M,ST,U02)"), // not testing nmos::make_fmtp_channel_order here
             sdp::timestamp_modes::SAMP,
-            82,
+            0,
             0.333
         }
     };
@@ -700,9 +676,9 @@ BST_TEST_CASE(testSdpParametersAudioL)
     for (auto& test : { example, wacky })
     {
         auto made = nmos::make_audio_L_sdp_parameters(test.first.session_name, test.second, test.first.rtpmap.payload_type);
-        check_sdp_parameters(test.first, made);
+        sdp_test::check_sdp_parameters(test.first, made);
         auto roundtripped = nmos::make_audio_L_sdp_parameters(made.session_name, nmos::get_audio_L_parameters(made), made.rtpmap.payload_type);
-        check_sdp_parameters(test.first, roundtripped);
+        sdp_test::check_sdp_parameters(test.first, roundtripped);
     }
 }
 
@@ -751,9 +727,9 @@ BST_TEST_CASE(testSdpParametersVideoSmpte291)
                 { U("exactframerate"), U("60000/1001") },
                 { U("TM"), U("CTM") },
                 { U("SSN"), U("ST2110-40:2021") },
-                { U("TROFF"), U("37") },
+                { U("TROFF"), U("0") },
                 { U("TSMODE"), U("SAMP") },
-                { U("TSDELAY"), U("82") }
+                { U("TSDELAY"), U("0") }
             }
         },
         {
@@ -762,18 +738,18 @@ BST_TEST_CASE(testSdpParametersVideoSmpte291)
             nmos::rates::rate59_94,
             sdp::transmission_models::compatible,
             sdp::smpte_standard_numbers::ST2110_40_2023,
-            37,
+            0,
             sdp::timestamp_modes::SAMP,
-            82
+            0
         }
     };
 
     for (auto& test : { example, wacky })
     {
         auto made = nmos::make_video_smpte291_sdp_parameters(test.first.session_name, test.second, test.first.rtpmap.payload_type);
-        check_sdp_parameters(test.first, made);
+        sdp_test::check_sdp_parameters(test.first, made);
         auto roundtripped = nmos::make_video_smpte291_sdp_parameters(made.session_name, nmos::get_video_smpte291_parameters(made), made.rtpmap.payload_type);
-        check_sdp_parameters(test.first, roundtripped);
+        sdp_test::check_sdp_parameters(test.first, roundtripped);
     }
 }
 
@@ -810,20 +786,20 @@ BST_TEST_CASE(testSdpParametersVideoSmpte2022_6)
             },
             {
                 { U("TP"), U("2110TPW") },
-                { U("TROFF"), U("37") }
+                { U("TROFF"), U("0") }
             }
         },
         {
              sdp::type_parameters::type_W,
-             37
+             0
         }
     };
 
     for (auto& test : { example, wacky })
     {
         auto made = nmos::make_video_SMPTE2022_6_sdp_parameters(test.first.session_name, test.second, test.first.rtpmap.payload_type);
-        check_sdp_parameters(test.first, made);
+        sdp_test::check_sdp_parameters(test.first, made);
         auto roundtripped = nmos::make_video_SMPTE2022_6_sdp_parameters(made.session_name, nmos::get_video_SMPTE2022_6_parameters(made), made.rtpmap.payload_type);
-        check_sdp_parameters(test.first, roundtripped);
+        sdp_test::check_sdp_parameters(test.first, roundtripped);
     }
 }

--- a/Development/nmos/test/sdp_utils_test.cpp
+++ b/Development/nmos/test/sdp_utils_test.cpp
@@ -598,11 +598,11 @@ BST_TEST_CASE(testSdpParametersVideoRaw)
             sdp::packing_modes::block,
             sdp::smpte_standard_numbers::ST2110_20_2022,
             sdp::type_parameters::type_W,
-            0,
+            uint32_t(0),
             42,
             57,
             sdp::timestamp_modes::SAMP,
-            0
+            uint32_t(0)
         }
     };
 
@@ -668,7 +668,7 @@ BST_TEST_CASE(testSdpParametersAudioL)
             96000,
             U("SMPTE2110.(M,M,M,M,ST,U02)"), // not testing nmos::make_fmtp_channel_order here
             sdp::timestamp_modes::SAMP,
-            0,
+            uint32_t(0),
             0.333
         }
     };
@@ -738,9 +738,9 @@ BST_TEST_CASE(testSdpParametersVideoSmpte291)
             nmos::rates::rate59_94,
             sdp::transmission_models::compatible,
             sdp::smpte_standard_numbers::ST2110_40_2023,
-            0,
+            uint32_t(0),
             sdp::timestamp_modes::SAMP,
-            0
+            uint32_t(0)
         }
     };
 
@@ -791,7 +791,7 @@ BST_TEST_CASE(testSdpParametersVideoSmpte2022_6)
         },
         {
              sdp::type_parameters::type_W,
-             0
+             uint32_t(0)
         }
     };
 

--- a/Development/nmos/test/sdp_utils_test.cpp
+++ b/Development/nmos/test/sdp_utils_test.cpp
@@ -576,6 +576,60 @@ BST_TEST_CASE(testSdpParametersVideoRaw)
                 { U("PM"), U("2110BPM") },
                 { U("SSN"), U("ST2110-20:2022") },
                 { U("TP"), U("2110TPW") },
+                { U("TROFF"), U("37") },
+                { U("CMAX"), U("42") },
+                { U("MAXUDP"), U("57") },
+                { U("TSMODE"), U("SAMP") },
+                { U("TSDELAY"), U("82") }
+            }
+        },
+        {
+            sdp::samplings::UNSPECIFIED,
+            16,
+            9999,
+            6666,
+            { 123, 1 },
+            true,
+            true,
+            sdp::transfer_characteristic_systems::ST2115LOGS3,
+            sdp::colorimetries::BT2100,
+            sdp::ranges::FULLPROTECT,
+            { 12, 11 },
+            sdp::packing_modes::block,
+            sdp::smpte_standard_numbers::ST2110_20_2022,
+            sdp::type_parameters::type_W,
+            37,
+            42,
+            57,
+            sdp::timestamp_modes::SAMP,
+            82
+        }
+    };
+
+    std::pair<nmos::sdp_parameters, nmos::video_raw_parameters> zero_troff_tsdelay{
+        {
+            U("zero_troff_tsdelay"),
+            sdp::media_types::video,
+            {
+                123,
+                U("raw"),
+                90000
+            },
+            {
+                { U("sampling"), U("UNSPECIFIED") },
+                { U("depth"), U("16") },
+                { U("width"), U("9999") },
+                { U("height"), U("6666") },
+                { U("exactframerate"), U("123") },
+                { U("interlace"), {} },
+                { U("segmented"), {} },
+                { U("TCS"), U("ST2115LOGS3") },
+                { U("colorimetry"), U("BT2100") },
+                { U("RANGE"), U("FULLPROTECT") },
+                { U("PAR"), U("12:11") },
+                { U("PM"), U("2110BPM") },
+                { U("SSN"), U("ST2110-20:2022") },
+                { U("TP"), U("2110TPW") },
                 { U("TROFF"), U("0") },
                 { U("CMAX"), U("42") },
                 { U("MAXUDP"), U("57") },
@@ -598,20 +652,20 @@ BST_TEST_CASE(testSdpParametersVideoRaw)
             sdp::packing_modes::block,
             sdp::smpte_standard_numbers::ST2110_20_2022,
             sdp::type_parameters::type_W,
-            uint32_t(0),
+            0U,
             42,
             57,
             sdp::timestamp_modes::SAMP,
-            uint32_t(0)
+            0U
         }
     };
 
-    for (auto& test : { example, wacky })
+    for (auto& test : { example, wacky, zero_troff_tsdelay })
     {
         auto made = nmos::make_video_raw_sdp_parameters(test.first.session_name, test.second, test.first.rtpmap.payload_type);
-        sdp_test::check_sdp_parameters(test.first, made);
+        nmos::check_sdp_parameters(test.first, made);
         auto roundtripped = nmos::make_video_raw_sdp_parameters(made.session_name, nmos::get_video_raw_parameters(made), made.rtpmap.payload_type);
-        sdp_test::check_sdp_parameters(test.first, roundtripped);
+        nmos::check_sdp_parameters(test.first, roundtripped);
     }
 }
 
@@ -657,6 +711,34 @@ BST_TEST_CASE(testSdpParametersAudioL)
             {
                 { U("channel-order"), U("SMPTE2110.(M,M,M,M,ST,U02)") },
                 { U("TSMODE"), U("SAMP") },
+                { U("TSDELAY"), U("82") }
+            },
+            {},
+            0.333
+        },
+        {
+            1,
+            16,
+            96000,
+            U("SMPTE2110.(M,M,M,M,ST,U02)"), // not testing nmos::make_fmtp_channel_order here
+            sdp::timestamp_modes::SAMP,
+            82,
+            0.333
+        }
+    };
+
+    std::pair<nmos::sdp_parameters, nmos::audio_L_parameters> zero_tsdelay{
+        {
+            U("zero_tsdelay"),
+            sdp::media_types::audio,
+            {
+                123,
+                U("L16"),
+                96000
+            },
+            {
+                { U("channel-order"), U("SMPTE2110.(M,M,M,M,ST,U02)") },
+                { U("TSMODE"), U("SAMP") },
                 { U("TSDELAY"), U("0") }
             },
             {},
@@ -668,17 +750,17 @@ BST_TEST_CASE(testSdpParametersAudioL)
             96000,
             U("SMPTE2110.(M,M,M,M,ST,U02)"), // not testing nmos::make_fmtp_channel_order here
             sdp::timestamp_modes::SAMP,
-            uint32_t(0),
+            0U,
             0.333
         }
     };
 
-    for (auto& test : { example, wacky })
+    for (auto& test : { example, wacky, zero_tsdelay })
     {
         auto made = nmos::make_audio_L_sdp_parameters(test.first.session_name, test.second, test.first.rtpmap.payload_type);
-        sdp_test::check_sdp_parameters(test.first, made);
+        nmos::check_sdp_parameters(test.first, made);
         auto roundtripped = nmos::make_audio_L_sdp_parameters(made.session_name, nmos::get_audio_L_parameters(made), made.rtpmap.payload_type);
-        sdp_test::check_sdp_parameters(test.first, roundtripped);
+        nmos::check_sdp_parameters(test.first, roundtripped);
     }
 }
 
@@ -727,6 +809,39 @@ BST_TEST_CASE(testSdpParametersVideoSmpte291)
                 { U("exactframerate"), U("60000/1001") },
                 { U("TM"), U("CTM") },
                 { U("SSN"), U("ST2110-40:2021") },
+                { U("TROFF"), U("37") },
+                { U("TSMODE"), U("SAMP") },
+                { U("TSDELAY"), U("82") }
+            }
+        },
+        {
+            { { 0xAB, 0xCD }, { 0xEF, 0x01 } },
+            nmos::vpid_codes::vpid_1_5Gbps_720_line,
+            nmos::rates::rate59_94,
+            sdp::transmission_models::compatible,
+            sdp::smpte_standard_numbers::ST2110_40_2023,
+            37,
+            sdp::timestamp_modes::SAMP,
+            82
+        }
+    };
+
+    std::pair<nmos::sdp_parameters, nmos::video_smpte291_parameters> zero_troff_tsdelay{
+        {
+            U("zero_troff_tsdelay"),
+            sdp::media_types::video,
+            {
+                123,
+                U("smpte291"),
+                90000
+            },
+            {
+                { U("DID_SDID"), U("{0xAB,0xCD}") },
+                { U("DID_SDID"), U("{0xEF,0x01}") },
+                { U("VPID_Code"), U("132") },
+                { U("exactframerate"), U("60000/1001") },
+                { U("TM"), U("CTM") },
+                { U("SSN"), U("ST2110-40:2021") },
                 { U("TROFF"), U("0") },
                 { U("TSMODE"), U("SAMP") },
                 { U("TSDELAY"), U("0") }
@@ -738,18 +853,18 @@ BST_TEST_CASE(testSdpParametersVideoSmpte291)
             nmos::rates::rate59_94,
             sdp::transmission_models::compatible,
             sdp::smpte_standard_numbers::ST2110_40_2023,
-            uint32_t(0),
+            0U,
             sdp::timestamp_modes::SAMP,
-            uint32_t(0)
+            0U
         }
     };
 
-    for (auto& test : { example, wacky })
+    for (auto& test : { example, wacky, zero_troff_tsdelay })
     {
         auto made = nmos::make_video_smpte291_sdp_parameters(test.first.session_name, test.second, test.first.rtpmap.payload_type);
-        sdp_test::check_sdp_parameters(test.first, made);
+        nmos::check_sdp_parameters(test.first, made);
         auto roundtripped = nmos::make_video_smpte291_sdp_parameters(made.session_name, nmos::get_video_smpte291_parameters(made), made.rtpmap.payload_type);
-        sdp_test::check_sdp_parameters(test.first, roundtripped);
+        nmos::check_sdp_parameters(test.first, roundtripped);
     }
 }
 
@@ -786,20 +901,40 @@ BST_TEST_CASE(testSdpParametersVideoSmpte2022_6)
             },
             {
                 { U("TP"), U("2110TPW") },
+                { U("TROFF"), U("37") }
+            }
+        },
+        {
+             sdp::type_parameters::type_W,
+             37
+        }
+    };
+
+    std::pair<nmos::sdp_parameters, nmos::video_SMPTE2022_6_parameters> zero_troff{
+        {
+            U("zero_troff"),
+            sdp::media_types::video,
+            {
+                123,
+                U("SMPTE2022-6"),
+                27000000
+            },
+            {
+                { U("TP"), U("2110TPW") },
                 { U("TROFF"), U("0") }
             }
         },
         {
              sdp::type_parameters::type_W,
-             uint32_t(0)
+             0U
         }
     };
 
-    for (auto& test : { example, wacky })
+    for (auto& test : { example, wacky, zero_troff })
     {
         auto made = nmos::make_video_SMPTE2022_6_sdp_parameters(test.first.session_name, test.second, test.first.rtpmap.payload_type);
-        sdp_test::check_sdp_parameters(test.first, made);
+        nmos::check_sdp_parameters(test.first, made);
         auto roundtripped = nmos::make_video_SMPTE2022_6_sdp_parameters(made.session_name, nmos::get_video_SMPTE2022_6_parameters(made), made.rtpmap.payload_type);
-        sdp_test::check_sdp_parameters(test.first, roundtripped);
+        nmos::check_sdp_parameters(test.first, roundtripped);
     }
 }

--- a/Development/nmos/test/video_jxsv_test.cpp
+++ b/Development/nmos/test/video_jxsv_test.cpp
@@ -169,11 +169,11 @@ BST_TEST_CASE(testSdpParametersVideoJpegXs)
             sdp::ranges::FULL,
             sdp::smpte_standard_numbers::ST2110_20_2022,
             sdp::type_parameters::type_W,
-            0,
+            uint32_t(0),
             42,
             57,
             sdp::timestamp_modes::SAMP,
-            0,
+            uint32_t(0),
             200000
         }
     };

--- a/Development/nmos/test/video_jxsv_test.cpp
+++ b/Development/nmos/test/video_jxsv_test.cpp
@@ -125,10 +125,11 @@ BST_TEST_CASE(testSdpParametersVideoJpegXs)
                 90000
             },
             {
-                { U("packetmode"), U("0") },
-                { U("profile"), U("High444.12") },
-                { U("level"), U("1k-1") },
-                { U("sublevel"), U("Sublev3bpp") },
+                { U("packetmode"), U("1") },
+                { U("transmode"), U("0") },
+                { U("profile"), U("Light444.12") },
+                { U("level"), U("Bayer16k-1") },
+                { U("sublevel"), U("Full") },
                 { U("sampling"), U("UNSPECIFIED") },
                 { U("width"), U("9999") },
                 { U("height"), U("6666") },
@@ -136,7 +137,67 @@ BST_TEST_CASE(testSdpParametersVideoJpegXs)
                 { U("depth"), U("16") },
                 { U("colorimetry"), U("BT2100") },
                 { U("TCS"), U("UNSPECIFIED") },
-                { U("RANGE"), U("FULL") },
+                { U("RANGE"), U("NARROW") },
+                { U("SSN"), U("ST2110-20:2022") },
+                { U("TP"), U("2110TPW") },
+                { U("TROFF"), U("37") },
+                { U("CMAX"), U("42") },
+                { U("MAXUDP"), U("57") },
+                { U("TSMODE"), U("SAMP") },
+                { U("TSDELAY"), U("82") }
+            },
+            200000
+        },
+        {
+            sdp::video_jxsv::packetization_mode::slice,
+            sdp::video_jxsv::transmission_mode::out_of_order,
+            sdp::video_jxsv::profiles::Light444_12,
+            sdp::video_jxsv::levels::Bayer16k_1,
+            sdp::video_jxsv::sublevels::Full,
+            sdp::samplings::UNSPECIFIED,
+            16,
+            9999,
+            6666,
+            { 123, 1 },
+            false,
+            false,
+            sdp::transfer_characteristic_systems::UNSPECIFIED,
+            sdp::colorimetries::BT2100,
+            sdp::ranges::NARROW,
+            sdp::smpte_standard_numbers::ST2110_20_2022,
+            sdp::type_parameters::type_W,
+            37,
+            42,
+            57,
+            sdp::timestamp_modes::SAMP,
+            82,
+            200000
+        }
+    };
+
+    std::pair<nmos::sdp_parameters, nmos::video_jxsv_parameters> zero_troff_tsdelay{
+        {
+            U("zero_troff_tsdelay"),
+            sdp::media_types::video,
+            {
+                123,
+                U("jxsv"),
+                90000
+            },
+            {
+                { U("packetmode"), U("1") },
+                { U("transmode"), U("0") },
+                { U("profile"), U("Light444.12") },
+                { U("level"), U("Bayer16k-1") },
+                { U("sublevel"), U("Full") },
+                { U("sampling"), U("UNSPECIFIED") },
+                { U("width"), U("9999") },
+                { U("height"), U("6666") },
+                { U("exactframerate"), U("123") },
+                { U("depth"), U("16") },
+                { U("colorimetry"), U("BT2100") },
+                { U("TCS"), U("UNSPECIFIED") },
+                { U("RANGE"), U("NARROW") },
                 { U("SSN"), U("ST2110-20:2022") },
                 { U("TP"), U("2110TPW") },
                 { U("TROFF"), U("0") },
@@ -148,11 +209,11 @@ BST_TEST_CASE(testSdpParametersVideoJpegXs)
             200000
         },
         {
-            sdp::video_jxsv::packetization_mode::codestream,
-            sdp::video_jxsv::transmission_mode::sequential,
-            sdp::video_jxsv::profiles::High444_12,
-            sdp::video_jxsv::levels::Level1k_1,
-            sdp::video_jxsv::sublevels::Sublev3bpp,
+            sdp::video_jxsv::packetization_mode::slice,
+            sdp::video_jxsv::transmission_mode::out_of_order,
+            sdp::video_jxsv::profiles::Light444_12,
+            sdp::video_jxsv::levels::Bayer16k_1,
+            sdp::video_jxsv::sublevels::Full,
             sdp::samplings::UNSPECIFIED,
             16,
             9999,
@@ -162,23 +223,23 @@ BST_TEST_CASE(testSdpParametersVideoJpegXs)
             false,
             sdp::transfer_characteristic_systems::UNSPECIFIED,
             sdp::colorimetries::BT2100,
-            sdp::ranges::FULL,
+            sdp::ranges::NARROW,
             sdp::smpte_standard_numbers::ST2110_20_2022,
             sdp::type_parameters::type_W,
-            uint32_t(0),
+            0U,
             42,
             57,
             sdp::timestamp_modes::SAMP,
-            uint32_t(0),
+            0U,
             200000
         }
     };
 
-    for (auto& test : { example, wacky })
+    for (auto& test : { example, wacky, zero_troff_tsdelay })
     {
         auto made = nmos::make_video_jxsv_sdp_parameters(test.first.session_name, test.second, test.first.rtpmap.payload_type);
-        sdp_test::check_sdp_parameters(test.first, made);
+        nmos::check_sdp_parameters(test.first, made);
         auto roundtripped = nmos::make_video_jxsv_sdp_parameters(made.session_name, nmos::get_video_jxsv_parameters(made), made.rtpmap.payload_type);
-        sdp_test::check_sdp_parameters(test.first, roundtripped);
+        nmos::check_sdp_parameters(test.first, roundtripped);
     }
 }

--- a/Development/nmos/test/video_jxsv_test.cpp
+++ b/Development/nmos/test/video_jxsv_test.cpp
@@ -86,9 +86,7 @@ BST_TEST_CASE(testSdpParametersVideoJpegXs)
                 { U("SSN"), U("ST2110-22:2019") },
                 { U("TP"), U("2110TPN") }
             },
-            {
-                116000
-            }
+            116000
         },
         {
             sdp::video_jxsv::packetization_mode::codestream,
@@ -147,9 +145,7 @@ BST_TEST_CASE(testSdpParametersVideoJpegXs)
                 { U("TSMODE"), U("SAMP") },
                 { U("TSDELAY"), U("0") }
             },
-            {
-                200000
-            }
+            200000
         },
         {
             sdp::video_jxsv::packetization_mode::codestream,

--- a/Development/nmos/test/video_jxsv_test.cpp
+++ b/Development/nmos/test/video_jxsv_test.cpp
@@ -3,6 +3,7 @@
 
 #include "bst/test/test.h"
 #include "nmos/json_fields.h"
+#include "nmos/test/sdp_test_utils.h"
 #include "sdp/sdp.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -55,4 +56,133 @@ a=fmtp:112 packetmode=0; profile=High444.12; level=1k-1; sublevel=Sublev3bpp; de
         if (!actual_line.empty() && '\r' == actual_line.back()) actual_line.pop_back();
         BST_CHECK_EQUAL(expected_line, actual_line);
     } while (!expected.fail() && !actual.fail());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testSdpParametersVideoJpegXs)
+{
+    std::pair<nmos::sdp_parameters, nmos::video_jxsv_parameters> example{
+        {
+            U("example"),
+            sdp::media_types::video,
+            {
+                112,
+                U("jxsv"),
+                90000
+            },
+            {
+                { U("packetmode"), U("0") },
+                { U("profile"), U("High444.12") },
+                { U("level"), U("1k-1") },
+                { U("sublevel"), U("Sublev3bpp") },
+                { U("sampling"), U("YCbCr-4:2:2") },
+                { U("width"), U("1280") },
+                { U("height"), U("720") },
+                { U("exactframerate"), U("60000/1001") },
+                { U("depth"), U("10") },
+                { U("colorimetry"), U("BT709") },
+                { U("TCS"), U("SDR") },
+                { U("RANGE"), U("FULL") },
+                { U("SSN"), U("ST2110-22:2019") },
+                { U("TP"), U("2110TPN") }
+            },
+            {
+                116000
+            }
+        },
+        {
+            sdp::video_jxsv::packetization_mode::codestream,
+            sdp::video_jxsv::transmission_mode::sequential,
+            sdp::video_jxsv::profiles::High444_12,
+            sdp::video_jxsv::levels::Level1k_1,
+            sdp::video_jxsv::sublevels::Sublev3bpp,
+            sdp::samplings::YCbCr_4_2_2,
+            10,
+            1280,
+            720,
+            nmos::rates::rate59_94,
+            false,
+            false,
+            sdp::transfer_characteristic_systems::SDR,
+            sdp::colorimetries::BT709,
+            sdp::ranges::FULL,
+            sdp::smpte_standard_numbers::ST2110_22_2019,
+            sdp::type_parameters::type_N,
+            {},
+            {},
+            {},
+            {},
+            {},
+            116000
+        }
+    };
+
+    std::pair<nmos::sdp_parameters, nmos::video_jxsv_parameters> wacky{
+        {
+            U("example"),
+            sdp::media_types::video,
+            {
+                123,
+                U("jxsv"),
+                90000
+            },
+            {
+                { U("packetmode"), U("0") },
+                { U("profile"), U("High444.12") },
+                { U("level"), U("1k-1") },
+                { U("sublevel"), U("Sublev3bpp") },
+                { U("sampling"), U("UNSPECIFIED") },
+                { U("width"), U("9999") },
+                { U("height"), U("6666") },
+                { U("exactframerate"), U("123") },
+                { U("depth"), U("16") },
+                { U("colorimetry"), U("BT2100") },
+                { U("TCS"), U("UNSPECIFIED") },
+                { U("RANGE"), U("FULL") },
+                { U("SSN"), U("ST2110-20:2022") },
+                { U("TP"), U("2110TPW") },
+                { U("TROFF"), U("0") },
+                { U("CMAX"), U("42") },
+                { U("MAXUDP"), U("57") },
+                { U("TSMODE"), U("SAMP") },
+                { U("TSDELAY"), U("0") }
+            },
+            {
+                200000
+            }
+        },
+        {
+            sdp::video_jxsv::packetization_mode::codestream,
+            sdp::video_jxsv::transmission_mode::sequential,
+            sdp::video_jxsv::profiles::High444_12,
+            sdp::video_jxsv::levels::Level1k_1,
+            sdp::video_jxsv::sublevels::Sublev3bpp,
+            sdp::samplings::UNSPECIFIED,
+            16,
+            9999,
+            6666,
+            { 123, 1 },
+            false,
+            false,
+            sdp::transfer_characteristic_systems::UNSPECIFIED,
+            sdp::colorimetries::BT2100,
+            sdp::ranges::FULL,
+            sdp::smpte_standard_numbers::ST2110_20_2022,
+            sdp::type_parameters::type_W,
+            0,
+            42,
+            57,
+            sdp::timestamp_modes::SAMP,
+            0,
+            200000
+        }
+    };
+
+    for (auto& test : { example, wacky })
+    {
+        auto made = nmos::make_video_jxsv_sdp_parameters(test.first.session_name, test.second, test.first.rtpmap.payload_type);
+        sdp_test::check_sdp_parameters(test.first, made);
+        auto roundtripped = nmos::make_video_jxsv_sdp_parameters(made.session_name, nmos::get_video_jxsv_parameters(made), made.rtpmap.payload_type);
+        sdp_test::check_sdp_parameters(test.first, roundtripped);
+    }
 }

--- a/Development/nmos/test/video_jxsv_test.cpp
+++ b/Development/nmos/test/video_jxsv_test.cpp
@@ -117,7 +117,7 @@ BST_TEST_CASE(testSdpParametersVideoJpegXs)
 
     std::pair<nmos::sdp_parameters, nmos::video_jxsv_parameters> wacky{
         {
-            U("example"),
+            U("wacky"),
             sdp::media_types::video,
             {
                 123,

--- a/Development/nmos/video_jxsv.cpp
+++ b/Development/nmos/video_jxsv.cpp
@@ -176,11 +176,11 @@ namespace nmos
         // additional parameters introduced by SMPTE specs since then...
         if (!params.ssn.empty()) fmtp.push_back({ sdp::fields::smpte_standard_number, params.ssn.name });
         if (!params.tp.empty()) fmtp.push_back({ sdp::fields::type_parameter, params.tp.name });
-        if (0 != params.troff) fmtp.push_back({ sdp::fields::TROFF, utility::ostringstreamed(params.troff) });
+        if (params.troff) fmtp.push_back({ sdp::fields::TROFF, utility::ostringstreamed(*params.troff) });
         if (0 != params.cmax) fmtp.push_back({ sdp::fields::CMAX, utility::ostringstreamed(params.cmax) });
         if (0 != params.maxudp) fmtp.push_back({ sdp::fields::max_udp_packet_size, utility::ostringstreamed(params.maxudp) });
         if (!params.tsmode.empty()) fmtp.push_back({ sdp::fields::timestamp_mode, params.tsmode.name });
-        if (0 != params.tsdelay) fmtp.push_back({ sdp::fields::timestamp_delay, utility::ostringstreamed(params.tsdelay) });
+        if (params.tsdelay) fmtp.push_back({ sdp::fields::timestamp_delay, utility::ostringstreamed(*params.tsdelay) });
 
         return{ session_name, sdp::media_types::video, rtpmap, fmtp, params.bit_rate, {}, {}, {}, media_stream_ids, ts_refclk };
     }

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -283,13 +283,13 @@ namespace nmos
 
         // additional fmtp parameters from ST 2110-21:2022
         sdp::type_parameter tp;
-        uint32_t troff; // if omitted (zero), assume default
+        bst::optional<uint32_t> troff; // if omitted, assume default
         uint32_t cmax; // if omitted (zero), assume max defined for tp
 
         // additional fmtp parameters from ST 2110-10:2022
         uint32_t maxudp; // if omitted (zero), assume the Standard UP Size Limit
         sdp::timestamp_mode tsmode; // if omitted (empty), assume sdp::timestamp_modes::NEW
-        uint32_t tsdelay;
+        bst::optional<uint32_t> tsdelay;
 
         // bandwidth
         uint64_t bit_rate; // transport bit rate
@@ -314,11 +314,11 @@ namespace nmos
             sdp::range range,
             sdp::smpte_standard_number ssn,
             sdp::type_parameter tp,
-            uint32_t troff,
+            bst::optional<uint32_t> troff,
             uint32_t cmax,
             uint32_t maxudp,
             sdp::timestamp_mode tsmode,
-            uint32_t tsdelay,
+            bst::optional<uint32_t> tsdelay,
             uint64_t bit_rate
         )
             : packetmode(packetmode)


### PR DESCRIPTION
SMPTE ST 2110-10:2022: `TSDELAY shall be a positive number or zero`
See SMPTE ST 2110-10:2022 Professional Media over Managed IP Networks: System Timing and Definitions, Annex B SDP Example (Informative)

SMPTE ST 2110-21:2022: `TROFF shall be a positive number or zero`
See SMPTE ST 2110-21:2022 Professional Media over Managed IP Networks: Traffic Shaping and Delivery Timing for Video, Section 6.2 Virtual Receiver Buffer Packet Read Schedule (PRS) Parameters