### PR TITLE
"caps" is required for all Receivers

### DIFF
--- a/Development/nmos/node_resources.cpp
+++ b/Development/nmos/node_resources.cpp
@@ -587,9 +587,11 @@ namespace nmos
         auto& data = resource.data;
 
         data[U("format")] = value::string(format.name);
+        auto& caps = data[U("caps")] = value::object();
+
         for (const auto& media_type : media_types)
         {
-            web::json::push_back(data[U("caps")][U("media_types")], value::string(media_type.name));
+            web::json::push_back(caps[U("media_types")], value::string(media_type.name));
         }
 
         return resource;


### PR DESCRIPTION
Like `format`, `caps` is required for all Receivers (even if there's no `media_types` capability)...

See:
* [receiver_audio](https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/schemas/with-refs/receiver_audio.html)
* [receiver_data](https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/schemas/with-refs/receiver_data.html)
* [receiver_mux](https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/schemas/with-refs/receiver_mux.html)
* [receiver_video](https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/schemas/with-refs/receiver_video.html)
