### PR TITLE
Discovery mode revisited

### DIFF
--- a/Development/nmos-cpp-node/config.json
+++ b/Development/nmos-cpp-node/config.json
@@ -235,9 +235,6 @@
     // proxy_port [registry, node]: forward proxy port
     //"proxy_port": 8080,
 
-    // discovery_mode [node]: whether the discovered host name (1) or resolved addresses (2) are used to construct request URLs for Registration APIs or System APIs
-    //"discovery_mode": 1,
-
     // href_mode [registry, node]: whether the host name (1), addresses (2) or both (3) are used to construct response headers, and host and URL fields in the data model
     //"href_mode": 1,
 

--- a/Development/nmos/authorization_operation.cpp
+++ b/Development/nmos/authorization_operation.cpp
@@ -1200,7 +1200,7 @@ namespace nmos
                     const auto service = top_authorization_service(model.settings);
 
                     const auto auth_uri = service.second;
-                    client.reset(new web::http::client::http_client(auth_uri, make_authorization_http_client_config(model.settings, load_ca_certificates, gate)));
+                    client = nmos::details::make_http_client(auth_uri, make_authorization_http_client_config(model.settings, load_ca_certificates, gate));
 
                     auto token = cancellation_source.get_token();
 

--- a/Development/nmos/authorization_state.h
+++ b/Development/nmos/authorization_state.h
@@ -28,7 +28,7 @@ namespace nmos
                 , immediate(true)
                 , received(false) {}
 
-            pubkeys_shared_state(web::http::client::http_client client, nmos::api_version version, web::uri issuer)//, bool one_shot = false)
+            pubkeys_shared_state(web::http::client::http_client client, nmos::api_version version, web::uri issuer)
                 : engine(seeder)
                 , client(std::unique_ptr<web::http::client::http_client>(new web::http::client::http_client(client)))
                 , version(std::move(version))

--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -256,6 +256,26 @@ namespace nmos
         return config;
     }
 
+    namespace details
+    {
+        // make a client for the specified base_uri and config, with Host header sneakily stashed in user info
+        std::unique_ptr<web::http::client::http_client> make_http_client(const web::uri& base_uri, const web::http::client::http_client_config& client_config)
+        {
+            // unstash the Host header
+            // cf. nmos::details::resolve_service
+            const auto& host_name = base_uri.user_info();
+            std::unique_ptr<web::http::client::http_client> client(new web::http::client::http_client(web::uri_builder(base_uri).set_user_info({}).to_uri(), client_config));
+            if (!host_name.empty())
+            {
+                client->add_handler([host_name](web::http::http_request request, std::shared_ptr<web::http::http_pipeline_stage> next_stage) -> pplx::task<web::http::http_response>
+                {
+                    request.headers().add(web::http::header_names::host, host_name);
+                    return next_stage->propagate(request);
+                });
+            }
+            return client;
+        }
+    }
 
     // make a request with logging
     pplx::task<web::http::http_response> api_request(web::http::client::http_client client, web::http::http_request request, slog::base_gate& gate, const pplx::cancellation_token& token)

--- a/Development/nmos/client_utils.h
+++ b/Development/nmos/client_utils.h
@@ -31,6 +31,12 @@ namespace nmos
     web::websockets::client::websocket_client_config make_websocket_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, nmos::experimental::get_authorization_bearer_token_handler get_authorization_bearer_token, slog::base_gate& gate);
     web::websockets::client::websocket_client_config make_websocket_client_config(const nmos::settings& settings, load_ca_certificates_handler load_ca_certificates, slog::base_gate& gate);
 
+    namespace details
+    {
+        // make a client for the specified base_uri and config, with Host header sneakily stashed in user info
+        std::unique_ptr<web::http::client::http_client> make_http_client(const web::uri& base_uri_with_host_name_in_user_info, const web::http::client::http_client_config& client_config);
+    }
+
     // make an API request with logging
     pplx::task<web::http::http_response> api_request(web::http::client::http_client client, web::http::http_request request, slog::base_gate& gate, const pplx::cancellation_token& token = pplx::cancellation_token::none());
     pplx::task<web::http::http_response> api_request(web::http::client::http_client client, const web::http::method& mtd, slog::base_gate& gate, const pplx::cancellation_token& token = pplx::cancellation_token::none());

--- a/Development/nmos/node_system_behaviour.cpp
+++ b/Development/nmos/node_system_behaviour.cpp
@@ -396,7 +396,7 @@ namespace nmos
                 if (!state.client)
                 {
                     const auto base_uri = top_system_service(model.settings);
-                    state.client.reset(new web::http::client::http_client(base_uri, make_system_client_config(model.settings, load_ca_certificates, gate)));
+                    state.client = nmos::details::make_http_client(base_uri, make_system_client_config(model.settings, load_ca_certificates, gate));
                 }
 
                 auto token = cancellation_source.get_token();

--- a/Development/nmos/ocsp_behaviour.cpp
+++ b/Development/nmos/ocsp_behaviour.cpp
@@ -347,7 +347,7 @@ namespace nmos
                 {
                     const auto ocsp_uri = ocsp_uris.front();
                     const auto secure = web::is_secure_uri_scheme(ocsp_uri.scheme());
-                    state.client.reset(new web::http::client::http_client(ocsp_uri, make_ocsp_client_config(secure, model.settings, state.load_ca_certificates, gate)));
+                    state.client = nmos::details::make_http_client(ocsp_uri, make_ocsp_client_config(secure, model.settings, state.load_ca_certificates, gate));
                 }
 
                 auto token = cancellation_source.get_token();

--- a/Development/nmos/settings.h
+++ b/Development/nmos/settings.h
@@ -294,9 +294,6 @@ namespace nmos
             // proxy_port [registry, node]: forward proxy port
             const web::json::field_as_integer_or proxy_port{ U("proxy_port"), 8080 };
 
-            // discovery_mode [node]: whether the discovered host name (1) or resolved addresses (2) are used to construct request URLs for Registration APIs or System APIs
-            const web::json::field_as_integer_or discovery_mode{ U("discovery_mode"), 0 }; // when omitted, a default heuristic is used
-
             // href_mode [registry, node]: whether the host name (1), addresses (2) or both (3) are used to construct response headers, and host and URL fields in the data model
             const web::json::field_as_integer_or href_mode{ U("href_mode"), 0 }; // when omitted, a default heuristic is used
 


### PR DESCRIPTION
POC of replacing `discovery_mode` setting with sneakily stashing `Host` header in the `web::uri` values returned by `nmos::details::resolve_service` and using this in a `web::http::http_pipeline_stage`.

Resolves #357

Using the user info in this way is a bit icky. But the other option is to make lots of places that pass `web::uri` around pass a pair of the URI with the `Host` header. This way has the side effect of making the values in the settings look something like this whether doing HTTP or HTTPS:

```
"registration_services": [
  "http://reg0.example.com@192.0.2.0:80/x-nmos/registration/v1.3",
  "http://reg0.example.com@198.51.100.0:80/x-nmos/registration/v1.3",
  "http://reg0.example.com@203.0.113.0:80/x-nmos/registration/v1.3",
  "http://reg1.example.com@192.0.2.1:80/x-nmos/registration/v1.3",
  "http://reg1.example.com@198.51.100.1:80/x-nmos/registration/v1.3",
  "http://reg1.example.com@203.0.113.1:80/x-nmos/registration/v1.3",
  ...
]
```

If anyone is relying on that property e.g. to populate UI, that would be an unexpected change. :-/

(However, it does also allow the existing `registry_address` setting to be populated in the same way, and that just works too.)
