### PR TITLE
Require CMake 3.24 when CMAKE_PROJECT_TOP_LEVEL_INCLUDES is specified

### DIFF
--- a/Development/CMakeLists.txt
+++ b/Development/CMakeLists.txt
@@ -1,4 +1,12 @@
-cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+# the injection point may be used to configure conan, but that requires CMake 3.24 or higher
+# so avoid confusion and reject invocations which attempt to use it on lower versions
+# see https://cmake.org/cmake/help/v3.24/variable/CMAKE_PROJECT_TOP_LEVEL_INCLUDES.html
+# the alternative is to run conan install first instead
+if(CMAKE_PROJECT_TOP_LEVEL_INCLUDES)
+    cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+else()
+    cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+endif()
 
 # project name
 project(nmos-cpp)


### PR DESCRIPTION
Follow up to #373