### PR TITLE
Update Conan version to handle upgraded MSVC compiler

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -121,7 +121,7 @@ jobs:
     - name: install conan
       if: matrix.use_conan == true
       run: |
-        pip install conan~=2.0.5
+        pip install conan~=2.4.1
 
     - name: 'ubuntu-14.04: install cmake'
       if: matrix.os == 'ubuntu-14.04'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -677,7 +677,7 @@ jobs:
     - name: install conan
       if: matrix.use_conan == true
       run: |
-        pip install conan~=2.0.5
+        pip install conan~=2.4.1
 
     - name: 'ubuntu-14.04: install cmake'
       if: matrix.os == 'ubuntu-14.04'

--- a/.github/workflows/src/build-setup.yml
+++ b/.github/workflows/src/build-setup.yml
@@ -1,7 +1,7 @@
 - name: install conan
   if: matrix.use_conan == true
   run: |
-    pip install conan~=2.0.5
+    pip install conan~=2.4.1
 
 - name: 'ubuntu-14.04: install cmake'
   if: matrix.os == 'ubuntu-14.04'


### PR DESCRIPTION
This fixes the failure we are seeing on the Windows 2022 GitHub runners due to the version of the MSVC compiler not being supported by the older version of Conan.