### PR TITLE
GitHub actions: Version up deprecated upload-artifact and download-artifact REDUX

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1171,7 +1171,7 @@ jobs:
         echo "GITHUB_WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
         echo "RUNNER_WORKSPACE=${{ runner.workspace }}" >> $GITHUB_ENV
 
-    - uses: actions/download-artifact@v4.1.8
+    - uses: actions/download-artifact@v3.0.2
       with:
         path: ${{ runner.workspace }}/artifacts
 

--- a/.github/workflows/src/build-test.yml
+++ b/.github/workflows/src/build-test.yml
@@ -199,7 +199,7 @@ jobs:
         echo "GITHUB_WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
         echo "RUNNER_WORKSPACE=${{ runner.workspace }}" >> $GITHUB_ENV
 
-    - uses: actions/download-artifact@v4.1.8
+    - uses: actions/download-artifact@v3.0.2
       with:
         path: ${{ runner.workspace }}/artifacts
 


### PR DESCRIPTION
In the `make_badges` action, the download-artifact action is not downloading the test results.

This is due to the `download-artifact` being at v4 but the `upload-artifact` only being bumped to v3 due to Node20 not being supported "out of the box" on the Ubuntu 14.04.

According the https://github.com/actions/download-artifact one breaking change of the v4 of `download-artifact` is "Downloading artifacts that were created from action/upload-artifact@v3 and below are not supported".

For this reason v3 artifacts were being ignored by the v4 `download-artifact` action, and `make_badges` was failing.

So this PR downgrades `download-artifact` to v3.

However this is a short term solution as v3 of the `download-artifacts` and `upload-artifacts` will be deprecated from Nov 24.
Therefore we need to either:

- Work out how to install Node20 on Ubuntu 14.04
- Exclude Ubuntu 14.04 from the `make_badges` process