### PR TITLE
Workaround GCC 10&11 optimiser compilation failure

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -646,7 +646,7 @@ jobs:
         # ubuntu-14.04 ca-certificates are out of date
         git config --global http.sslVerify false
         # build and install openssl
-        curl -OsSk https://openssl.org/source/old/1.1.1/openssl-1.1.1v.tar.gz
+        curl -OsSkL https://openssl.org/source/old/1.1.1/openssl-1.1.1v.tar.gz
         tar xzf openssl-1.1.1v.tar.gz
         cd openssl-1.1.1v
         ./config --prefix=/usr/local/custom-openssl --libdir=lib --openssldir=/etc/ssl

--- a/.github/workflows/src/build-test.yml
+++ b/.github/workflows/src/build-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
         install_mdns: [false, true]
         use_conan: [true]
         force_cpprest_asio: [false]
@@ -26,18 +26,18 @@ jobs:
         enable_authorization: [false, true]
         exclude:
           # install_mdns is only meaningful on Linux
-          - os: macos-11
+          - os: macos-12
             enable_authorization: false
           - os: windows-2019
             enable_authorization: false
           - os: ubuntu-20.04
             enable_authorization: false
-          - os: macos-11
+          - os: macos-12
             install_mdns: true
           - os: windows-2019
             install_mdns: true
           # for now, unicast DNS-SD tests are only implemented on Linux
-          - os: macos-11
+          - os: macos-12
             dns_sd_mode: unicast
           - os: windows-2019
             dns_sd_mode: unicast
@@ -160,7 +160,7 @@ jobs:
         # ubuntu-14.04 ca-certificates are out of date
         git config --global http.sslVerify false
         # build and install openssl
-        curl -OsSk https://openssl.org/source/old/1.1.1/openssl-1.1.1v.tar.gz
+        curl -OsSkL https://openssl.org/source/old/1.1.1/openssl-1.1.1v.tar.gz
         tar xzf openssl-1.1.1v.tar.gz
         cd openssl-1.1.1v
         ./config --prefix=/usr/local/custom-openssl --libdir=lib --openssldir=/etc/ssl
@@ -205,8 +205,8 @@ jobs:
 
     - name: make badges
       run: |
-        # combine badges from all builds, exclude macos-11
-        ${{ github.workspace }}/Sandbox/make_badges.sh ${{ github.workspace }} ${{ runner.workspace }}/artifacts macos-11_auth macos-11_noauth
+        # combine badges from all builds, exclude macos-12
+        ${{ github.workspace }}/Sandbox/make_badges.sh ${{ github.workspace }} ${{ runner.workspace }}/artifacts macos-12_auth macos-12_noauth
 
         # force push to github onto an orphan 'badges' branch
         cd ${{ github.workspace }}

--- a/Development/cpprest/json_ops.h
+++ b/Development/cpprest/json_ops.h
@@ -51,12 +51,7 @@ namespace web
             return !(lhs == rhs);
         }
 
-        inline bool operator<(const web::json::object& lhs, const web::json::object& rhs)
-        {
-            using std::begin;
-            using std::end;
-            return std::lexicographical_compare(begin(lhs), end(lhs), begin(rhs), end(rhs));
-        }
+        inline bool operator<(const web::json::object& lhs, const web::json::object& rhs);
 
         inline bool operator>(const web::json::object& lhs, const web::json::object& rhs)
         {
@@ -87,12 +82,7 @@ namespace web
             return !(lhs == rhs);
         }
 
-        inline bool operator<(const web::json::array& lhs, const web::json::array& rhs)
-        {
-            using std::begin;
-            using std::end;
-            return std::lexicographical_compare(begin(lhs), end(lhs), begin(rhs), end(rhs));
-        }
+        inline bool operator<(const web::json::array& lhs, const web::json::array& rhs);
 
         inline bool operator>(const web::json::array& lhs, const web::json::array& rhs)
         {
@@ -141,6 +131,20 @@ namespace web
         inline bool operator>=(const web::json::value& lhs, const web::json::value& rhs)
         {
             return !(lhs < rhs);
+        }
+
+        inline bool operator<(const web::json::array& lhs, const web::json::array& rhs)
+        {
+            using std::begin;
+            using std::end;
+            return std::lexicographical_compare(begin(lhs), end(lhs), begin(rhs), end(rhs));
+        }
+
+        inline bool operator<(const web::json::object& lhs, const web::json::object& rhs)
+        {
+            using std::begin;
+            using std::end;
+            return std::lexicographical_compare(begin(lhs), end(lhs), begin(rhs), end(rhs));
         }
     }
 }


### PR DESCRIPTION
GCC 10 and 11 seem to have an issue compiling the `std::lexicographical_compare` statements in `json_ops.h`. The issue seems to be that the operators used inside `std::lexicographical_compare` aren't defined before the call to `std::lexicographical_compare`.

This only seems to cause a problem for GCC 10 and 11, with c++20 and optimisations enabled. Clang always rejects the code.

A reduced example of the problem: https://godbolt.org/z/9ra6hn7c9