### PR TITLE
IS-12: Ensure NcMethodResultError returned on error (not NcMethodResult)

### DIFF
--- a/Development/nmos/control_protocol_methods.cpp
+++ b/Development/nmos/control_protocol_methods.cpp
@@ -51,14 +51,20 @@ namespace nmos
         {
             if (nmos::fields::nc::is_read_only(property))
             {
-                return details::make_nc_method_result({ nc_method_status::read_only });
+                utility::stringstream_t ss;
+                ss << U("can not set read only property: ") << property_id.serialize();
+                slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
+                return details::make_nc_method_result_error({ nc_method_status::read_only }, ss.str());
             }
 
             if ((val.is_null() && !nmos::fields::nc::is_nullable(property))
                 || (!val.is_array() && nmos::fields::nc::is_sequence(property))
                 || (val.is_array() && !nmos::fields::nc::is_sequence(property)))
             {
-                return details::make_nc_method_result({ nc_method_status::parameter_error });
+                utility::stringstream_t ss;
+                ss << U("parameter error: can not set value: ") << val.serialize() << U(" on property: ") << property_id.serialize();
+                slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
+                return details::make_nc_method_result_error({ nc_method_status::parameter_error }, ss.str());
             }
 
             try

--- a/Development/nmos/control_protocol_ws_api.cpp
+++ b/Development/nmos/control_protocol_ws_api.cpp
@@ -277,8 +277,10 @@ namespace nmos
                                             catch (const nmos::control_protocol_exception& e)
                                             {
                                                 // invalid arguments
-                                                slog::log<slog::severities::error>(gate, SLOG_FLF) << "invalid argument: " << arguments.serialize() << " error: " << e.what();
-                                                nc_method_result = details::make_nc_method_result({ nmos::nc_method_status::parameter_error });
+                                                utility::stringstream_t ss;
+                                                ss << "invalid argument: " << arguments.serialize() << " error: " << e.what();
+                                                slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
+                                                nc_method_result = details::make_nc_method_result_error({ nmos::nc_method_status::parameter_error }, ss.str());
                                             }
                                         }
                                         else
@@ -287,6 +289,7 @@ namespace nmos
                                             utility::stringstream_t ss;
                                             ss << U("unsupported method_id: ") << nmos::fields::nc::method_id(cmd).serialize()
                                                 << U(" for control class class_id: ") << resource->data.at(nmos::fields::nc::class_id).serialize();
+                                            slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                                             nc_method_result = details::make_nc_method_result_error({ nc_method_status::method_not_implemented }, ss.str());
                                         }
                                     }
@@ -295,6 +298,7 @@ namespace nmos
                                         // resource not found for the given oid
                                         utility::stringstream_t ss;
                                         ss << U("unknown oid: ") << oid;
+                                        slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                                         nc_method_result = details::make_nc_method_result_error({ nc_method_status::bad_oid }, ss.str());
                                     }
                                     // accumulating up response


### PR DESCRIPTION
Consistently log  and return NcMethodResultError on error
