### PR TITLE
Fix Ubuntu 14.04 and MacOS runners in GitHub actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,6 +10,7 @@ on: [pull_request, push]
 env:
   SECRET_GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
   SECRET_RESULTS_SHEET_ID: ${{ secrets.RESULTS_SHEET_ID }}
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   build_and_test:
     name: '${{ matrix.os }}: build and test (install mdns: ${{ matrix.install_mdns }}, use conan: ${{ matrix.use_conan }}, force cpprest asio: ${{ matrix.force_cpprest_asio }}, dns-sd mode: ${{ matrix.dns_sd_mode}}, enable_authorization: ${{ matrix.enable_authorization }})'
@@ -17,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
         install_mdns: [false, true]
         use_conan: [true]
         force_cpprest_asio: [false]
@@ -25,18 +26,18 @@ jobs:
         enable_authorization: [false, true]
         exclude:
           # install_mdns is only meaningful on Linux
-          - os: macos-11
+          - os: macos-12
             enable_authorization: false
           - os: windows-2019
             enable_authorization: false
           - os: ubuntu-20.04
             enable_authorization: false
-          - os: macos-11
+          - os: macos-12
             install_mdns: true
           - os: windows-2019
             install_mdns: true
           # for now, unicast DNS-SD tests are only implemented on Linux
-          - os: macos-11
+          - os: macos-12
             dns_sd_mode: unicast
           - os: windows-2019
             dns_sd_mode: unicast
@@ -643,7 +644,7 @@ jobs:
         # ubuntu-14.04 ca-certificates are out of date
         git config --global http.sslVerify false
         # build and install openssl
-        curl -OsSk https://www.openssl.org/source/openssl-1.1.1v.tar.gz
+        curl -OsSk https://openssl.org/source/old/1.1.1/openssl-1.1.1v.tar.gz
         tar xzf openssl-1.1.1v.tar.gz
         cd openssl-1.1.1v
         ./config --prefix=/usr/local/custom-openssl --libdir=lib --openssldir=/etc/ssl
@@ -1172,8 +1173,8 @@ jobs:
 
     - name: make badges
       run: |
-        # combine badges from all builds, exclude macos-11
-        ${{ github.workspace }}/Sandbox/make_badges.sh ${{ github.workspace }} ${{ runner.workspace }}/artifacts macos-11_auth macos-11_noauth
+        # combine badges from all builds, exclude macos-12
+        ${{ github.workspace }}/Sandbox/make_badges.sh ${{ github.workspace }} ${{ runner.workspace }}/artifacts macos-12_auth macos-12_noauth
 
         # force push to github onto an orphan 'badges' branch
         cd ${{ github.workspace }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -910,6 +910,7 @@ jobs:
         echo "CMAKE_WORKSPACE=${RUNNER_WORKSPACE//\\/\/}" >> $GITHUB_ENV
 
     - name: install test
+      if: runner.os != 'macOS'
       uses: lukka/run-cmake@v3.4
       with:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
@@ -924,6 +925,7 @@ jobs:
             ${{ env.CMAKE_COMPILER_ARGS }}'
 
     - name: install test log
+      if: runner.os != 'macOS'
       run: |
         # dump the log file created in Sandbox/my-nmos-node/CMakeLists.txt
         cat ${{ env.RUNNER_WORKSPACE }}/build-my-nmos-node/my-nmos-node_include-release.txt

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -354,6 +354,7 @@ jobs:
         echo "CMAKE_WORKSPACE=${RUNNER_WORKSPACE//\\/\/}" >> $GITHUB_ENV
 
     - name: install test
+      if: runner.os != 'macOS'
       uses: lukka/run-cmake@v3.4
       with:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
@@ -368,6 +369,7 @@ jobs:
             ${{ env.CMAKE_COMPILER_ARGS }}'
 
     - name: install test log
+      if: runner.os != 'macOS'
       run: |
         # dump the log file created in Sandbox/my-nmos-node/CMakeLists.txt
         cat ${{ env.RUNNER_WORKSPACE }}/build-my-nmos-node/my-nmos-node_include-release.txt

--- a/.github/workflows/src/build-test.yml
+++ b/.github/workflows/src/build-test.yml
@@ -10,6 +10,7 @@ on: [pull_request, push]
 env:
   SECRET_GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
   SECRET_RESULTS_SHEET_ID: ${{ secrets.RESULTS_SHEET_ID }}
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   build_and_test:
     name: '${{ matrix.os }}: build and test (install mdns: ${{ matrix.install_mdns }}, use conan: ${{ matrix.use_conan }}, force cpprest asio: ${{ matrix.force_cpprest_asio }}, dns-sd mode: ${{ matrix.dns_sd_mode}}, enable_authorization: ${{ matrix.enable_authorization }})'
@@ -159,7 +160,7 @@ jobs:
         # ubuntu-14.04 ca-certificates are out of date
         git config --global http.sslVerify false
         # build and install openssl
-        curl -OsSk https://www.openssl.org/source/openssl-1.1.1v.tar.gz
+        curl -OsSk https://openssl.org/source/old/1.1.1/openssl-1.1.1v.tar.gz
         tar xzf openssl-1.1.1v.tar.gz
         cd openssl-1.1.1v
         ./config --prefix=/usr/local/custom-openssl --libdir=lib --openssldir=/etc/ssl

--- a/.github/workflows/src/install-test.yml
+++ b/.github/workflows/src/install-test.yml
@@ -5,6 +5,7 @@
     echo "CMAKE_WORKSPACE=${RUNNER_WORKSPACE//\\/\/}" >> $GITHUB_ENV
 
 - name: install test
+  if: runner.os != 'macOS'
   uses: lukka/run-cmake@v3.4
   with:
     cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
@@ -19,6 +20,7 @@
         ${{ env.CMAKE_COMPILER_ARGS }}'
 
 - name: install test log
+  if: runner.os != 'macOS'
   run: |
     # dump the log file created in Sandbox/my-nmos-node/CMakeLists.txt
     cat ${{ env.RUNNER_WORKSPACE }}/build-my-nmos-node/my-nmos-node_include-release.txt


### PR DESCRIPTION
- Allow Ubuntu-14.04 to use node16 instead of node20 to enable Ubuntu-14.04 runner to work
- Upgrade no longer supported MacOS-11 runner to MacOS-12

Caveats:
- The `test install` target for MacOS fails due to a CMake issue that needs to be resolved
- For this reason the `test install` target (along with the `test install log` target) are currently excluded for MacOS runners 