### PR TITLE
Fix validation of MS-05 NcFloat32 values.

### DIFF
--- a/Development/nmos/control_protocol_utils.cpp
+++ b/Development/nmos/control_protocol_utils.cpp
@@ -185,7 +185,7 @@ namespace nmos
                         };
                         auto is_float32 = [](double value)
                         {
-                            return value >= (std::numeric_limits<float_t>::min)()
+                            return value >= (std::numeric_limits<float_t>::lowest)()
                                 && value <= (std::numeric_limits<float_t>::max)();
                         };
 

--- a/Development/nmos/test/control_protocol_test.cpp
+++ b/Development/nmos/test/control_protocol_test.cpp
@@ -885,7 +885,7 @@ BST_TEST_CASE(testConstraints)
     const nmos::details::datatype_constraints_validation_parameters no_constraints_float32_constraints_validation_params{ no_constraints_float32_datatype, nmos::make_get_control_protocol_datatype_descriptor_handler(control_protocol_state) };
     BST_REQUIRE_THROW(nmos::details::constraints_validation(std::numeric_limits<double>::lowest(), value::null(), value::null(), no_constraints_float32_constraints_validation_params), nmos::control_protocol_exception);
     BST_REQUIRE_THROW(nmos::details::constraints_validation(std::numeric_limits<double>::max(), value::null(), value::null(), no_constraints_float32_constraints_validation_params), nmos::control_protocol_exception);
-    BST_REQUIRE_NO_THROW(nmos::details::constraints_validation(std::numeric_limits<float_t>::min(), value::null(), value::null(), no_constraints_float32_constraints_validation_params));
+    BST_REQUIRE_NO_THROW(nmos::details::constraints_validation(std::numeric_limits<float_t>::lowest(), value::null(), value::null(), no_constraints_float32_constraints_validation_params));
     BST_REQUIRE_NO_THROW(nmos::details::constraints_validation(std::numeric_limits<float_t>::max(), value::null(), value::null(), no_constraints_float32_constraints_validation_params));
     BST_REQUIRE_NO_THROW(nmos::details::constraints_validation(0.0, value::null(), value::null(), no_constraints_float32_constraints_validation_params));
     BST_REQUIRE_NO_THROW(nmos::details::constraints_validation(-1000.0, value::null(), value::null(), no_constraints_float32_constraints_validation_params));

--- a/Development/nmos/test/control_protocol_test.cpp
+++ b/Development/nmos/test/control_protocol_test.cpp
@@ -883,10 +883,12 @@ BST_TEST_CASE(testConstraints)
     BST_REQUIRE_NO_THROW(nmos::details::constraints_validation(std::numeric_limits<uint64_t>::max(), value::null(), value::null(), no_constraints_uint64_constraints_validation_params));
     // float32 datatype constraints validation
     const nmos::details::datatype_constraints_validation_parameters no_constraints_float32_constraints_validation_params{ no_constraints_float32_datatype, nmos::make_get_control_protocol_datatype_descriptor_handler(control_protocol_state) };
-    BST_REQUIRE_THROW(nmos::details::constraints_validation(std::numeric_limits<double>::min(), value::null(), value::null(), no_constraints_float32_constraints_validation_params), nmos::control_protocol_exception);
+    BST_REQUIRE_THROW(nmos::details::constraints_validation(std::numeric_limits<double>::lowest(), value::null(), value::null(), no_constraints_float32_constraints_validation_params), nmos::control_protocol_exception);
     BST_REQUIRE_THROW(nmos::details::constraints_validation(std::numeric_limits<double>::max(), value::null(), value::null(), no_constraints_float32_constraints_validation_params), nmos::control_protocol_exception);
     BST_REQUIRE_NO_THROW(nmos::details::constraints_validation(std::numeric_limits<float_t>::min(), value::null(), value::null(), no_constraints_float32_constraints_validation_params));
     BST_REQUIRE_NO_THROW(nmos::details::constraints_validation(std::numeric_limits<float_t>::max(), value::null(), value::null(), no_constraints_float32_constraints_validation_params));
+    BST_REQUIRE_NO_THROW(nmos::details::constraints_validation(0.0, value::null(), value::null(), no_constraints_float32_constraints_validation_params));
+    BST_REQUIRE_NO_THROW(nmos::details::constraints_validation(-1000.0, value::null(), value::null(), no_constraints_float32_constraints_validation_params));
     // float64 datatype constraints validation
     const nmos::details::datatype_constraints_validation_parameters no_constraints_float64_constraints_validation_params{ no_constraints_float64_datatype, nmos::make_get_control_protocol_datatype_descriptor_handler(control_protocol_state) };
     BST_REQUIRE_THROW(nmos::details::constraints_validation(1000, value::null(), value::null(), no_constraints_float64_constraints_validation_params), nmos::control_protocol_exception);


### PR DESCRIPTION
- Validation check for NcFloat32 was enforcing values between `std::numeric_limits<float_t>::min` and `std::numeric_limits<float_t>::max`.
- However, `std::numeric_limits<float_t>::min` is the lowest __positive__ float value and so legitimate float32 numbers including 0.0 and all negative floats fail the validation.
- `::min` has been replaced with `::lowest`.
- A regression test has also been added.