### PR TITLE
Fix advertiser service

### DIFF
--- a/Development/mdns/service_advertiser_impl.cpp
+++ b/Development/mdns/service_advertiser_impl.cpp
@@ -69,7 +69,7 @@ namespace mdns_details
         }
     }
 
-    static bool register_address(DNSServiceRef client, const std::string& host_name, const std::string& ip_address_, const std::string& domain, std::uint32_t interface_id, slog::base_gate& gate)
+    static bool register_address(DNSServiceRef& client, const std::string& host_name, const std::string& ip_address_, const std::string& domain, std::uint32_t interface_id, slog::base_gate& gate)
     {
         // since empty host_name is valid for other functions, check that logic error here
         if (host_name.empty()) return false;


### PR DESCRIPTION
Thank you to `Niitsu Keita-san` from Sony, who has pointed out that the newly created client (the _DNSServiceRef_t*) will not be reflected to the outside function. In this case, the client will not be released when the advertiser is destructed, i.e., causing a memory leak.