### PR TITLE
Fix slog warning

### DIFF
--- a/Development/cmake/NmosCppTest.cmake
+++ b/Development/cmake/NmosCppTest.cmake
@@ -52,6 +52,7 @@ set(NMOS_CPP_TEST_NMOS_TEST_SOURCES
     nmos/test/query_api_test.cpp
     nmos/test/sdp_test_utils.cpp
     nmos/test/sdp_utils_test.cpp
+    nmos/test/slog_test.cpp
     nmos/test/system_resources_test.cpp
     nmos/test/video_jxsv_test.cpp
     )

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -1260,7 +1260,7 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
                 {
                     const auto receiver_id = impl::make_id(seed_id, nmos::types::receiver, port, index);
 
-                    utility::stringstream_t role;
+                    utility::ostringstream_t role;
                     role << U("monitor-") << ++count;
                     const auto& receiver = nmos::find_resource(model.node_resources, receiver_id);
                     const auto receiver_monitor = nmos::make_receiver_monitor(++oid, true, nmos::root_block_oid, role.str(), nmos::fields::label(receiver->data), nmos::fields::description(receiver->data), value_of({ { nmos::details::make_nc_touchpoint_nmos({nmos::ncp_nmos_resource_types::receiver, receiver_id}) } }));

--- a/Development/nmos/certificate_handlers.cpp
+++ b/Development/nmos/certificate_handlers.cpp
@@ -22,7 +22,7 @@ namespace nmos
             else
             {
                 utility::ifstream_t ca_file(ca_certificate_file);
-                utility::stringstream_t cacerts;
+                utility::ostringstream_t cacerts;
                 cacerts << ca_file.rdbuf();
                 return cacerts.str();
             }
@@ -70,7 +70,7 @@ namespace nmos
                 const auto private_key_file = nmos::experimental::fields::private_key_file(server_certificate);
                 const auto certificate_chain_file = nmos::experimental::fields::certificate_chain_file(server_certificate);
 
-                utility::stringstream_t pkey;
+                utility::ostringstream_t pkey;
                 if (private_key_file.empty())
                 {
                     slog::log<slog::severities::warning>(gate, SLOG_FLF) << "Missing server private key file";
@@ -81,7 +81,7 @@ namespace nmos
                     pkey << pkey_file.rdbuf();
                 }
 
-                utility::stringstream_t cert_chain;
+                utility::ostringstream_t cert_chain;
                 if (certificate_chain_file.empty())
                 {
                     slog::log<slog::severities::warning>(gate, SLOG_FLF) << "Missing server certificate chain file";
@@ -114,7 +114,7 @@ namespace nmos
             else
             {
                 utility::ifstream_t dh_file(dh_param_file);
-                utility::stringstream_t dh_param;
+                utility::ostringstream_t dh_param;
                 dh_param << dh_file.rdbuf();
                 return dh_param.str();
             }
@@ -160,7 +160,7 @@ namespace nmos
                 const auto key_algorithm = nmos::experimental::fields::key_algorithm(server_certificate);
                 const auto private_key_file = nmos::experimental::fields::private_key_file(server_certificate);
 
-                utility::stringstream_t pkey;
+                utility::ostringstream_t pkey;
                 if (private_key_file.empty())
                 {
                     slog::log<slog::severities::warning>(gate, SLOG_FLF) << "Missing private key file";

--- a/Development/nmos/control_protocol_methods.cpp
+++ b/Development/nmos/control_protocol_methods.cpp
@@ -28,7 +28,7 @@ namespace nmos
         }
 
         // unknown property
-        utility::stringstream_t ss;
+        utility::ostringstream_t ss;
         ss << U("unknown property: ") << property_id.serialize() << U(" to do Get");
         slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
         return details::make_nc_method_result_error({ nc_method_status::property_not_implemented }, ss.str());
@@ -51,7 +51,7 @@ namespace nmos
         {
             if (nmos::fields::nc::is_read_only(property))
             {
-                utility::stringstream_t ss;
+                utility::ostringstream_t ss;
                 ss << U("can not set read only property: ") << property_id.serialize();
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                 return details::make_nc_method_result_error({ nc_method_status::read_only }, ss.str());
@@ -61,7 +61,7 @@ namespace nmos
                 || (!val.is_array() && nmos::fields::nc::is_sequence(property))
                 || (val.is_array() && !nmos::fields::nc::is_sequence(property)))
             {
-                utility::stringstream_t ss;
+                utility::ostringstream_t ss;
                 ss << U("parameter error: can not set value: ") << val.serialize() << U(" on property: ") << property_id.serialize();
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                 return details::make_nc_method_result_error({ nc_method_status::parameter_error }, ss.str());
@@ -89,7 +89,7 @@ namespace nmos
             }
             catch (const nmos::control_protocol_exception& e)
             {
-                utility::stringstream_t ss;
+                utility::ostringstream_t ss;
                 ss << "Set property: " << property_id.serialize() << " value: " << val.serialize() << " error: " << e.what();
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                 return details::make_nc_method_result_error({ nc_method_status::parameter_error }, ss.str());
@@ -97,7 +97,7 @@ namespace nmos
         }
 
         // unknown property
-        utility::stringstream_t ss;
+        utility::ostringstream_t ss;
         ss << U("unknown property: ") << property_id.serialize() << " to do Set";
         slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
         return details::make_nc_method_result_error({ nc_method_status::property_not_implemented }, ss.str());
@@ -122,7 +122,7 @@ namespace nmos
             if (!nmos::fields::nc::is_sequence(property) || data.is_null() || !data.is_array())
             {
                 // property is not a sequence
-                utility::stringstream_t ss;
+                utility::ostringstream_t ss;
                 ss << U("property: ") << property_id.serialize() << U(" is not a sequence to do GetSequenceItem");
                 return details::make_nc_method_result_error({ nc_method_status::invalid_request }, ss.str());
             }
@@ -133,14 +133,14 @@ namespace nmos
             }
 
             // out of bound
-            utility::stringstream_t ss;
+            utility::ostringstream_t ss;
             ss << U("property: ") << property_id.serialize() << U(" is outside the available range to do GetSequenceItem");
             slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
             return details::make_nc_method_result_error({ nc_method_status::index_out_of_bounds }, ss.str());
         }
 
         // unknown property
-        utility::stringstream_t ss;
+        utility::ostringstream_t ss;
         ss << U("unknown property: ") << property_id.serialize() << U(" to do GetSequenceItem");
         slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
         return details::make_nc_method_result_error({ nc_method_status::property_not_implemented }, ss.str());
@@ -172,7 +172,7 @@ namespace nmos
             if (!nmos::fields::nc::is_sequence(property) || data.is_null() || !data.is_array())
             {
                 // property is not a sequence
-                utility::stringstream_t ss;
+                utility::ostringstream_t ss;
                 ss << U("property: ") << property_id.serialize() << U(" is not a sequence to do SetSequenceItem");
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                 return details::make_nc_method_result_error({ nc_method_status::invalid_request }, ss.str());
@@ -202,7 +202,7 @@ namespace nmos
                 }
                 catch (const nmos::control_protocol_exception& e)
                 {
-                    utility::stringstream_t ss;
+                    utility::ostringstream_t ss;
                     ss << "Set sequence item: " << property_id.serialize() << " index: " << index << " value: " << val.serialize() << " error: " << e.what();
                     slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                     return details::make_nc_method_result_error({ nc_method_status::parameter_error }, ss.str());
@@ -210,14 +210,14 @@ namespace nmos
             }
 
             // out of bound
-            utility::stringstream_t ss;
+            utility::ostringstream_t ss;
             ss << U("property: ") << property_id.serialize() << U(" is outside the available range to do SetSequenceItem");
             slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
             return details::make_nc_method_result_error({ nc_method_status::index_out_of_bounds }, ss.str());
         }
 
         // unknown property
-        utility::stringstream_t ss;
+        utility::ostringstream_t ss;
         ss << U("unknown property: ") << property_id.serialize() << U(" to do SetSequenceItem");
         slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
         return details::make_nc_method_result_error({ nc_method_status::property_not_implemented }, ss.str());
@@ -248,7 +248,7 @@ namespace nmos
             if (!nmos::fields::nc::is_sequence(property))
             {
                 // property is not a sequence
-                utility::stringstream_t ss;
+                utility::ostringstream_t ss;
                 ss << U("property: ") << property_id.serialize() << U(" is not a sequence to do AddSequenceItem");
                 return details::make_nc_method_result_error({ nc_method_status::invalid_request }, ss.str());
             }
@@ -281,7 +281,7 @@ namespace nmos
             }
             catch (const nmos::control_protocol_exception& e)
             {
-                utility::stringstream_t ss;
+                utility::ostringstream_t ss;
                 ss << "Add sequence item: " << property_id.serialize() << " value: " << val.serialize() << " error: " << e.what();
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                 return details::make_nc_method_result_error({ nc_method_status::parameter_error }, ss.str());
@@ -289,7 +289,7 @@ namespace nmos
         }
 
         // unknown property
-        utility::stringstream_t ss;
+        utility::ostringstream_t ss;
         ss << U("unknown property: ") << property_id.serialize() << U(" to do AddSequenceItem");
         slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
         return details::make_nc_method_result_error({ nc_method_status::property_not_implemented }, ss.str());
@@ -314,7 +314,7 @@ namespace nmos
             if (!nmos::fields::nc::is_sequence(property) || data.is_null() || !data.is_array())
             {
                 // property is not a sequence
-                utility::stringstream_t ss;
+                utility::ostringstream_t ss;
                 ss << U("property: ") << property_id.serialize() << U(" is not a sequence to do RemoveSequenceItem");
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                 return details::make_nc_method_result_error({ nc_method_status::invalid_request }, ss.str());
@@ -333,14 +333,14 @@ namespace nmos
             }
 
             // out of bound
-            utility::stringstream_t ss;
+            utility::ostringstream_t ss;
             ss << U("property: ") << property_id.serialize() << U(" is outside the available range to do RemoveSequenceItem");
             slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
             return details::make_nc_method_result_error({ nc_method_status::index_out_of_bounds }, ss.str());
         }
 
         // unknown property
-        utility::stringstream_t ss;
+        utility::ostringstream_t ss;
         ss << U("unknown property: ") << property_id.serialize() << U(" to do RemoveSequenceItem");
         slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
         return details::make_nc_method_result_error({ nc_method_status::property_not_implemented }, ss.str());
@@ -364,7 +364,7 @@ namespace nmos
             if (!nmos::fields::nc::is_sequence(property))
             {
                 // property is not a sequence
-                utility::stringstream_t ss;
+                utility::ostringstream_t ss;
                 ss << U("property: ") << property_id.serialize() << U(" is not a sequence to do GetSequenceLength");
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                 return details::make_nc_method_result_error({ nc_method_status::invalid_request }, ss.str());
@@ -387,7 +387,7 @@ namespace nmos
                 if (data.is_null())
                 {
                     // null
-                    utility::stringstream_t ss;
+                    utility::ostringstream_t ss;
                     ss << U("property: ") << property_id.serialize() << " is a null sequence to do GetSequenceLength";
                     slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                     return details::make_nc_method_result_error({ nc_method_status::invalid_request }, ss.str());
@@ -397,7 +397,7 @@ namespace nmos
         }
 
         // unknown property
-        utility::stringstream_t ss;
+        utility::ostringstream_t ss;
         ss << U("unknown property: ") << property_id.serialize() << " to do GetSequenceLength";
         slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
         return details::make_nc_method_result_error({ nc_method_status::property_not_implemented }, ss.str());
@@ -465,7 +465,7 @@ namespace nmos
                 else
                 {
                     // no role
-                    utility::stringstream_t ss;
+                    utility::ostringstream_t ss;
                     ss << U("role: ") << role.as_string() << U(" not found to do FindMembersByPath");
                     slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                     return details::make_nc_method_result_error({ nc_method_status::parameter_error }, ss.str());
@@ -474,7 +474,7 @@ namespace nmos
             else
             {
                 // no members
-                utility::stringstream_t ss;
+                utility::ostringstream_t ss;
                 ss << U("role: ") << role.as_string() << U(" has no members to do FindMembersByPath");
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                 return details::make_nc_method_result_error({ nc_method_status::parameter_error }, ss.str());

--- a/Development/nmos/control_protocol_ws_api.cpp
+++ b/Development/nmos/control_protocol_ws_api.cpp
@@ -277,7 +277,7 @@ namespace nmos
                                             catch (const nmos::control_protocol_exception& e)
                                             {
                                                 // invalid arguments
-                                                utility::stringstream_t ss;
+                                                utility::ostringstream_t ss;
                                                 ss << "invalid argument: " << arguments.serialize() << " error: " << e.what();
                                                 slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                                                 nc_method_result = details::make_nc_method_result_error({ nmos::nc_method_status::parameter_error }, ss.str());
@@ -286,7 +286,7 @@ namespace nmos
                                         else
                                         {
                                             // unknown methodId
-                                            utility::stringstream_t ss;
+                                            utility::ostringstream_t ss;
                                             ss << U("unsupported method_id: ") << nmos::fields::nc::method_id(cmd).serialize()
                                                 << U(" for control class class_id: ") << resource->data.at(nmos::fields::nc::class_id).serialize();
                                             slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
@@ -296,7 +296,7 @@ namespace nmos
                                     else
                                     {
                                         // resource not found for the given oid
-                                        utility::stringstream_t ss;
+                                        utility::ostringstream_t ss;
                                         ss << U("unknown oid: ") << oid;
                                         slog::log<slog::severities::error>(gate, SLOG_FLF) << ss.str();
                                         nc_method_result = details::make_nc_method_result_error({ nc_method_status::bad_oid }, ss.str());

--- a/Development/nmos/slog.h
+++ b/Development/nmos/slog.h
@@ -16,6 +16,10 @@ namespace slog
     {
         return s << utility::conversions::to_utf8string(u16s);
     }
+    inline log_statement& operator<<(log_statement&& s, const utf16string& u16s)
+    {
+        return s << u16s;
+    }
 }
 
 namespace nmos
@@ -24,6 +28,10 @@ namespace nmos
     inline slog::log_statement& operator<<(slog::log_statement& s, const std::pair<nmos::id, nmos::type>& id_type)
     {
         return s << id_type.second.name << ": " << id_type.first;
+    }
+    inline slog::log_statement& operator<<(slog::log_statement&& s, const std::pair<nmos::id, nmos::type>& id_type)
+    {
+        return s << id_type;
     }
 
     // Log message categories

--- a/Development/nmos/test/slog_test.cpp
+++ b/Development/nmos/test/slog_test.cpp
@@ -1,0 +1,26 @@
+// The first "test" is of course whether the header compiles standalone
+#include "nmos/slog.h"
+
+#include "bst/test/test.h"
+
+namespace
+{
+    struct dull_gate
+    {
+        bool pertinent(slog::severity level) const { return true; }
+        void log(const slog::log_message& message) {}
+    };
+}
+
+BST_TEST_CASE(testSlogLog)
+{
+    dull_gate gate;
+    const auto str = utility::string_t{ U("foo") };
+    const auto it = std::make_pair(nmos::id{ U("bar") }, nmos::types::node);
+    // log statement
+    slog::log<SLOG_LOGGING_SEVERITY>(gate, SLOG_FLF) << str << 42 << str;
+    slog::log<SLOG_LOGGING_SEVERITY>(gate, SLOG_FLF) << it << 42 << it;
+    // no log statement
+    slog::log<SLOG_LOGGING_SEVERITY - 1>(gate, SLOG_FLF) << str << 42 << str;
+    slog::log<SLOG_LOGGING_SEVERITY - 1>(gate, SLOG_FLF) << it << 42 << it;
+}


### PR DESCRIPTION
I propose this as an alternative to #418 to fix #417.

I'm not 100% sure about the overloads taking rvalue-ref and returning lvalue-ref, but it seems to work in my local env...