### PR TITLE
Use hostname in secure mode for the resolved service

### DIFF
--- a/Development/nmos/client_utils.cpp
+++ b/Development/nmos/client_utils.cpp
@@ -263,14 +263,24 @@ namespace nmos
         {
             // unstash the host name for the Host header
             // cf. nmos::details::resolve_service
-            std::unique_ptr<web::http::client::http_client> client(new web::http::client::http_client(web::uri_builder(base_uri).set_user_info({}).to_uri(), client_config));
+            // don't bother clearing user_info since http_client makes no use of it
+            // see https://github.com/microsoft/cpprestsdk/issues/3
+            std::unique_ptr<web::http::client::http_client> client(new web::http::client::http_client(base_uri, client_config));
             if (!base_uri.user_info().empty())
             {
                 auto host = base_uri.user_info();
-                if (base_uri.port() > 0)
+
+                // hmm, in secure mode, don't append the port to the Host header
+                // because both calc_cn_host in cpprestsdk/Release/src/http/client/http_client_asio.cpp
+                // and winhttp_client::send_request in cpprestsdk/Release/src/http/client/http_client_winhttp.cpp
+                // compare the entire Host header value with the certificate Common Name
+                // which causes an SSL handshake error
+                // see https://github.com/microsoft/cpprestsdk/issues/1790
+                if (base_uri.port() > 0 && !web::is_secure_uri_scheme(base_uri.scheme()))
                 {
                     host.append(U(":")).append(utility::conversions::details::to_string_t(base_uri.port()));
                 }
+
                 client->add_handler([host](web::http::http_request request, std::shared_ptr<web::http::http_pipeline_stage> next_stage) -> pplx::task<web::http::http_response>
                 {
                     request.headers().add(web::http::header_names::host, host);

--- a/Development/nmos/node_behaviour.cpp
+++ b/Development/nmos/node_behaviour.cpp
@@ -554,7 +554,8 @@ namespace nmos
                             // Location may be a relative (to the request URL) or absolute URL
                             auto request_uri = web::uri_builder(client.base_uri()).append_path(U("/resource")).to_uri();
                             auto location_uri = request_uri.resolve_uri(response.headers()[web::http::header_names::location]);
-                            deletion = api_request(web::http::client::http_client(location_uri, client.client_config()), web::http::methods::DEL, gate, token);
+                            auto deletion_client = nmos::details::make_http_client(location_uri, client.client_config());
+                            deletion = api_request(*deletion_client, web::http::methods::DEL, gate, token);
                         }
                         else
                         {

--- a/Development/nmos/node_behaviour.cpp
+++ b/Development/nmos/node_behaviour.cpp
@@ -784,7 +784,7 @@ namespace nmos
 
                     self_id = id_type.first;
 
-                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Registering nmos-cpp node with the Registration API at: " << registration_client->base_uri().host() << ":" << registration_client->base_uri().port();
+                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Registering nmos-cpp node with the Registration API at: " << registration_client->base_uri().to_string();
 
                     auto token = cancellation_source.get_token();
                     request = details::request_registration(*registration_client, events.at(0), gate, token).then([&](pplx::task<void> finally)
@@ -908,7 +908,7 @@ namespace nmos
                     // "The first interaction with a new Registration API [after a server side or connectivity issue]
                     // should be a heartbeat to confirm whether whether the Node is still present in the registry"
 
-                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Attempting registration heartbeats with the Registration API at: " << registration_client->base_uri().host() << ":" << registration_client->base_uri().port();
+                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Attempting registration heartbeats with the Registration API at: " << registration_client->base_uri().to_string();
 
                     node_registered = false;
 

--- a/Development/nmos/node_server.cpp
+++ b/Development/nmos/node_server.cpp
@@ -5,6 +5,7 @@
 #include "nmos/channelmapping_activation.h"
 #include "nmos/events_api.h"
 #include "nmos/events_ws_api.h"
+#include "nmos/is04_versions.h"
 #include "nmos/logging_api.h"
 #include "nmos/manifest_api.h"
 #include "nmos/model.h"
@@ -25,7 +26,13 @@ namespace nmos
         {
             // Log the API addresses we'll be using
 
-            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Configuring nmos-cpp node with its primary Node API at: " << nmos::get_host(node_model.settings) << ":" << nmos::fields::node_port(node_model.settings);
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Configuring nmos-cpp node with its primary Node API at: "
+                << web::uri_builder()
+                .set_scheme(nmos::http_scheme(node_model.settings))
+                .set_host(nmos::get_host(node_model.settings))
+                .set_port(nmos::fields::node_port(node_model.settings))
+                .set_path(U("/x-nmos/node/") + nmos::make_api_version(*nmos::is04_versions::from_settings(node_model.settings).rbegin()))
+                .to_string();
 
             nmos::server node_server{ node_model };
 

--- a/Development/nmos/registry_server.cpp
+++ b/Development/nmos/registry_server.cpp
@@ -33,9 +33,27 @@ namespace nmos
         {
             // Log the API addresses we'll be using
 
-            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Configuring nmos-cpp registry with its primary Node API at: " << nmos::get_host(registry_model.settings) << ":" << nmos::fields::node_port(registry_model.settings);
-            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Configuring nmos-cpp registry with its primary Registration API at: " << nmos::get_host(registry_model.settings) << ":" << nmos::fields::registration_port(registry_model.settings);
-            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Configuring nmos-cpp registry with its primary Query API at: " << nmos::get_host(registry_model.settings) << ":" << nmos::fields::query_port(registry_model.settings);
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Configuring nmos-cpp registry with its primary Node API at: "
+                << web::uri_builder()
+                .set_scheme(nmos::http_scheme(registry_model.settings))
+                .set_host(nmos::get_host(registry_model.settings))
+                .set_port(nmos::fields::node_port(registry_model.settings))
+                .set_path(U("/x-nmos/node/") + nmos::make_api_version(*nmos::is04_versions::from_settings(registry_model.settings).rbegin()))
+                .to_string();
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Configuring nmos-cpp registry with its primary Registration API at: "
+                << web::uri_builder()
+                .set_scheme(nmos::http_scheme(registry_model.settings))
+                .set_host(nmos::get_host(registry_model.settings))
+                .set_port(nmos::fields::registration_port(registry_model.settings))
+                .set_path(U("/x-nmos/registration/") + nmos::make_api_version(*nmos::is04_versions::from_settings(registry_model.settings).rbegin()))
+                .to_string();
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Configuring nmos-cpp registry with its primary Query API at: "
+                << web::uri_builder()
+                .set_scheme(nmos::http_scheme(registry_model.settings))
+                .set_host(nmos::get_host(registry_model.settings))
+                .set_port(nmos::fields::query_port(registry_model.settings))
+                .set_path(U("/x-nmos/query/") + nmos::make_api_version(*nmos::is04_versions::from_settings(registry_model.settings).rbegin()))
+                .to_string();
 
             nmos::server registry_server{ registry_model };
 


### PR DESCRIPTION
- host name should be used instead of the IP adddress for the host in the service uri.
- the port number used in the Host header causes SSL handshake Error, disable it for now.