### PR TITLE
Add _or_defaults versions of the  format-specific parameters parsing functions

### DIFF
--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -1380,8 +1380,6 @@ namespace nmos
     // Get additional "video/raw" parameters from the SDP parameters
     video_raw_parameters get_video_raw_parameters(const sdp_parameters& sdp_params)
     {
-        if (sdp_params.fmtp.empty()) throw details::sdp_processing_error("missing attribute: fmtp");
-
         return get_video_raw_parameters<details::throw_missing_fmtp>(sdp_params);
     }
 

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -1383,6 +1383,12 @@ namespace nmos
         return get_video_raw_parameters<details::throw_missing_fmtp>(sdp_params);
     }
 
+    // Get additional "video/raw" parameters from the SDP parameters
+    video_raw_parameters get_video_raw_parameters_or_defaults(const sdp_parameters& sdp_params)
+    {
+        return get_video_raw_parameters<>(sdp_params, [](const utility::string_t&) {});
+    }
+
     // Get additional "audio/L" parameters from the SDP parameters
     audio_L_parameters get_audio_L_parameters(const sdp_parameters& sdp_params)
     {

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -1293,24 +1293,24 @@ namespace nmos
         // and Section 7.3 Media Type Parameters with default values
 
         const auto sampling = details::find_fmtp(sdp_params.fmtp, sdp::fields::sampling);
-        if (sdp_params.fmtp.end() == sampling) missing(sdp::fields::sampling);
-        else params.sampling = sdp::sampling{ sampling->second };
+        if (sdp_params.fmtp.end() != sampling) params.sampling = sdp::sampling{ sampling->second };
+        else missing(sdp::fields::sampling);
 
         const auto depth = details::find_fmtp(sdp_params.fmtp, sdp::fields::depth);
-        if (sdp_params.fmtp.end() == depth) missing(sdp::fields::depth);
-        else params.depth = utility::istringstreamed<uint32_t>(depth->second);
+        if (sdp_params.fmtp.end() != depth) params.depth = utility::istringstreamed<uint32_t>(depth->second);
+        else missing(sdp::fields::depth);
 
         const auto width = details::find_fmtp(sdp_params.fmtp, sdp::fields::width);
-        if (sdp_params.fmtp.end() == width) missing(sdp::fields::width);
-        else params.width = utility::istringstreamed<uint32_t>(width->second);
+        if (sdp_params.fmtp.end() != width) params.width = utility::istringstreamed<uint32_t>(width->second);
+        else missing(sdp::fields::width);
 
         const auto height = details::find_fmtp(sdp_params.fmtp, sdp::fields::height);
-        if (sdp_params.fmtp.end() == height) missing(sdp::fields::height);
-        else params.height = utility::istringstreamed<uint32_t>(height->second);
+        if (sdp_params.fmtp.end() != height) params.height = utility::istringstreamed<uint32_t>(height->second);
+        else missing(sdp::fields::height);
 
         const auto exactframerate = details::find_fmtp(sdp_params.fmtp, sdp::fields::exactframerate);
-        if (sdp_params.fmtp.end() == exactframerate) missing(sdp::fields::exactframerate);
-        else params.exactframerate = nmos::details::parse_exactframerate(exactframerate->second);
+        if (sdp_params.fmtp.end() != exactframerate) params.exactframerate = nmos::details::parse_exactframerate(exactframerate->second);
+        else missing(sdp::fields::exactframerate);
 
         // optional
         const auto interlace = details::find_fmtp(sdp_params.fmtp, sdp::fields::interlace);
@@ -1325,8 +1325,8 @@ namespace nmos
         if (sdp_params.fmtp.end() != tcs) params.tcs = sdp::transfer_characteristic_system{ tcs->second };
 
         const auto colorimetry = details::find_fmtp(sdp_params.fmtp, sdp::fields::colorimetry);
-        if (sdp_params.fmtp.end() == colorimetry) missing(sdp::fields::colorimetry);
-        else params.colorimetry = sdp::colorimetry{ colorimetry->second };
+        if (sdp_params.fmtp.end() != colorimetry) params.colorimetry = sdp::colorimetry{ colorimetry->second };
+        else missing(sdp::fields::colorimetry);
 
         // optional
         const auto range = details::find_fmtp(sdp_params.fmtp, sdp::fields::range);
@@ -1337,12 +1337,12 @@ namespace nmos
         if (sdp_params.fmtp.end() != par) params.par = nmos::details::parse_pixel_aspect_ratio(par->second);
 
         const auto pm = details::find_fmtp(sdp_params.fmtp, sdp::fields::packing_mode);
-        if (sdp_params.fmtp.end() == pm) missing(sdp::fields::packing_mode);
-        else params.pm = sdp::packing_mode{ pm->second };
+        if (sdp_params.fmtp.end() != pm) params.pm = sdp::packing_mode{ pm->second };
+        else missing(sdp::fields::packing_mode);
 
         const auto ssn = details::find_fmtp(sdp_params.fmtp, sdp::fields::smpte_standard_number);
-        if (sdp_params.fmtp.end() == ssn) missing(sdp::fields::smpte_standard_number);
-        else params.ssn = sdp::smpte_standard_number{ ssn->second };
+        if (sdp_params.fmtp.end() != ssn) params.ssn = sdp::smpte_standard_number{ ssn->second };
+        else missing(sdp::fields::smpte_standard_number);
 
         // "Senders and Receivers compliant to [ST 2110-20] shall comply with the provisions of SMPTE ST 2110-21."
         // See SMPTE ST 2110-20:2017 Section 6.1.1

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -507,6 +507,7 @@ namespace nmos
     sdp_parameters make_video_raw_sdp_parameters(const utility::string_t& session_name, const video_raw_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
     // Get additional "video/raw" parameters from the SDP parameters
     video_raw_parameters get_video_raw_parameters(const sdp_parameters& sdp_params);
+    video_raw_parameters get_video_raw_parameters_or_defaults(const sdp_parameters& sdp_params);
 
     // Construct additional "audio/L" parameters from the IS-04 resources, using default values for unspecified items
     audio_L_parameters make_audio_L_parameters(const web::json::value& node, const web::json::value& source, const web::json::value& flow, const web::json::value& sender, bst::optional<double> packet_time);

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include "bst/any.h"
 #include "bst/optional.h"
+#include "cpprest/basic_utils.h"
 #include "sdp/json.h"
 #include "sdp/ntp.h"
 #include "nmos/did_sdid.h"
@@ -581,6 +582,14 @@ namespace nmos
         {
             return std::runtime_error{ "sdp processing error - " + message };
         }
+
+        struct throw_missing_fmtp
+        {
+            void operator()(const utility::string_t& name) const
+            {
+                throw details::sdp_processing_error("missing format parameter: " + utility::us2s(name));
+            }
+        };
 
         inline sdp_parameters::fmtp_t::const_iterator find_fmtp(const sdp_parameters::fmtp_t& fmtp, const utility::string_t& name)
         {

--- a/Development/nmos/video_jxsv.cpp
+++ b/Development/nmos/video_jxsv.cpp
@@ -192,8 +192,8 @@ namespace nmos
         video_jxsv_parameters params;
 
         const auto packetmode = details::find_fmtp(sdp_params.fmtp, sdp::video_jxsv::fields::packetmode);
-        if (sdp_params.fmtp.end() == packetmode) missing(sdp::video_jxsv::fields::packetmode);
-        else params.packetmode = (sdp::video_jxsv::packetization_mode)utility::istringstreamed<uint32_t>(packetmode->second);
+        if (sdp_params.fmtp.end() != packetmode) params.packetmode = (sdp::video_jxsv::packetization_mode)utility::istringstreamed<uint32_t>(packetmode->second);
+        else missing(sdp::video_jxsv::fields::packetmode);
 
         // optional
         const auto transmode = details::find_fmtp(sdp_params.fmtp, sdp::video_jxsv::fields::transmode);

--- a/Development/nmos/video_jxsv.cpp
+++ b/Development/nmos/video_jxsv.cpp
@@ -186,13 +186,14 @@ namespace nmos
     }
 
     // Get additional "video/jxsv" parameters from the SDP parameters
-    video_jxsv_parameters get_video_jxsv_parameters(const sdp_parameters& sdp_params)
+    template <typename MissingRequiredParameter>
+    video_jxsv_parameters get_video_jxsv_parameters(const sdp_parameters& sdp_params, MissingRequiredParameter missing = MissingRequiredParameter{})
     {
         video_jxsv_parameters params;
 
         const auto packetmode = details::find_fmtp(sdp_params.fmtp, sdp::video_jxsv::fields::packetmode);
-        if (sdp_params.fmtp.end() == packetmode) throw details::sdp_processing_error("missing format parameter: packetmode");
-        params.packetmode = (sdp::video_jxsv::packetization_mode)utility::istringstreamed<uint32_t>(packetmode->second);
+        if (sdp_params.fmtp.end() == packetmode) missing(sdp::video_jxsv::fields::packetmode);
+        else params.packetmode = (sdp::video_jxsv::packetization_mode)utility::istringstreamed<uint32_t>(packetmode->second);
 
         // optional
         const auto transmode = details::find_fmtp(sdp_params.fmtp, sdp::video_jxsv::fields::transmode);
@@ -284,6 +285,12 @@ namespace nmos
         if (sdp::bandwidth_types::application_specific == sdp_params.bandwidth.bandwidth_type) params.bit_rate = sdp_params.bandwidth.bandwidth;
 
         return params;
+    }
+
+    // Get additional "video/jxsv" parameters from the SDP parameters
+    video_jxsv_parameters get_video_jxsv_parameters(const sdp_parameters& sdp_params)
+    {
+        return get_video_jxsv_parameters<details::throw_missing_fmtp>(sdp_params);
     }
 
     // Calculate the format bit rate (kilobits/second) from the specified frame rate, dimensions and bits per pixel

--- a/Development/nmos/video_jxsv.cpp
+++ b/Development/nmos/video_jxsv.cpp
@@ -293,6 +293,12 @@ namespace nmos
         return get_video_jxsv_parameters<details::throw_missing_fmtp>(sdp_params);
     }
 
+    // Get additional "video/jxsv" parameters from the SDP parameters
+    video_jxsv_parameters get_video_jxsv_parameters_or_defaults(const sdp_parameters& sdp_params)
+    {
+        return get_video_jxsv_parameters<>(sdp_params, [](const utility::string_t&) {});
+    }
+
     // Calculate the format bit rate (kilobits/second) from the specified frame rate, dimensions and bits per pixel
     uint64_t get_video_jxsv_bit_rate(const nmos::rational& grain_rate, uint32_t frame_width, uint32_t frame_height, double bits_per_pixel)
     {

--- a/Development/nmos/video_jxsv.h
+++ b/Development/nmos/video_jxsv.h
@@ -353,6 +353,7 @@ namespace nmos
     sdp_parameters make_video_jxsv_sdp_parameters(const utility::string_t& session_name, const video_jxsv_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {});
     // Get additional "video/jxsv" parameters from the SDP parameters
     video_jxsv_parameters get_video_jxsv_parameters(const sdp_parameters& sdp_params);
+    video_jxsv_parameters get_video_jxsv_parameters_or_defaults(const sdp_parameters& sdp_params);
 
     // Construct SDP parameters for "video/jxsv"
     inline sdp_parameters make_sdp_parameters(const utility::string_t& session_name, const video_jxsv_parameters& params, uint64_t payload_type, const std::vector<utility::string_t>& media_stream_ids = {}, const std::vector<sdp_parameters::ts_refclk_t>& ts_refclk = {})


### PR DESCRIPTION
Add `_or_defaults` versions of the  format-specific parameters parsing functions; the current functions throw when required parameters are omitted. The intention is the new functions are for parsing partial `fmtp` lines, not handling invalid values, so they can still throw in those circumstances.

I should probably add `_or_defaults` versions for the other three media types even though none of those have required parameters, just so the naming and intended usage is clear?
