### PR TITLE
Changed urns of default Node

### DIFF
--- a/Development/nmos/registry_resources.cpp
+++ b/Development/nmos/registry_resources.cpp
@@ -30,7 +30,7 @@ namespace nmos
                         .set_scheme(nmos::http_scheme(settings))
                         .set_port(nmos::experimental::fields::mdns_port(settings))
                         .set_path(U("/x-dns-sd/") + make_api_version(version));
-                    auto type = U("urn:x-dns-sd/") + make_api_version(version);
+                    auto type = U("urn:x-dns-sd:mdns-advertisement");
 
                     for (const auto& host : hosts)
                     {


### PR DESCRIPTION
Not sure if the Urn here is just invalid and rusts Urn crate is more stringent or if the Urn crate is TOO stringent.

Nmos-cpp-registry always includes a default node when starting up which we could not parse using the translator because of this urn. pretty annoying.