### PR TITLE
Fix condition variable wait

### DIFF
--- a/Development/boost/thread/win32_condition_variable.hpp
+++ b/Development/boost/thread/win32_condition_variable.hpp
@@ -9,7 +9,7 @@
 
 #include <boost/thread/win32/condition_variable.hpp>
 
-// Note: Windows `boost::condition_variable_any::wait` would throw nested lock exceptions when `boost::shared_mutex` has reached the
+// Note: Windows `boost::condition_variable_any::wait` throws nested lock exceptions when `boost::shared_mutex` has reached the
 // maximum number of exclusive_waiting locks. This problem occurrs inside the `boost::basic_condition_variable`'s do_wait_until(...),
 // when relocker is out scope. This could cause program termination due to unhandled exception.
 // This modified version of `condition_variable_any` presented below addresses the issues mentioned earlier.

--- a/Development/boost/thread/win32_condition_variable.hpp
+++ b/Development/boost/thread/win32_condition_variable.hpp
@@ -9,11 +9,10 @@
 
 #include <boost/thread/win32/condition_variable.hpp>
 
-// note, Windows `boost::condition_variable_any::wait` would throw a lock expectation when `boost::shared_mutex` has reached the
-// maximum number of exclusive_waiting locks. Unfortunately, the standard `boost::condition_variable_any`'s relocker
-// destructor could also throw a lock exception. This could cause program termination due to unhandled exceptions by the
-// `boost::condition_variable_any`'s do_wait_until(...).
-// The modified version of `condition_variable_any` presented below addresses the issues mentioned earlier.
+// Note: Windows `boost::condition_variable_any::wait` would throw nested lock exceptions when `boost::shared_mutex` has reached the
+// maximum number of exclusive_waiting locks. This problem occurrs inside the `boost::basic_condition_variable`'s do_wait_until(...),
+// when relocker is out scope. This could cause program termination due to unhandled exception.
+// This modified version of `condition_variable_any` presented below addresses the issues mentioned earlier.
 namespace boost
 {
 	namespace experimental

--- a/Development/boost/thread/win32_condition_variable.hpp
+++ b/Development/boost/thread/win32_condition_variable.hpp
@@ -1,0 +1,445 @@
+// based on the <boost/thread/win32/condition_variable.hpp>
+
+#ifndef BOOST_THREAD_WIN32_CONDITION_VARIABLE_HPP
+#define BOOST_THREAD_WIN32_CONDITION_VARIABLE_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include <boost/thread/win32/condition_variable.hpp>
+
+// note, Windows `boost::condition_variable_any::wait` would throw a lock expectation when `boost::shared_mutex` has reached the
+// maximum number of exclusive_waiting locks. Unfortunately, the standard `boost::condition_variable_any`'s relocker
+// destructor could also throw a lock exception. This could cause program termination due to unhandled exceptions by the
+// `boost::condition_variable_any`'s do_wait_until(...).
+// The modified version of `condition_variable_any` presented below addresses the issues mentioned earlier.
+namespace boost
+{
+	namespace experimental
+    {
+        class basic_condition_variable
+        {
+            boost::mutex internal_mutex;
+            long total_count;
+            unsigned active_generation_count;
+
+            typedef boost::detail::basic_cv_list_entry list_entry;
+
+            typedef boost::intrusive_ptr<list_entry> entry_ptr;
+            typedef std::vector<entry_ptr> generation_list;
+
+            generation_list generations;
+            detail::win32::handle_manager wake_sem;
+
+            void wake_waiters(long count_to_wake)
+            {
+                detail::interlocked_write_release(&total_count, total_count - count_to_wake);
+                winapi::ReleaseSemaphore(wake_sem, count_to_wake, 0);
+            }
+
+            template<typename lock_type>
+            struct relocker
+            {
+                BOOST_THREAD_NO_COPYABLE(relocker)
+                    lock_type& _lock;
+                bool _unlocked;
+
+                relocker(lock_type& lock_) :
+                    _lock(lock_), _unlocked(false)
+                {
+                }
+                void unlock()
+                {
+                    if (!_unlocked)
+                    {
+                        try
+                        {
+                            _lock.unlock();
+                        }
+                        catch (...)
+                        {
+                            // ignore, threat this as unlocked
+                        }
+                        _unlocked = true;
+                    }
+                }
+                void lock()
+                {
+                    if (_unlocked)
+                    {
+                        _lock.lock();
+                        _unlocked = false;
+                    }
+                }
+                ~relocker() BOOST_NOEXCEPT_IF(true)
+                {
+                    try
+                    {
+                        lock();
+                    }
+                    catch (...)
+                    {
+                        // ignore the lock exception. This could cause program termination due to unhandled exceptions
+                    }
+                }
+            };
+
+
+            entry_ptr get_wait_entry()
+            {
+                boost::lock_guard<boost::mutex> lk(internal_mutex);
+                if (!wake_sem)
+                {
+                    wake_sem = detail::win32::create_anonymous_semaphore(0, LONG_MAX);
+                    BOOST_ASSERT(wake_sem);
+                }
+
+                detail::interlocked_write_release(&total_count, total_count + 1);
+                if (generations.empty() || generations.back()->is_notified())
+                {
+                    entry_ptr new_entry(new list_entry(wake_sem));
+                    generations.push_back(new_entry);
+                    return new_entry;
+                }
+                else
+                {
+                    generations.back()->add_waiter();
+                    return generations.back();
+                }
+            }
+
+            struct entry_manager
+            {
+                entry_ptr entry;
+                boost::mutex& internal_mutex;
+
+
+                BOOST_THREAD_NO_COPYABLE(entry_manager)
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+                    entry_manager(entry_ptr&& entry_, boost::mutex& mutex_) :
+                    entry(static_cast<entry_ptr&&>(entry_)), internal_mutex(mutex_)
+                {
+                }
+#else
+                    entry_manager(entry_ptr const& entry_, boost::mutex& mutex_) :
+                    entry(entry_), internal_mutex(mutex_)
+                {
+                }
+#endif
+
+                void remove_waiter_and_reset()
+                {
+                    if (entry) {
+                        boost::lock_guard<boost::mutex> internal_lock(internal_mutex);
+                        entry->remove_waiter();
+                        entry.reset();
+                    }
+                }
+                ~entry_manager() BOOST_NOEXCEPT_IF(false)
+                {
+                    remove_waiter_and_reset();
+                }
+
+                list_entry* operator->()
+                {
+                    return entry.get();
+                }
+            };
+
+        protected:
+            basic_condition_variable(const basic_condition_variable& other);
+            basic_condition_variable& operator=(const basic_condition_variable& other);
+
+        public:
+            basic_condition_variable() :
+                total_count(0), active_generation_count(0), wake_sem(0)
+            {
+            }
+
+            ~basic_condition_variable()
+            {
+            }
+
+            // When this function returns true:
+            // * A notification (or sometimes a spurious OS signal) has been received
+            // * Do not assume that the timeout has not been reached
+            // * Do not assume that the predicate has been changed
+            //
+            // When this function returns false:
+            // * The timeout has been reached
+            // * Do not assume that a notification has not been received
+            // * Do not assume that the predicate has not been changed
+            template<typename lock_type>
+            bool do_wait_until(lock_type& lock, detail::internal_platform_timepoint const& timeout)
+            {
+                relocker<lock_type> locker(lock);
+                entry_manager entry(get_wait_entry(), internal_mutex);
+                locker.unlock();
+
+                bool woken = false;
+                while (!woken)
+                {
+                    if (!entry->interruptible_wait(timeout))
+                    {
+                        return false;
+                    }
+
+                    woken = entry->woken();
+                }
+                // do it here to avoid throwing on the destructor
+                entry.remove_waiter_and_reset();
+                locker.lock();
+                return true;
+            }
+
+            void notify_one() BOOST_NOEXCEPT
+            {
+                if (detail::interlocked_read_acquire(&total_count))
+                {
+                    boost::lock_guard<boost::mutex> internal_lock(internal_mutex);
+                    if (!total_count)
+                    {
+                        return;
+                    }
+                    wake_waiters(1);
+
+                    for (generation_list::iterator it = generations.begin(),
+                        end = generations.end();
+                        it != end; ++it)
+                    {
+                        (*it)->release(1);
+                    }
+                    generations.erase(std::remove_if(generations.begin(), generations.end(), &boost::detail::basic_cv_list_entry::no_waiters), generations.end());
+                }
+            }
+
+            void notify_all() BOOST_NOEXCEPT
+            {
+                if (detail::interlocked_read_acquire(&total_count))
+                {
+                    boost::lock_guard<boost::mutex> internal_lock(internal_mutex);
+                    if (!total_count)
+                    {
+                        return;
+                    }
+                    wake_waiters(total_count);
+                    for (generation_list::iterator it = generations.begin(),
+                        end = generations.end();
+                        it != end; ++it)
+                    {
+                        (*it)->release_waiters();
+                    }
+                    generations.clear();
+                    wake_sem = detail::win32::handle(0);
+                }
+            }
+
+        };
+
+        class condition_variable_any :
+            public experimental::basic_condition_variable
+        {
+        public:
+            BOOST_THREAD_NO_COPYABLE(condition_variable_any)
+                condition_variable_any()
+            {
+            }
+
+            using experimental::basic_condition_variable::do_wait_until;
+            using experimental::basic_condition_variable::notify_one;
+            using experimental::basic_condition_variable::notify_all;
+
+            template<typename lock_type>
+            void wait(lock_type& m)
+            {
+                do_wait_until(m, detail::internal_platform_timepoint::getMax());
+            }
+
+            template<typename lock_type, typename predicate_type>
+            void wait(lock_type& m, predicate_type pred)
+            {
+                while (!pred())
+                {
+                    wait(m);
+                }
+            }
+
+#if defined BOOST_THREAD_USES_DATETIME
+            template<typename lock_type>
+            bool timed_wait(lock_type& m, boost::system_time const& abs_time)
+            {
+                // The system time may jump while this function is waiting. To compensate for this and time
+                // out near the correct time, we could call do_wait_until() in a loop with a short timeout
+                // and recheck the time remaining each time through the loop. However, because we can't
+                // check the predicate each time do_wait_until() completes, this introduces the possibility
+                // of not exiting the function when a notification occurs, since do_wait_until() may report
+                // that it timed out even though a notification was received. The best this function can do
+                // is report correctly whether or not it reached the timeout time.
+                const detail::real_platform_timepoint ts(abs_time);
+                const detail::platform_duration d(ts - detail::real_platform_clock::now());
+                do_wait_until(m, detail::internal_platform_clock::now() + d);
+                return ts > detail::real_platform_clock::now();
+            }
+
+            template<typename lock_type>
+            bool timed_wait(lock_type& m, boost::xtime const& abs_time)
+            {
+                return timed_wait(m, system_time(abs_time));
+            }
+
+            template<typename lock_type, typename duration_type>
+            bool timed_wait(lock_type& m, duration_type const& wait_duration)
+            {
+                if (wait_duration.is_pos_infinity())
+                {
+                    wait(m);
+                    return true;
+                }
+                if (wait_duration.is_special())
+                {
+                    return true;
+                }
+                const detail::platform_duration d(wait_duration);
+                return do_wait_until(m, detail::internal_platform_clock::now() + d);
+            }
+
+            template<typename lock_type, typename predicate_type>
+            bool timed_wait(lock_type& m, boost::system_time const& abs_time, predicate_type pred)
+            {
+                // The system time may jump while this function is waiting. To compensate for this
+                // and time out near the correct time, we call do_wait_until() in a loop with a
+                // short timeout and recheck the time remaining each time through the loop.
+                const detail::real_platform_timepoint ts(abs_time);
+                while (!pred())
+                {
+                    detail::platform_duration d(ts - detail::real_platform_clock::now());
+                    if (d <= detail::platform_duration::zero()) break; // timeout occurred
+                    d = (std::min)(d, detail::platform_milliseconds(BOOST_THREAD_POLL_INTERVAL_MILLISECONDS));
+                    do_wait_until(m, detail::internal_platform_clock::now() + d);
+                }
+                return pred();
+            }
+
+            template<typename lock_type, typename predicate_type>
+            bool timed_wait(lock_type& m, boost::xtime const& abs_time, predicate_type pred)
+            {
+                return timed_wait(m, system_time(abs_time), pred);
+            }
+
+            template<typename lock_type, typename duration_type, typename predicate_type>
+            bool timed_wait(lock_type& m, duration_type const& wait_duration, predicate_type pred)
+            {
+                if (wait_duration.is_pos_infinity())
+                {
+                    while (!pred())
+                    {
+                        wait(m);
+                    }
+                    return true;
+                }
+                if (wait_duration.is_special())
+                {
+                    return pred();
+                }
+                const detail::platform_duration d(wait_duration);
+                const detail::internal_platform_timepoint ts(detail::internal_platform_clock::now() + d);
+                while (!pred())
+                {
+                    if (!do_wait_until(m, ts)) break; // timeout occurred
+                }
+                return pred();
+            }
+#endif
+#ifdef BOOST_THREAD_USES_CHRONO
+            template <class lock_type, class Duration>
+            cv_status
+                wait_until(
+                    lock_type& lock,
+                    const chrono::time_point<detail::internal_chrono_clock, Duration>& t)
+            {
+                const detail::internal_platform_timepoint ts(t);
+                if (do_wait_until(lock, ts)) return cv_status::no_timeout;
+                else return cv_status::timeout;
+            }
+
+            template <class lock_type, class Clock, class Duration>
+            cv_status
+                wait_until(
+                    lock_type& lock,
+                    const chrono::time_point<Clock, Duration>& t)
+            {
+                // The system time may jump while this function is waiting. To compensate for this and time
+                // out near the correct time, we could call do_wait_until() in a loop with a short timeout
+                // and recheck the time remaining each time through the loop. However, because we can't
+                // check the predicate each time do_wait_until() completes, this introduces the possibility
+                // of not exiting the function when a notification occurs, since do_wait_until() may report
+                // that it timed out even though a notification was received. The best this function can do
+                // is report correctly whether or not it reached the timeout time.
+                typedef typename common_type<Duration, typename Clock::duration>::type common_duration;
+                common_duration d(t - Clock::now());
+                do_wait_until(lock, detail::internal_chrono_clock::now() + d);
+                if (t > Clock::now()) return cv_status::no_timeout;
+                else return cv_status::timeout;
+            }
+
+            template <class lock_type, class Rep, class Period>
+            cv_status
+                wait_for(
+                    lock_type& lock,
+                    const chrono::duration<Rep, Period>& d)
+            {
+                return wait_until(lock, chrono::steady_clock::now() + d);
+            }
+
+            template <class lock_type, class Clock, class Duration, class Predicate>
+            bool
+                wait_until(
+                    lock_type& lock,
+                    const chrono::time_point<detail::internal_chrono_clock, Duration>& t,
+                    Predicate pred)
+            {
+                const detail::internal_platform_timepoint ts(t);
+                while (!pred())
+                {
+                    if (!do_wait_until(lock, ts)) break; // timeout occurred
+                }
+                return pred();
+            }
+
+            template <class lock_type, class Clock, class Duration, class Predicate>
+            bool
+                wait_until(
+                    lock_type& lock,
+                    const chrono::time_point<Clock, Duration>& t,
+                    Predicate pred)
+            {
+                // The system time may jump while this function is waiting. To compensate for this
+                // and time out near the correct time, we call do_wait_until() in a loop with a
+                // short timeout and recheck the time remaining each time through the loop.
+                typedef typename common_type<Duration, typename Clock::duration>::type common_duration;
+                while (!pred())
+                {
+                    common_duration d(t - Clock::now());
+                    if (d <= common_duration::zero()) break; // timeout occurred
+                    d = (std::min)(d, common_duration(chrono::milliseconds(BOOST_THREAD_POLL_INTERVAL_MILLISECONDS)));
+                    do_wait_until(lock, detail::internal_platform_clock::now() + detail::platform_duration(d));
+                }
+                return pred();
+            }
+
+            template <class lock_type, class Rep, class Period, class Predicate>
+            bool
+                wait_for(
+                    lock_type& lock,
+                    const chrono::duration<Rep, Period>& d,
+                    Predicate pred)
+            {
+                return wait_until(lock, chrono::steady_clock::now() + d, boost::move(pred));
+            }
+#endif
+        };
+	} // namespace experimental
+} // namespace boost
+
+#endif // BOOST_THREAD_WIN32_CONDITION_VARIABLE_HPP

--- a/Development/boost/thread/win32_condition_variable.hpp
+++ b/Development/boost/thread/win32_condition_variable.hpp
@@ -1,4 +1,4 @@
-// based on the <boost/thread/win32/condition_variable.hpp>
+// based on the <boost/thread/win32/condition_variable.hpp version 1.83.0>
 
 #ifndef BOOST_THREAD_WIN32_CONDITION_VARIABLE_HPP
 #define BOOST_THREAD_WIN32_CONDITION_VARIABLE_HPP
@@ -15,7 +15,7 @@
 // This modified version of `condition_variable_any` presented below addresses the issues mentioned earlier.
 namespace boost
 {
-	namespace experimental
+    namespace experimental
     {
         class basic_condition_variable
         {
@@ -438,7 +438,7 @@ namespace boost
             }
 #endif
         };
-	} // namespace experimental
+    } // namespace experimental
 } // namespace boost
 
 #endif // BOOST_THREAD_WIN32_CONDITION_VARIABLE_HPP

--- a/Development/bst/shared_mutex.h
+++ b/Development/bst/shared_mutex.h
@@ -3,14 +3,7 @@
 
 // Provide bst::shared_mutex, bst::shared_lock etc. using either std:: or boost:: symbols
 
-#if !defined(BST_SHARED_MUTEX_STD) && !defined(BST_SHARED_MUTEX_BOOST)
-// To do: Detect whether std::shared_mutex is available using __cplusplus (and compiler/library-specific preprocessor definitions)
-// Note: If this isn't defined under the same condition as BST_THREAD_BOOST, adding shared_timed_mutex is problematic
-// because its timeout functionality won't be consistent with bst::chrono
-#define BST_SHARED_MUTEX_BOOST
-#endif
-
-#ifndef BST_SHARED_MUTEX_BOOST
+#ifndef BST_THREAD_BOOST
 
 #include <condition_variable>
 #include <shared_mutex>
@@ -23,11 +16,9 @@ namespace bst_shared_mutex_condition_variable_any = std;
 #include <boost/thread/shared_mutex.hpp>
 namespace bst_shared_mutex = boost;
 
-#if defined(_WIN32)
-// note, Windows boost::condition_variable_any::wait would throw a lock expectation when boost::shared_mutex has reached the
-// maximum number of exclusive_waiting locks. Unfortunately, the standard boost::condition_variable_any's relocker
-// destructor could also throw a lock exception. This could cause program termination due to unhandled exceptions by the
-// boost::condition_variable_any's do_wait_until(...)
+#ifdef _WIN32
+// Note:: Windows boost::condition_variable_any::wait would throw nested lock expectations when boost::shared_mutex has reached the
+// maximum number of exclusive_waiting locks.A modified version of the boost::condition_variable_any was created to address this issue.
 #include "boost/thread/win32_condition_variable.hpp"
 namespace bst_shared_mutex_condition_variable_any = boost::experimental;
 #else

--- a/Development/bst/shared_mutex.h
+++ b/Development/bst/shared_mutex.h
@@ -17,7 +17,7 @@ namespace bst_shared_mutex_condition_variable_any = std;
 namespace bst_shared_mutex = boost;
 
 #ifdef _WIN32
-// Note:: Windows boost::condition_variable_any::wait would throw nested lock expectations when boost::shared_mutex has reached the
+// Note:: Windows boost::condition_variable_any::wait would throw nested lock exceptions when boost::shared_mutex has reached the
 // maximum number of exclusive_waiting locks.A modified version of the boost::condition_variable_any was created to address this issue.
 #include "boost/thread/win32_condition_variable.hpp"
 namespace bst_shared_mutex_condition_variable_any = boost::experimental;

--- a/Development/bst/shared_mutex.h
+++ b/Development/bst/shared_mutex.h
@@ -17,8 +17,8 @@ namespace bst_shared_mutex_condition_variable_any = std;
 namespace bst_shared_mutex = boost;
 
 #ifdef _WIN32
-// Note:: Windows boost::condition_variable_any::wait would throw nested lock exceptions when boost::shared_mutex has reached the
-// maximum number of exclusive_waiting locks.A modified version of the boost::condition_variable_any was created to address this issue.
+// Note:: Windows boost::condition_variable_any::wait throws nested lock exceptions when boost::shared_mutex has reached the
+// maximum number of exclusive_waiting locks. A modified version of the boost::condition_variable_any was created to address this issue.
 #include "boost/thread/win32_condition_variable.hpp"
 namespace bst_shared_mutex_condition_variable_any = boost::experimental;
 #else

--- a/Development/bst/shared_mutex.h
+++ b/Development/bst/shared_mutex.h
@@ -12,8 +12,10 @@
 
 #ifndef BST_SHARED_MUTEX_BOOST
 
+#include <condition_variable>
 #include <shared_mutex>
 namespace bst_shared_mutex = std;
+namespace bst_shared_mutex_condition_variable_any = std;
 
 #else
 
@@ -21,12 +23,27 @@ namespace bst_shared_mutex = std;
 #include <boost/thread/shared_mutex.hpp>
 namespace bst_shared_mutex = boost;
 
+#if defined(_WIN32)
+// note, Windows boost::condition_variable_any::wait would throw a lock expectation when boost::shared_mutex has reached the
+// maximum number of exclusive_waiting locks. Unfortunately, the standard boost::condition_variable_any's relocker
+// destructor could also throw a lock exception. This could cause program termination due to unhandled exceptions by the
+// boost::condition_variable_any's do_wait_until(...)
+#include "boost/thread/win32_condition_variable.hpp"
+namespace bst_shared_mutex_condition_variable_any = boost::experimental;
+#else
+#include <boost/thread/condition_variable.hpp>
+namespace bst_shared_mutex_condition_variable_any = boost;
+#endif
+
 #endif
 
 namespace bst
 {
     using bst_shared_mutex::shared_mutex;
     using bst_shared_mutex::shared_lock;
+    using bst_shared_mutex_condition_variable_any::condition_variable_any;
+    using bst_shared_mutex::nano;
+    using bst_shared_mutex::cv_status;
 }
 
 #endif

--- a/Development/cmake/NmosCppLibraries.cmake
+++ b/Development/cmake/NmosCppLibraries.cmake
@@ -837,6 +837,12 @@ add_library(nmos-cpp::nmos_is12_schemas ALIAS nmos_is12_schemas)
 
 # nmos-cpp library
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    set(NMOS_CPP_BOOST_THREAD_HEADERS
+        boost/thread/win32_condition_variable.hpp
+        )
+endif()
+
 set(NMOS_CPP_BST_SOURCES
     )
 set(NMOS_CPP_BST_HEADERS
@@ -1237,6 +1243,9 @@ target_include_directories(nmos-cpp PUBLIC
     $<INSTALL_INTERFACE:${NMOS_CPP_INSTALL_INCLUDEDIR}>
     )
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    install(FILES ${NMOS_CPP_BOOST_THREAD_HEADERS} DESTINATION ${NMOS_CPP_INSTALL_INCLUDEDIR}/boost/thread)
+endif()
 install(FILES ${NMOS_CPP_BST_HEADERS} DESTINATION ${NMOS_CPP_INSTALL_INCLUDEDIR}/bst)
 install(FILES ${NMOS_CPP_CPPREST_HEADERS} DESTINATION ${NMOS_CPP_INSTALL_INCLUDEDIR}/cpprest)
 install(FILES ${NMOS_CPP_CPPREST_DETAILS_HEADERS} DESTINATION ${NMOS_CPP_INSTALL_INCLUDEDIR}/cpprest/details)

--- a/Development/cmake/NmosCppLibraries.cmake
+++ b/Development/cmake/NmosCppLibraries.cmake
@@ -30,6 +30,7 @@ target_compile_definitions(
     slog INTERFACE
     SLOG_STATIC
     SLOG_LOGGING_SEVERITY=${SLOG_LOGGING_SEVERITY}
+    BST_THREAD_BOOST # provide bst::chrono::duration, etc. using either std:: or boost:: symbols
     )
 if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)

--- a/Development/cmake/NmosCppTest.cmake
+++ b/Development/cmake/NmosCppTest.cmake
@@ -42,8 +42,8 @@ set(NMOS_CPP_TEST_MDNS_TEST_HEADERS
 set(NMOS_CPP_TEST_NMOS_TEST_SOURCES
     nmos/test/api_utils_test.cpp
     nmos/test/capabilities_test.cpp
-    nmos/test/condition_variable_test.cpp
     nmos/test/channels_test.cpp
+    nmos/test/condition_variable_test.cpp
     nmos/test/control_protocol_test.cpp
     nmos/test/did_sdid_test.cpp
     nmos/test/event_type_test.cpp

--- a/Development/cmake/NmosCppTest.cmake
+++ b/Development/cmake/NmosCppTest.cmake
@@ -42,6 +42,7 @@ set(NMOS_CPP_TEST_MDNS_TEST_HEADERS
 set(NMOS_CPP_TEST_NMOS_TEST_SOURCES
     nmos/test/api_utils_test.cpp
     nmos/test/capabilities_test.cpp
+    nmos/test/condition_variable_test.cpp
     nmos/test/channels_test.cpp
     nmos/test/control_protocol_test.cpp
     nmos/test/did_sdid_test.cpp

--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -283,7 +283,7 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
     // and that the the node behaviour thread be notified after doing so
     const auto insert_resource_after = [&model, &lock](unsigned int milliseconds, nmos::resources& resources, nmos::resource&& resource, slog::base_gate& gate)
     {
-        if (nmos::details::wait_for(model.shutdown_condition, lock, std::chrono::milliseconds(milliseconds), [&] { return model.shutdown; })) return false;
+        if (nmos::details::wait_for(model.shutdown_condition, lock, bst::chrono::milliseconds(milliseconds), [&] { return model.shutdown; })) return false;
 
         const std::pair<nmos::id, nmos::type> id_type{ resource.id, resource.type };
         const bool success = insert_resource(resources, std::move(resource)).second;

--- a/Development/nmos/activation_utils.cpp
+++ b/Development/nmos/activation_utils.cpp
@@ -167,12 +167,12 @@ namespace nmos
         // or for the timeout to expire
         bool wait_immediate_activation_not_pending(nmos::node_model& model, nmos::read_lock& lock, const std::pair<nmos::id, nmos::type>& id_type)
         {
-            return model.wait_for(lock, std::chrono::seconds(nmos::fields::immediate_activation_max(model.settings)), immediate_activation_not_pending{ model, id_type });
+            return model.wait_for(lock, bst::chrono::seconds(nmos::fields::immediate_activation_max(model.settings)), immediate_activation_not_pending{ model, id_type });
         }
 
         bool wait_immediate_activation_not_pending(nmos::node_model& model, nmos::write_lock& lock, const std::pair<nmos::id, nmos::type>& id_type)
         {
-            return model.wait_for(lock, std::chrono::seconds(nmos::fields::immediate_activation_max(model.settings)), immediate_activation_not_pending{ model, id_type });
+            return model.wait_for(lock, bst::chrono::seconds(nmos::fields::immediate_activation_max(model.settings)), immediate_activation_not_pending{ model, id_type });
         }
 
         // wait for the staged activation of the specified resource to have changed
@@ -181,7 +181,7 @@ namespace nmos
         // or for the timeout to expire
         bool wait_activation_modified(nmos::node_model& model, nmos::write_lock& lock, std::pair<nmos::id, nmos::type> id_type, web::json::value initial_activation)
         {
-            return model.wait_for(lock, std::chrono::seconds(nmos::fields::immediate_activation_max(model.settings)), [&]
+            return model.wait_for(lock, bst::chrono::seconds(nmos::fields::immediate_activation_max(model.settings)), [&]
             {
                 if (model.shutdown) return true;
 

--- a/Development/nmos/api_utils.cpp
+++ b/Development/nmos/api_utils.cpp
@@ -506,7 +506,7 @@ namespace nmos
 
                 const auto received_time = req.headers().find(details::received_time);
                 const auto processing_dur = req.headers().end() != received_time
-                    ? std::chrono::duration_cast<std::chrono::microseconds>(nmos::tai_clock::now() - nmos::time_point_from_tai(nmos::parse_version(received_time->second))).count() / 1000.0
+                    ? bst::chrono::duration_cast<bst::chrono::microseconds>(nmos::tai_clock::now() - nmos::time_point_from_tai(nmos::parse_version(received_time->second))).count() / 1000.0
                     : 0.0;
 
                 // experimental extension, to add Server-Timing response header

--- a/Development/nmos/authorization_behaviour.cpp
+++ b/Development/nmos/authorization_behaviour.cpp
@@ -112,10 +112,8 @@ namespace nmos
                         auto lock = model.read_lock();
                         const auto random_backoff = std::uniform_real_distribution<>(0, discovery_backoff)(discovery_backoff_engine);
                         slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Waiting to retry Authorization API discovery for about " << std::fixed << std::setprecision(3) << random_backoff << " seconds (current backoff limit: " << discovery_backoff << " seconds)";
-                        if (model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; }))
-                        {
-                            if (model.shutdown) break;
-                        }
+                        model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });
+                        if (model.shutdown) break;
                     }
 
                     // The Node performs a DNS-SD browse for services of type '_nmos-auth._tcp' as specified.

--- a/Development/nmos/authorization_behaviour.cpp
+++ b/Development/nmos/authorization_behaviour.cpp
@@ -112,8 +112,10 @@ namespace nmos
                         auto lock = model.read_lock();
                         const auto random_backoff = std::uniform_real_distribution<>(0, discovery_backoff)(discovery_backoff_engine);
                         slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Waiting to retry Authorization API discovery for about " << std::fixed << std::setprecision(3) << random_backoff << " seconds (current backoff limit: " << discovery_backoff << " seconds)";
-                        model.wait_for(lock, std::chrono::milliseconds(std::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });
-                        if (model.shutdown) break;
+                        if (model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; }))
+                        {
+                            if (model.shutdown) break;
+                        }
                     }
 
                     // The Node performs a DNS-SD browse for services of type '_nmos-auth._tcp' as specified.

--- a/Development/nmos/authorization_operation.cpp
+++ b/Development/nmos/authorization_operation.cpp
@@ -1646,7 +1646,7 @@ namespace nmos
                     if (authorization_code_flow_max > -1)
                     {
                         // wait for access token with timeout
-                        if (!model.wait_for(lock, std::chrono::seconds(authorization_code_flow_max), [&] {
+                        if (!model.wait_for(lock, bst::chrono::seconds(authorization_code_flow_max), [&] {
                             authorization_flow = with_read_lock(authorization_state.mutex, [&] { return authorization_state.authorization_flow; });
                             return shutdown || nmos::experimental::authorization_state::failed == authorization_flow || nmos::experimental::authorization_state::access_token_received == authorization_flow; }))
                         {

--- a/Development/nmos/channelmapping_activation.cpp
+++ b/Development/nmos/channelmapping_activation.cpp
@@ -198,7 +198,7 @@ namespace nmos
             if ((nmos::tai_clock::time_point::max)() != earliest_scheduled_activation)
             {
                 slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Next scheduled channel mapping activation is at " << nmos::make_version(nmos::tai_from_time_point(earliest_scheduled_activation))
-                    << " in about " << std::fixed << std::setprecision(3) << std::chrono::duration_cast<std::chrono::duration<double>>(earliest_scheduled_activation - now).count() << " seconds time";
+                    << " in about " << std::fixed << std::setprecision(3) << bst::chrono::duration_cast<bst::chrono::duration<double>>(earliest_scheduled_activation - now).count() << " seconds time";
             }
 
             if (notify)

--- a/Development/nmos/connection_activation.cpp
+++ b/Development/nmos/connection_activation.cpp
@@ -194,7 +194,7 @@ namespace nmos
             if ((nmos::tai_clock::time_point::max)() != earliest_scheduled_activation)
             {
                 slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Next scheduled activation is at " << nmos::make_version(nmos::tai_from_time_point(earliest_scheduled_activation))
-                    << " in about " << std::fixed << std::setprecision(3) << std::chrono::duration_cast<std::chrono::duration<double>>(earliest_scheduled_activation - now).count() << " seconds time";
+                    << " in about " << std::fixed << std::setprecision(3) << bst::chrono::duration_cast<bst::chrono::duration<double>>(earliest_scheduled_activation - now).count() << " seconds time";
             }
 
             if (notify)

--- a/Development/nmos/control_protocol_ws_api.cpp
+++ b/Development/nmos/control_protocol_ws_api.cpp
@@ -448,91 +448,89 @@ namespace nmos
         {
             // wait for the thread to be interrupted either because there are resource changes, or because the server is being shut down
             // or because message sending was throttled earlier
-            if (details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || most_recent_message < most_recent_update(resources); }))
+            details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || most_recent_message < most_recent_update(resources); });
+            if (shutdown) break;
+            most_recent_message = most_recent_update(resources);
+
+            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Got notification on control protocol websockets thread";
+
+            earliest_necessary_update = (tai_clock::time_point::max)();
+
+            std::vector<std::pair<web::websockets::experimental::listener::connection_id, web::websockets::websocket_outgoing_message>> outgoing_messages;
+
+            for (auto wit = websockets.left.begin(); websockets.left.end() != wit;)
             {
-                if (shutdown) break;
-                most_recent_message = most_recent_update(resources);
+                const auto& websocket = *wit;
 
-                slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Got notification on control protocol websockets thread";
-
-                earliest_necessary_update = (tai_clock::time_point::max)();
-
-                std::vector<std::pair<web::websockets::experimental::listener::connection_id, web::websockets::websocket_outgoing_message>> outgoing_messages;
-
-                for (auto wit = websockets.left.begin(); websockets.left.end() != wit;)
+                // for each websocket connection that has valid grain and subscription resources
+                const auto grain = find_resource(resources, { websocket.first, nmos::types::grain });
+                if (resources.end() == grain)
                 {
-                    const auto& websocket = *wit;
-
-                    // for each websocket connection that has valid grain and subscription resources
-                    const auto grain = find_resource(resources, { websocket.first, nmos::types::grain });
-                    if (resources.end() == grain)
-                    {
-                        auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
-                            .then(details::observe_websocket_exception(gate));
-                        // theoretically blocking, but in fact not
-                        close.wait();
-
-                        wit = websockets.left.erase(wit);
-                        continue;
-                    }
-                    const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
-                    if (resources.end() == subscription)
-                    {
-                        // a grain without a subscription shouldn't be possible, but let's be tidy
-                        erase_resource(resources, grain->id);
-
-                        auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
-                            .then(details::observe_websocket_exception(gate));
-                        // theoretically blocking, but in fact not
-                        close.wait();
-
-                        wit = websockets.left.erase(wit);
-                        continue;
-                    }
-                    // and has events to send
-                    if (0 == nmos::fields::message_grain_data(grain->data).size())
-                    {
-                        ++wit;
-                        continue;
-                    }
-
-                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing to send " << nmos::fields::message_grain_data(grain->data).size() << " events on websocket connection: " << grain->id;
-
-                    for (const auto& event : nmos::fields::message_grain_data(grain->data).as_array())
-                    {
-                        web::websockets::websocket_outgoing_message message;
-
-                        slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "outgoing_message: " << event.serialize();
-                        message.set_utf8_message(utility::us2s(event.serialize()));
-                        outgoing_messages.push_back({ websocket.second, message });
-                    }
-
-                    // reset the grain for next time
-                    resources.modify(grain, [&resources](nmos::resource& grain)
-                    {
-                        // all messages have now been prepared
-                        nmos::fields::message_grain_data(grain.data) = value::array();
-                        grain.updated = strictly_increasing_update(resources);
-                    });
-
-                    ++wit;
-                }
-
-                // send the messages without the lock on resources
-                details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
-
-                if (!outgoing_messages.empty()) slog::log<slog::severities::info>(gate, SLOG_FLF) << "Sending " << outgoing_messages.size() << " websocket messages";
-
-                for (auto& outgoing_message : outgoing_messages)
-                {
-                    // hmmm, no way to cancel this currently...
-
-                    auto send = listener.send(outgoing_message.first, outgoing_message.second)
+                    auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
                         .then(details::observe_websocket_exception(gate));
-                    // current websocket_listener implementation is synchronous in any case, but just to make clear...
-                    // for now, wait for the message to be sent
-                    send.wait();
+                    // theoretically blocking, but in fact not
+                    close.wait();
+
+                    wit = websockets.left.erase(wit);
+                    continue;
                 }
+                const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
+                if (resources.end() == subscription)
+                {
+                    // a grain without a subscription shouldn't be possible, but let's be tidy
+                    erase_resource(resources, grain->id);
+
+                    auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
+                        .then(details::observe_websocket_exception(gate));
+                    // theoretically blocking, but in fact not
+                    close.wait();
+
+                    wit = websockets.left.erase(wit);
+                    continue;
+                }
+                // and has events to send
+                if (0 == nmos::fields::message_grain_data(grain->data).size())
+                {
+                    ++wit;
+                    continue;
+                }
+
+                slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing to send " << nmos::fields::message_grain_data(grain->data).size() << " events on websocket connection: " << grain->id;
+
+                for (const auto& event : nmos::fields::message_grain_data(grain->data).as_array())
+                {
+                    web::websockets::websocket_outgoing_message message;
+
+                    slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "outgoing_message: " << event.serialize();
+                    message.set_utf8_message(utility::us2s(event.serialize()));
+                    outgoing_messages.push_back({ websocket.second, message });
+                }
+
+                // reset the grain for next time
+                resources.modify(grain, [&resources](nmos::resource& grain)
+                {
+                    // all messages have now been prepared
+                    nmos::fields::message_grain_data(grain.data) = value::array();
+                    grain.updated = strictly_increasing_update(resources);
+                });
+
+                ++wit;
+            }
+
+            // send the messages without the lock on resources
+            details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
+
+            if (!outgoing_messages.empty()) slog::log<slog::severities::info>(gate, SLOG_FLF) << "Sending " << outgoing_messages.size() << " websocket messages";
+
+            for (auto& outgoing_message : outgoing_messages)
+            {
+                // hmmm, no way to cancel this currently...
+
+                auto send = listener.send(outgoing_message.first, outgoing_message.second)
+                    .then(details::observe_websocket_exception(gate));
+                // current websocket_listener implementation is synchronous in any case, but just to make clear...
+                // for now, wait for the message to be sent
+                send.wait();
             }
         }
     }

--- a/Development/nmos/control_protocol_ws_api.cpp
+++ b/Development/nmos/control_protocol_ws_api.cpp
@@ -448,89 +448,91 @@ namespace nmos
         {
             // wait for the thread to be interrupted either because there are resource changes, or because the server is being shut down
             // or because message sending was throttled earlier
-            details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || most_recent_message < most_recent_update(resources); });
-            if (shutdown) break;
-            most_recent_message = most_recent_update(resources);
-
-            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Got notification on control protocol websockets thread";
-
-            earliest_necessary_update = (tai_clock::time_point::max)();
-
-            std::vector<std::pair<web::websockets::experimental::listener::connection_id, web::websockets::websocket_outgoing_message>> outgoing_messages;
-
-            for (auto wit = websockets.left.begin(); websockets.left.end() != wit;)
+            if (details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || most_recent_message < most_recent_update(resources); }))
             {
-                const auto& websocket = *wit;
+                if (shutdown) break;
+                most_recent_message = most_recent_update(resources);
 
-                // for each websocket connection that has valid grain and subscription resources
-                const auto grain = find_resource(resources, { websocket.first, nmos::types::grain });
-                if (resources.end() == grain)
+                slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Got notification on control protocol websockets thread";
+
+                earliest_necessary_update = (tai_clock::time_point::max)();
+
+                std::vector<std::pair<web::websockets::experimental::listener::connection_id, web::websockets::websocket_outgoing_message>> outgoing_messages;
+
+                for (auto wit = websockets.left.begin(); websockets.left.end() != wit;)
                 {
-                    auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
-                        .then(details::observe_websocket_exception(gate));
-                    // theoretically blocking, but in fact not
-                    close.wait();
+                    const auto& websocket = *wit;
 
-                    wit = websockets.left.erase(wit);
-                    continue;
-                }
-                const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
-                if (resources.end() == subscription)
-                {
-                    // a grain without a subscription shouldn't be possible, but let's be tidy
-                    erase_resource(resources, grain->id);
+                    // for each websocket connection that has valid grain and subscription resources
+                    const auto grain = find_resource(resources, { websocket.first, nmos::types::grain });
+                    if (resources.end() == grain)
+                    {
+                        auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
+                            .then(details::observe_websocket_exception(gate));
+                        // theoretically blocking, but in fact not
+                        close.wait();
 
-                    auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
-                        .then(details::observe_websocket_exception(gate));
-                    // theoretically blocking, but in fact not
-                    close.wait();
+                        wit = websockets.left.erase(wit);
+                        continue;
+                    }
+                    const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
+                    if (resources.end() == subscription)
+                    {
+                        // a grain without a subscription shouldn't be possible, but let's be tidy
+                        erase_resource(resources, grain->id);
 
-                    wit = websockets.left.erase(wit);
-                    continue;
-                }
-                // and has events to send
-                if (0 == nmos::fields::message_grain_data(grain->data).size())
-                {
+                        auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
+                            .then(details::observe_websocket_exception(gate));
+                        // theoretically blocking, but in fact not
+                        close.wait();
+
+                        wit = websockets.left.erase(wit);
+                        continue;
+                    }
+                    // and has events to send
+                    if (0 == nmos::fields::message_grain_data(grain->data).size())
+                    {
+                        ++wit;
+                        continue;
+                    }
+
+                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing to send " << nmos::fields::message_grain_data(grain->data).size() << " events on websocket connection: " << grain->id;
+
+                    for (const auto& event : nmos::fields::message_grain_data(grain->data).as_array())
+                    {
+                        web::websockets::websocket_outgoing_message message;
+
+                        slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "outgoing_message: " << event.serialize();
+                        message.set_utf8_message(utility::us2s(event.serialize()));
+                        outgoing_messages.push_back({ websocket.second, message });
+                    }
+
+                    // reset the grain for next time
+                    resources.modify(grain, [&resources](nmos::resource& grain)
+                    {
+                        // all messages have now been prepared
+                        nmos::fields::message_grain_data(grain.data) = value::array();
+                        grain.updated = strictly_increasing_update(resources);
+                    });
+
                     ++wit;
-                    continue;
                 }
 
-                slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing to send " << nmos::fields::message_grain_data(grain->data).size() << " events on websocket connection: " << grain->id;
+                // send the messages without the lock on resources
+                details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
 
-                for (const auto& event : nmos::fields::message_grain_data(grain->data).as_array())
+                if (!outgoing_messages.empty()) slog::log<slog::severities::info>(gate, SLOG_FLF) << "Sending " << outgoing_messages.size() << " websocket messages";
+
+                for (auto& outgoing_message : outgoing_messages)
                 {
-                    web::websockets::websocket_outgoing_message message;
+                    // hmmm, no way to cancel this currently...
 
-                    slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "outgoing_message: " << event.serialize();
-                    message.set_utf8_message(utility::us2s(event.serialize()));
-                    outgoing_messages.push_back({ websocket.second, message });
+                    auto send = listener.send(outgoing_message.first, outgoing_message.second)
+                        .then(details::observe_websocket_exception(gate));
+                    // current websocket_listener implementation is synchronous in any case, but just to make clear...
+                    // for now, wait for the message to be sent
+                    send.wait();
                 }
-
-                // reset the grain for next time
-                resources.modify(grain, [&resources](nmos::resource& grain)
-                {
-                    // all messages have now been prepared
-                    nmos::fields::message_grain_data(grain.data) = value::array();
-                    grain.updated = strictly_increasing_update(resources);
-                });
-
-                ++wit;
-            }
-
-            // send the messages without the lock on resources
-            details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
-
-            if (!outgoing_messages.empty()) slog::log<slog::severities::info>(gate, SLOG_FLF) << "Sending " << outgoing_messages.size() << " websocket messages";
-
-            for (auto& outgoing_message : outgoing_messages)
-            {
-                // hmmm, no way to cancel this currently...
-
-                auto send = listener.send(outgoing_message.first, outgoing_message.second)
-                    .then(details::observe_websocket_exception(gate));
-                // current websocket_listener implementation is synchronous in any case, but just to make clear...
-                // for now, wait for the message to be sent
-                send.wait();
             }
         }
     }

--- a/Development/nmos/events_ws_api.cpp
+++ b/Development/nmos/events_ws_api.cpp
@@ -270,7 +270,11 @@ namespace nmos
 
                                 resources.modify(grain, [&](nmos::resource& grain)
                                 {
-                                    web::json::push_back(nmos::fields::message_grain_data(grain.data), make_events_health_message({ nmos::tai_now(), nmos::fields::timestamp(message) }));
+                                    // ensure the health response creation_timestamp is greater than the health command timestamp
+                                    const auto command_timestamp = nmos::fields::timestamp(message);
+                                    const auto now = nmos::tai_now();
+                                    const auto response_time = now > command_timestamp ? now : tai_from_time_point(time_point_from_tai(command_timestamp) + tai_clock::duration(1));
+                                    web::json::push_back(nmos::fields::message_grain_data(grain.data), make_events_health_message({ response_time, command_timestamp }));
 
                                     grain.updated = strictly_increasing_update(resources);
                                 });

--- a/Development/nmos/events_ws_api.cpp
+++ b/Development/nmos/events_ws_api.cpp
@@ -372,103 +372,101 @@ namespace nmos
         {
             // wait for the thread to be interrupted either because there are resource changes, or because the server is being shut down
             // or because message sending was throttled earlier
-            if (details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || most_recent_message < most_recent_update(resources); }))
+            details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || most_recent_message < most_recent_update(resources); });
+            if (shutdown) break;
+            most_recent_message = most_recent_update(resources);
+
+            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Got notification on events websockets thread";
+
+            earliest_necessary_update = (tai_clock::time_point::max)();
+
+            std::vector<std::pair<web::websockets::experimental::listener::connection_id, web::websockets::websocket_outgoing_message>> outgoing_messages;
+
+            for (auto wit = websockets.left.begin(); websockets.left.end() != wit;)
             {
-                if (shutdown) break;
-                most_recent_message = most_recent_update(resources);
+                const auto& websocket = *wit;
 
-                slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Got notification on events websockets thread";
-
-                earliest_necessary_update = (tai_clock::time_point::max)();
-
-                std::vector<std::pair<web::websockets::experimental::listener::connection_id, web::websockets::websocket_outgoing_message>> outgoing_messages;
-
-                for (auto wit = websockets.left.begin(); websockets.left.end() != wit;)
+                // for each websocket connection that has valid grain and subscription resources
+                const auto grain = find_resource(resources, { websocket.first, nmos::types::grain });
+                if (resources.end() == grain)
                 {
-                    const auto& websocket = *wit;
-
-                    // for each websocket connection that has valid grain and subscription resources
-                    const auto grain = find_resource(resources, { websocket.first, nmos::types::grain });
-                    if (resources.end() == grain)
-                    {
-                        auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
-                            .then(details::observe_websocket_exception(gate));
-                        // theoretically blocking, but in fact not
-                        close.wait();
-
-                        wit = websockets.left.erase(wit);
-                        continue;
-                    }
-                    const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
-                    if (resources.end() == subscription)
-                    {
-                        // a grain without a subscription shouldn't be possible, but let's be tidy
-                        erase_resource(resources, grain->id);
-
-                        auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
-                            .then(details::observe_websocket_exception(gate));
-                        // theoretically blocking, but in fact not
-                        close.wait();
-
-                        wit = websockets.left.erase(wit);
-                        continue;
-                    }
-                    // and has events to send
-                    if (0 == nmos::fields::message_grain_data(grain->data).size())
-                    {
-                        ++wit;
-                        continue;
-                    }
-
-                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing to send " << nmos::fields::message_grain_data(grain->data).size() << " events on websocket connection: " << grain->id;
-
-                    for (const auto& event : nmos::fields::message_grain_data(grain->data).as_array())
-                    {
-                        web::websockets::websocket_outgoing_message message;
-
-                        if (event.has_field(U("message_type")))
-                        {
-                            // reboot, shutdown or health message
-                            message.set_utf8_message(utility::us2s(event.serialize()));
-                            outgoing_messages.push_back({ websocket.second, message });
-                        }
-                        else if (event.has_field(U("post")))
-                        {
-                            // state message
-                            // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#11-the-state-message-type
-                            // and nmos::make_events_boolean_state, nmos::make_events_number_state, etc.
-                            // and nmos::details::make_resource_event
-                            const web::json::value& state = nmos::fields::endpoint_state(event.at(U("post")));
-                            message.set_utf8_message(utility::us2s(state.serialize()));
-                            outgoing_messages.push_back({ websocket.second, message });
-                        }
-                    }
-
-                    // reset the grain for next time
-                    resources.modify(grain, [&resources](nmos::resource& grain)
-                    {
-                        // all messages have now been prepared
-                        nmos::fields::message_grain_data(grain.data) = value::array();
-                        grain.updated = strictly_increasing_update(resources);
-                    });
-
-                    ++wit;
-                }
-
-                // send the messages without the lock on resources
-                details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
-
-                if (!outgoing_messages.empty()) slog::log<slog::severities::info>(gate, SLOG_FLF) << "Sending " << outgoing_messages.size() << " websocket messages";
-
-                for (auto& outgoing_message : outgoing_messages)
-                {
-                    // hmmm, no way to cancel this currently...
-                    auto send = listener.send(outgoing_message.first, outgoing_message.second)
+                    auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
                         .then(details::observe_websocket_exception(gate));
-                    // current websocket_listener implementation is synchronous in any case, but just to make clear...
-                    // for now, wait for the message to be sent
-                    send.wait();
+                    // theoretically blocking, but in fact not
+                    close.wait();
+
+                    wit = websockets.left.erase(wit);
+                    continue;
                 }
+                const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
+                if (resources.end() == subscription)
+                {
+                    // a grain without a subscription shouldn't be possible, but let's be tidy
+                    erase_resource(resources, grain->id);
+
+                    auto close = listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Expired"))
+                        .then(details::observe_websocket_exception(gate));
+                    // theoretically blocking, but in fact not
+                    close.wait();
+
+                    wit = websockets.left.erase(wit);
+                    continue;
+                }
+                // and has events to send
+                if (0 == nmos::fields::message_grain_data(grain->data).size())
+                {
+                    ++wit;
+                    continue;
+                }
+
+                slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing to send " << nmos::fields::message_grain_data(grain->data).size() << " events on websocket connection: " << grain->id;
+
+                for (const auto& event : nmos::fields::message_grain_data(grain->data).as_array())
+                {
+                    web::websockets::websocket_outgoing_message message;
+
+                    if (event.has_field(U("message_type")))
+                    {
+                        // reboot, shutdown or health message
+                        message.set_utf8_message(utility::us2s(event.serialize()));
+                        outgoing_messages.push_back({ websocket.second, message });
+                    }
+                    else if (event.has_field(U("post")))
+                    {
+                        // state message
+                        // see https://specs.amwa.tv/is-07/releases/v1.0.1/docs/2.0._Message_types.html#11-the-state-message-type
+                        // and nmos::make_events_boolean_state, nmos::make_events_number_state, etc.
+                        // and nmos::details::make_resource_event
+                        const web::json::value& state = nmos::fields::endpoint_state(event.at(U("post")));
+                        message.set_utf8_message(utility::us2s(state.serialize()));
+                        outgoing_messages.push_back({ websocket.second, message });
+                    }
+                }
+
+                // reset the grain for next time
+                resources.modify(grain, [&resources](nmos::resource& grain)
+                {
+                    // all messages have now been prepared
+                    nmos::fields::message_grain_data(grain.data) = value::array();
+                    grain.updated = strictly_increasing_update(resources);
+                });
+
+                ++wit;
+            }
+
+            // send the messages without the lock on resources
+            details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
+
+            if (!outgoing_messages.empty()) slog::log<slog::severities::info>(gate, SLOG_FLF) << "Sending " << outgoing_messages.size() << " websocket messages";
+
+            for (auto& outgoing_message : outgoing_messages)
+            {
+                // hmmm, no way to cancel this currently...
+                auto send = listener.send(outgoing_message.first, outgoing_message.second)
+                    .then(details::observe_websocket_exception(gate));
+                // current websocket_listener implementation is synchronous in any case, but just to make clear...
+                // for now, wait for the message to be sent
+                send.wait();
             }
         }
     }

--- a/Development/nmos/health.h
+++ b/Development/nmos/health.h
@@ -13,13 +13,13 @@ namespace nmos
 
     inline health health_now()
     {
-        return std::chrono::duration_cast<std::chrono::seconds>(
+        return bst::chrono::duration_cast<bst::chrono::seconds>(
             tai_clock::now().time_since_epoch()).count();
     }
 
     inline tai_clock::time_point time_point_from_health(health health)
     {
-        return tai_clock::time_point(std::chrono::seconds(health));
+        return tai_clock::time_point(bst::chrono::seconds(health));
     }
 }
 

--- a/Development/nmos/mutex.h
+++ b/Development/nmos/mutex.h
@@ -11,7 +11,7 @@ namespace nmos
     typedef std::unique_lock<mutex> write_lock;
 
     // locking strategy tag structs must be usable for both read_lock and write_lock
-#ifndef BST_SHARED_MUTEX_BOOST
+#ifndef BST_THREAD_BOOST
     typedef std::adopt_lock_t adopt_lock_t;
     typedef std::defer_lock_t defer_lock_t;
     typedef std::try_to_lock_t try_to_lock_t;

--- a/Development/nmos/mutex.h
+++ b/Development/nmos/mutex.h
@@ -1,7 +1,6 @@
 #ifndef NMOS_MUTEX_H
 #define NMOS_MUTEX_H
 
-#include <condition_variable>
 #include "bst/shared_mutex.h"
 
 namespace nmos
@@ -28,8 +27,8 @@ namespace nmos
     const try_to_lock_t try_to_lock;
 #endif
 
-    typedef std::condition_variable_any condition_variable;
-    typedef std::cv_status cv_status;
+    typedef bst::condition_variable_any condition_variable;
+    typedef bst::cv_status cv_status;
 
     template <typename Func>
     auto with_read_lock(nmos::mutex& mutex, Func&& func) -> decltype(func())

--- a/Development/nmos/node_behaviour.cpp
+++ b/Development/nmos/node_behaviour.cpp
@@ -153,7 +153,7 @@ namespace nmos
                     const auto random_backoff = std::uniform_real_distribution<>(0, discovery_backoff)(discovery_backoff_engine);
                     slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Waiting to retry Registration API discovery for about " << std::fixed << std::setprecision(3) << random_backoff << " seconds (current backoff limit: " << discovery_backoff << " seconds)";
                     model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });
-                        if (model.shutdown) break;
+                    if (model.shutdown) break;
                 }
 
                 // "4. The Node performs a DNS-SD browse for services of type '_nmos-registration._tcp' as specified."

--- a/Development/nmos/node_behaviour.cpp
+++ b/Development/nmos/node_behaviour.cpp
@@ -152,10 +152,8 @@ namespace nmos
                     auto lock = model.read_lock();
                     const auto random_backoff = std::uniform_real_distribution<>(0, discovery_backoff)(discovery_backoff_engine);
                     slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Waiting to retry Registration API discovery for about " << std::fixed << std::setprecision(3) << random_backoff << " seconds (current backoff limit: " << discovery_backoff << " seconds)";
-                    if (model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; }))
-                    {
+                    model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });
                         if (model.shutdown) break;
-                    }
                 }
 
                 // "4. The Node performs a DNS-SD browse for services of type '_nmos-registration._tcp' as specified."
@@ -1164,53 +1162,51 @@ namespace nmos
                 // or because a Registration API has been discovered so registered operation should be attempted
                 // or because the server is being shut down
                 // or because message sending was throttled earlier
-                if (details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || registration_services_discovered || most_recent_update < grain->updated; }))
+                details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || registration_services_discovered || most_recent_update < grain->updated; });
+                if (shutdown || registration_services_discovered) break;
+
+                // usually the daemon will be updated
+                earliest_necessary_update = (tai_clock::time_point::max)();
+
+                auto events = web::json::value::array();
+                node_behaviour_grain_guard guard(resources, grain, events);
+                most_recent_update = grain->updated;
+
+                // update the 'ver_' TXT records, without the lock on the resources
+                details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
+
+                for (const auto& event : events.as_array())
                 {
-                    if (shutdown || registration_services_discovered) break;
-
-                    // usually the daemon will be updated
-                    earliest_necessary_update = (tai_clock::time_point::max)();
-
-                    auto events = web::json::value::array();
-                    node_behaviour_grain_guard guard(resources, grain, events);
-                    most_recent_update = grain->updated;
-
-                    // update the 'ver_' TXT records, without the lock on the resources
-                    details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
-
-                    for (const auto& event : events.as_array())
-                    {
-                        const auto id_type = get_resource_event_resource(node_behaviour_topic, event);
-                        update_resource_version(ver, id_type.second);
-                    }
-
-                    // job done
-                    events = web::json::value::array();
-
-                    // throttle updates to the DNS-SD daemon
-                    // "to protect the network against excessive packet flooding due to software
-                    // bugs or malicious attack, a Multicast DNS responder MUST NOT multicast a
-                    // record on a given interface until at least one second has elapsed since
-                    // the last time that record was multicast on that particular interface."
-                    // see https://tools.ietf.org/html/rfc6762#section-6
-                    // (unfortunately mDNSResponder may still report "excessive update rate"
-                    // because it implements a target interval of 6 seconds...)
-                    const auto max_update_rate = bst::chrono::seconds(1);
-                    const auto now = tai_clock::now();
-                    if (earliest_allowed_update > now)
-                    {
-                        // make sure to update the daemon as soon as allowed
-                        earliest_necessary_update = earliest_allowed_update;
-
-                        // just don't do it now!
-                        continue;
-                    }
-
-                    slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Updating the 'ver_' TXT records";
-                    update_node_service(advertiser, model.settings, ver);
-
-                    earliest_allowed_update = now + max_update_rate;
+                    const auto id_type = get_resource_event_resource(node_behaviour_topic, event);
+                    update_resource_version(ver, id_type.second);
                 }
+
+                // job done
+                events = web::json::value::array();
+
+                // throttle updates to the DNS-SD daemon
+                // "to protect the network against excessive packet flooding due to software
+                // bugs or malicious attack, a Multicast DNS responder MUST NOT multicast a
+                // record on a given interface until at least one second has elapsed since
+                // the last time that record was multicast on that particular interface."
+                // see https://tools.ietf.org/html/rfc6762#section-6
+                // (unfortunately mDNSResponder may still report "excessive update rate"
+                // because it implements a target interval of 6 seconds...)
+                const auto max_update_rate = bst::chrono::seconds(1);
+                const auto now = tai_clock::now();
+                if (earliest_allowed_update > now)
+                {
+                    // make sure to update the daemon as soon as allowed
+                    earliest_necessary_update = earliest_allowed_update;
+
+                    // just don't do it now!
+                    continue;
+                }
+
+                slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Updating the 'ver_' TXT records";
+                update_node_service(advertiser, model.settings, ver);
+
+                earliest_allowed_update = now + max_update_rate;
             }
 
             slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Withdrawing the 'ver_' TXT records";

--- a/Development/nmos/node_behaviour.cpp
+++ b/Development/nmos/node_behaviour.cpp
@@ -152,8 +152,10 @@ namespace nmos
                     auto lock = model.read_lock();
                     const auto random_backoff = std::uniform_real_distribution<>(0, discovery_backoff)(discovery_backoff_engine);
                     slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Waiting to retry Registration API discovery for about " << std::fixed << std::setprecision(3) << random_backoff << " seconds (current backoff limit: " << discovery_backoff << " seconds)";
-                    model.wait_for(lock, std::chrono::milliseconds(std::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });
-                    if (model.shutdown) break;
+                    if (model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; }))
+                    {
+                        if (model.shutdown) break;
+                    }
                 }
 
                 // "4. The Node performs a DNS-SD browse for services of type '_nmos-registration._tcp' as specified."
@@ -1162,51 +1164,53 @@ namespace nmos
                 // or because a Registration API has been discovered so registered operation should be attempted
                 // or because the server is being shut down
                 // or because message sending was throttled earlier
-                details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || registration_services_discovered || most_recent_update < grain->updated; });
-                if (shutdown || registration_services_discovered) break;
-
-                // usually the daemon will be updated
-                earliest_necessary_update = (tai_clock::time_point::max)();
-
-                auto events = web::json::value::array();
-                node_behaviour_grain_guard guard(resources, grain, events);
-                most_recent_update = grain->updated;
-
-                // update the 'ver_' TXT records, without the lock on the resources
-                details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
-
-                for (const auto& event : events.as_array())
+                if (details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || registration_services_discovered || most_recent_update < grain->updated; }))
                 {
-                    const auto id_type = get_resource_event_resource(node_behaviour_topic, event);
-                    update_resource_version(ver, id_type.second);
+                    if (shutdown || registration_services_discovered) break;
+
+                    // usually the daemon will be updated
+                    earliest_necessary_update = (tai_clock::time_point::max)();
+
+                    auto events = web::json::value::array();
+                    node_behaviour_grain_guard guard(resources, grain, events);
+                    most_recent_update = grain->updated;
+
+                    // update the 'ver_' TXT records, without the lock on the resources
+                    details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
+
+                    for (const auto& event : events.as_array())
+                    {
+                        const auto id_type = get_resource_event_resource(node_behaviour_topic, event);
+                        update_resource_version(ver, id_type.second);
+                    }
+
+                    // job done
+                    events = web::json::value::array();
+
+                    // throttle updates to the DNS-SD daemon
+                    // "to protect the network against excessive packet flooding due to software
+                    // bugs or malicious attack, a Multicast DNS responder MUST NOT multicast a
+                    // record on a given interface until at least one second has elapsed since
+                    // the last time that record was multicast on that particular interface."
+                    // see https://tools.ietf.org/html/rfc6762#section-6
+                    // (unfortunately mDNSResponder may still report "excessive update rate"
+                    // because it implements a target interval of 6 seconds...)
+                    const auto max_update_rate = bst::chrono::seconds(1);
+                    const auto now = tai_clock::now();
+                    if (earliest_allowed_update > now)
+                    {
+                        // make sure to update the daemon as soon as allowed
+                        earliest_necessary_update = earliest_allowed_update;
+
+                        // just don't do it now!
+                        continue;
+                    }
+
+                    slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Updating the 'ver_' TXT records";
+                    update_node_service(advertiser, model.settings, ver);
+
+                    earliest_allowed_update = now + max_update_rate;
                 }
-
-                // job done
-                events = web::json::value::array();
-
-                // throttle updates to the DNS-SD daemon
-                // "to protect the network against excessive packet flooding due to software
-                // bugs or malicious attack, a Multicast DNS responder MUST NOT multicast a
-                // record on a given interface until at least one second has elapsed since
-                // the last time that record was multicast on that particular interface."
-                // see https://tools.ietf.org/html/rfc6762#section-6
-                // (unfortunately mDNSResponder may still report "excessive update rate"
-                // because it implements a target interval of 6 seconds...)
-                const auto max_update_rate = std::chrono::seconds(1);
-                const auto now = tai_clock::now();
-                if (earliest_allowed_update > now)
-                {
-                    // make sure to update the daemon as soon as allowed
-                    earliest_necessary_update = earliest_allowed_update;
-
-                    // just don't do it now!
-                    continue;
-                }
-
-                slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Updating the 'ver_' TXT records";
-                update_node_service(advertiser, model.settings, ver);
-
-                earliest_allowed_update = now + max_update_rate;
             }
 
             slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Withdrawing the 'ver_' TXT records";

--- a/Development/nmos/node_system_behaviour.cpp
+++ b/Development/nmos/node_system_behaviour.cpp
@@ -82,10 +82,8 @@ namespace nmos
                     auto lock = model.read_lock();
                     const auto random_backoff = std::uniform_real_distribution<>(0, discovery_backoff)(discovery_backoff_engine);
                     slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Waiting to retry System API discovery for about " << std::fixed << std::setprecision(3) << random_backoff << " seconds (current backoff limit: " << discovery_backoff << " seconds)";
-                    if (model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; }))
-                    {
-                        if (model.shutdown) break;
-                    }
+                    model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });;
+                    if (model.shutdown) break;
                 }
 
                 // The Node performs a DNS-SD browse for services of type '_nmos-system._tcp' as specified.

--- a/Development/nmos/node_system_behaviour.cpp
+++ b/Development/nmos/node_system_behaviour.cpp
@@ -82,7 +82,7 @@ namespace nmos
                     auto lock = model.read_lock();
                     const auto random_backoff = std::uniform_real_distribution<>(0, discovery_backoff)(discovery_backoff_engine);
                     slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Waiting to retry System API discovery for about " << std::fixed << std::setprecision(3) << random_backoff << " seconds (current backoff limit: " << discovery_backoff << " seconds)";
-                    model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });;
+                    model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });
                     if (model.shutdown) break;
                 }
 

--- a/Development/nmos/node_system_behaviour.cpp
+++ b/Development/nmos/node_system_behaviour.cpp
@@ -82,8 +82,10 @@ namespace nmos
                     auto lock = model.read_lock();
                     const auto random_backoff = std::uniform_real_distribution<>(0, discovery_backoff)(discovery_backoff_engine);
                     slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Waiting to retry System API discovery for about " << std::fixed << std::setprecision(3) << random_backoff << " seconds (current backoff limit: " << discovery_backoff << " seconds)";
-                    model.wait_for(lock, std::chrono::milliseconds(std::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });
-                    if (model.shutdown) break;
+                    if (model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; }))
+                    {
+                        if (model.shutdown) break;
+                    }
                 }
 
                 // The Node performs a DNS-SD browse for services of type '_nmos-system._tcp' as specified.
@@ -161,7 +163,7 @@ namespace nmos
             }).get();
 
             with_write_lock(model.mutex, [&]
-            { 
+            {
                 if (!system_services.empty())
                 {
                     slog::log<slog::severities::info>(gate, SLOG_FLF) << "Discovered " << system_services.size() << " System API(s)";

--- a/Development/nmos/ocsp_behaviour.cpp
+++ b/Development/nmos/ocsp_behaviour.cpp
@@ -83,10 +83,8 @@ namespace nmos
                         auto lock = model.read_lock();
                         const auto random_backoff = std::uniform_real_distribution<>(0, backoff)(backoff_engine);
                         slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Waiting to retry OCSP server for about " << std::fixed << std::setprecision(3) << random_backoff << " seconds (current backoff limit: " << backoff << " seconds)";
-                        if (model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; }))
-                        {
-                            if (model.shutdown) break;
-                        }
+                        model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });
+                        if (model.shutdown) break;
                     }
 
                     // get the list of server certificates chain

--- a/Development/nmos/ocsp_behaviour.cpp
+++ b/Development/nmos/ocsp_behaviour.cpp
@@ -83,8 +83,10 @@ namespace nmos
                         auto lock = model.read_lock();
                         const auto random_backoff = std::uniform_real_distribution<>(0, backoff)(backoff_engine);
                         slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Waiting to retry OCSP server for about " << std::fixed << std::setprecision(3) << random_backoff << " seconds (current backoff limit: " << backoff << " seconds)";
-                        model.wait_for(lock, std::chrono::milliseconds(std::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; });
-                        if (model.shutdown) break;
+                        if (model.wait_for(lock, bst::chrono::milliseconds(bst::chrono::milliseconds::rep(1000 * random_backoff)), [&] { return model.shutdown; }))
+                        {
+                            if (model.shutdown) break;
+                        }
                     }
 
                     // get the list of server certificates chain

--- a/Development/nmos/query_ws_api.cpp
+++ b/Development/nmos/query_ws_api.cpp
@@ -168,195 +168,193 @@ namespace nmos
         {
             // wait for the thread to be interrupted either because there are resource changes, or because the server is being shut down
             // or because message sending was throttled earlier
-            if (details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || most_recent_message < most_recent_update(resources); }))
+            details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown || most_recent_message < most_recent_update(resources); });
+            if (shutdown) break;
+            most_recent_message = most_recent_update(resources);
+
+            slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Got notification on query websockets thread";
+
+            const auto now = tai_clock::now();
+
+            earliest_necessary_update = (tai_clock::time_point::max)();
+
+            std::vector<std::pair<web::websockets::experimental::listener::connection_id, web::websockets::websocket_outgoing_message>> outgoing_messages;
+
+            for (auto wit = websockets.left.begin(); websockets.left.end() != wit;)
             {
-                if (shutdown) break;
-                most_recent_message = most_recent_update(resources);
+                const auto& websocket = *wit;
 
-                slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "Got notification on query websockets thread";
-
-                const auto now = tai_clock::now();
-
-                earliest_necessary_update = (tai_clock::time_point::max)();
-
-                std::vector<std::pair<web::websockets::experimental::listener::connection_id, web::websockets::websocket_outgoing_message>> outgoing_messages;
-
-                for (auto wit = websockets.left.begin(); websockets.left.end() != wit;)
+                // for each websocket connection that has valid grain and subscription resources
+                const auto grain = find_resource(resources, { websocket.first, nmos::types::grain });
+                if (resources.end() == grain)
                 {
-                    const auto& websocket = *wit;
+                    // theoretically blocking, but in fact not
+                    listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Deleted")).wait();
 
-                    // for each websocket connection that has valid grain and subscription resources
-                    const auto grain = find_resource(resources, { websocket.first, nmos::types::grain });
-                    if (resources.end() == grain)
-                    {
-                        // theoretically blocking, but in fact not
-                        listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Deleted")).wait();
+                    wit = websockets.left.erase(wit);
+                    continue;
+                }
+                const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
+                if (resources.end() == subscription)
+                {
+                    // a grain without a subscription shouldn't be possible, but let's be tidy
+                    erase_resource(resources, grain->id);
 
-                        wit = websockets.left.erase(wit);
-                        continue;
-                    }
-                    const auto subscription = find_resource(resources, { nmos::fields::subscription_id(grain->data), nmos::types::subscription });
-                    if (resources.end() == subscription)
-                    {
-                        // a grain without a subscription shouldn't be possible, but let's be tidy
-                        erase_resource(resources, grain->id);
+                    // theoretically blocking, but in fact not
+                    listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Deleted")).wait();
 
-                        // theoretically blocking, but in fact not
-                        listener.close(websocket.second, web::websockets::websocket_close_status::server_terminate, U("Deleted")).wait();
-
-                        wit = websockets.left.erase(wit);
-                        continue;
-                    }
-                    // and has events to send
-                    if (0 == nmos::fields::message_grain_data(grain->data).size())
-                    {
-                        ++wit;
-                        continue;
-                    }
-
-                    // throttle messages according to the subscription's max_update_rate_ms
-                    // see discussion about creation_timestamp below...
-                    const auto max_update_rate = bst::chrono::milliseconds(nmos::fields::max_update_rate_ms(subscription->data));
-                    const auto earliest_allowed_update = time_point_from_tai(nmos::fields::creation_timestamp(nmos::fields::message(grain->data))) + max_update_rate;
-                    if (earliest_allowed_update > now)
-                    {
-                        // make sure to send a message as soon as allowed
-                        if (earliest_allowed_update < earliest_necessary_update)
-                        {
-                            earliest_necessary_update = earliest_allowed_update;
-                        }
-                        // just don't do it now!
-                        ++wit;
-                        continue;
-                    }
-
-                    // experimental extension, to limit maximum number of events per message
-
-                    resource_paging paging(nmos::fields::params(subscription->data), most_recent_message, (size_t)nmos::experimental::fields::query_ws_paging_default(model.settings), (size_t)nmos::experimental::fields::query_ws_paging_limit(model.settings));
-                    auto next_events = value::array();
-
-                    // determine the grain timestamps
-
-                    // the meanings of each of these are being clarified in IS-04 v1.3
-                    // see https://github.com/AMWA-TV/is-04/pull/102
-
-                    // origin_timestamp is like paging.until, the timestamp of the most recent update potentially included in this message
-                    // it has therefore been subject to the usual adjustments to make it unique and strictly increasing
-                    // another possibility would be to make it the timestamp of the most recent update *actually* included
-                    // or it could be the timestamp of (or the timestamp before, like paging.since) the least recent update included
-                    const auto origin_timestamp = value::string(nmos::make_version(most_recent_message));
-
-                    // creation_timestamp reflects the time that the message is actually being prepared
-                    // this may be more recent if messages have been throttled
-                    // or less recent since it hasn't been adjusted in the same way as the update timestamps
-                    const auto creation_timestamp = value::string(nmos::make_version(tai_from_time_point(now)));
-
-                    // prepare the message
-
-                    resources.modify(grain, [&paging, &next_events, &origin_timestamp, &creation_timestamp](nmos::resource& grain)
-                        {
-                            auto& message = nmos::fields::message(grain.data);
-
-                            // postpone all the events after the specified limit
-                            auto& next_storage = web::json::storage_of(next_events.as_array());
-                            auto& message_storage = web::json::storage_of(nmos::fields::grain_data(message).as_array());
-                            if (paging.limit < message_storage.size())
-                            {
-                                const auto b = message_storage.begin() + paging.limit, e = message_storage.end();
-                                next_storage.assign(std::make_move_iterator(b), std::make_move_iterator(e));
-                                message_storage.erase(b, e);
-                                // hmm, feels like origin_timestamp should be adjusted in this case, but how?
-                            }
-
-                            // set the timestamps
-                            message[nmos::fields::origin_timestamp] = origin_timestamp;
-                            message[nmos::fields::sync_timestamp] = origin_timestamp;
-                            message[nmos::fields::creation_timestamp] = creation_timestamp;
-                        });
-
-                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing to send " << nmos::fields::message_grain_data(grain->data).size() << " changes on websocket connection: " << grain->id;
-
-                    //+ additional logging, cf. nmos::details::request_registration
-                    // see nmos/node_behaviour.cpp
-                    const auto topic = nmos::fields::grain_topic(nmos::fields::message(grain->data));
-                    const auto message_origin_timestamp = nmos::fields::origin_timestamp(nmos::fields::message(grain->data));
-                    for (const auto& event : nmos::fields::message_grain_data(grain->data).as_array())
-                    {
-                        const auto id_type = nmos::details::get_resource_event_resource(topic, event);
-                        const auto event_type = nmos::details::get_resource_event_type(event);
-                        const auto event_origin_timestamp = web::json::field_with_default<tai>{ nmos::fields::origin_timestamp, message_origin_timestamp }(event);
-
-                        slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Sending registration " << slog::omanip([&event_type](std::ostream& s)
-                            {
-                                switch (event_type)
-                                {
-                                case nmos::details::resource_added_event: s << "creation"; break;
-                                case nmos::details::resource_removed_event: s << "deletion"; break;
-                                case nmos::details::resource_modified_event: s << "update"; break;
-                                case nmos::details::resource_unchanged_event: s << "sync"; break;
-                                default: s << "event"; break;
-                                }
-                            }) << " for " << id_type << " at: " << nmos::make_version(event_origin_timestamp);
-                    }
-                    //- additional logging, cf. nmos::details::request_registration
-
-                    auto serialized = utility::us2s(nmos::fields::message(grain->data).serialize());
-                    web::websockets::websocket_outgoing_message message;
-                    message.set_utf8_message(serialized);
-
-                    outgoing_messages.push_back({ websocket.second, message });
-
-                    if (0 != next_events.size())
-                    {
-                        // make sure to send a message as soon as allowed
-                        if (now + max_update_rate < earliest_necessary_update)
-                        {
-                            earliest_necessary_update = now + max_update_rate;
-                        }
-                    }
-
-                    // reset the grain for next time
-                    resources.modify(grain, [&next_events, &resources](nmos::resource& grain)
-                        {
-                            using std::swap;
-                            swap(nmos::fields::message_grain_data(grain.data), next_events);
-                            next_events = value::array(); // unnecessary
-                            grain.updated = strictly_increasing_update(resources);
-                        });
-
+                    wit = websockets.left.erase(wit);
+                    continue;
+                }
+                // and has events to send
+                if (0 == nmos::fields::message_grain_data(grain->data).size())
+                {
                     ++wit;
+                    continue;
                 }
 
-                // send the messages without the lock on resources
-                try
+                // throttle messages according to the subscription's max_update_rate_ms
+                // see discussion about creation_timestamp below...
+                const auto max_update_rate = bst::chrono::milliseconds(nmos::fields::max_update_rate_ms(subscription->data));
+                const auto earliest_allowed_update = time_point_from_tai(nmos::fields::creation_timestamp(nmos::fields::message(grain->data))) + max_update_rate;
+                if (earliest_allowed_update > now)
                 {
-                    details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
-                }
-                catch (const std::exception& e)
-                {
-                    slog::log<slog::severities::error>(gate, SLOG_FLF) << "Unlock error: " << e.what();
+                    // make sure to send a message as soon as allowed
+                    if (earliest_allowed_update < earliest_necessary_update)
+                    {
+                        earliest_necessary_update = earliest_allowed_update;
+                    }
+                    // just don't do it now!
+                    ++wit;
+                    continue;
                 }
 
-                if (!outgoing_messages.empty()) slog::log<slog::severities::info>(gate, SLOG_FLF) << "Sending " << outgoing_messages.size() << " websocket messages";
+                // experimental extension, to limit maximum number of events per message
 
-                for (auto& outgoing_message : outgoing_messages)
+                resource_paging paging(nmos::fields::params(subscription->data), most_recent_message, (size_t)nmos::experimental::fields::query_ws_paging_default(model.settings), (size_t)nmos::experimental::fields::query_ws_paging_limit(model.settings));
+                auto next_events = value::array();
+
+                // determine the grain timestamps
+
+                // the meanings of each of these are being clarified in IS-04 v1.3
+                // see https://github.com/AMWA-TV/is-04/pull/102
+
+                // origin_timestamp is like paging.until, the timestamp of the most recent update potentially included in this message
+                // it has therefore been subject to the usual adjustments to make it unique and strictly increasing
+                // another possibility would be to make it the timestamp of the most recent update *actually* included
+                // or it could be the timestamp of (or the timestamp before, like paging.since) the least recent update included
+                const auto origin_timestamp = value::string(nmos::make_version(most_recent_message));
+
+                // creation_timestamp reflects the time that the message is actually being prepared
+                // this may be more recent if messages have been throttled
+                // or less recent since it hasn't been adjusted in the same way as the update timestamps
+                const auto creation_timestamp = value::string(nmos::make_version(tai_from_time_point(now)));
+
+                // prepare the message
+
+                resources.modify(grain, [&paging, &next_events, &origin_timestamp, &creation_timestamp](nmos::resource& grain)
                 {
-                    // hmmm, no way to cancel this currently...
-                    auto send = listener.send(outgoing_message.first, outgoing_message.second).then([&](pplx::task<void> finally)
+                    auto& message = nmos::fields::message(grain.data);
+
+                    // postpone all the events after the specified limit
+                    auto& next_storage = web::json::storage_of(next_events.as_array());
+                    auto& message_storage = web::json::storage_of(nmos::fields::grain_data(message).as_array());
+                    if (paging.limit < message_storage.size())
+                    {
+                        const auto b = message_storage.begin() + paging.limit, e = message_storage.end();
+                        next_storage.assign(std::make_move_iterator(b), std::make_move_iterator(e));
+                        message_storage.erase(b, e);
+                        // hmm, feels like origin_timestamp should be adjusted in this case, but how?
+                    }
+
+                    // set the timestamps
+                    message[nmos::fields::origin_timestamp] = origin_timestamp;
+                    message[nmos::fields::sync_timestamp] = origin_timestamp;
+                    message[nmos::fields::creation_timestamp] = creation_timestamp;
+                });
+
+                slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing to send " << nmos::fields::message_grain_data(grain->data).size() << " changes on websocket connection: " << grain->id;
+
+                //+ additional logging, cf. nmos::details::request_registration
+                // see nmos/node_behaviour.cpp
+                const auto topic = nmos::fields::grain_topic(nmos::fields::message(grain->data));
+                const auto message_origin_timestamp = nmos::fields::origin_timestamp(nmos::fields::message(grain->data));
+                for (const auto& event : nmos::fields::message_grain_data(grain->data).as_array())
+                {
+                    const auto id_type = nmos::details::get_resource_event_resource(topic, event);
+                    const auto event_type = nmos::details::get_resource_event_type(event);
+                    const auto event_origin_timestamp = web::json::field_with_default<tai>{ nmos::fields::origin_timestamp, message_origin_timestamp }(event);
+
+                    slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Sending registration " << slog::omanip([&event_type](std::ostream& s)
+                    {
+                        switch (event_type)
                         {
-                            try
-                            {
-                                finally.get();
-                            }
-                            catch (const web::websockets::websocket_exception& e)
-                            {
-                                slog::log<slog::severities::error>(gate, SLOG_FLF) << "WebSocket error: " << e.what() << " [" << e.error_code() << "]";
-                            }
-                        });
-                    // current websocket_listener implementation is synchronous in any case, but just to make clear...
-                    // for now, wait for the message to be sent
-                    send.wait();
+                        case nmos::details::resource_added_event: s << "creation"; break;
+                        case nmos::details::resource_removed_event: s << "deletion"; break;
+                        case nmos::details::resource_modified_event: s << "update"; break;
+                        case nmos::details::resource_unchanged_event: s << "sync"; break;
+                        default: s << "event"; break;
+                        }
+                    }) << " for " << id_type << " at: " << nmos::make_version(event_origin_timestamp);
                 }
+                //- additional logging, cf. nmos::details::request_registration
+
+                auto serialized = utility::us2s(nmos::fields::message(grain->data).serialize());
+                web::websockets::websocket_outgoing_message message;
+                message.set_utf8_message(serialized);
+
+                outgoing_messages.push_back({ websocket.second, message });
+
+                if (0 != next_events.size())
+                {
+                    // make sure to send a message as soon as allowed
+                    if (now + max_update_rate < earliest_necessary_update)
+                    {
+                        earliest_necessary_update = now + max_update_rate;
+                    }
+                }
+
+                // reset the grain for next time
+                resources.modify(grain, [&next_events, &resources](nmos::resource& grain)
+                {
+                    using std::swap;
+                    swap(nmos::fields::message_grain_data(grain.data), next_events);
+                    next_events = value::array(); // unnecessary
+                    grain.updated = strictly_increasing_update(resources);
+                });
+
+                ++wit;
+            }
+
+            // send the messages without the lock on resources
+            try
+            {
+                details::reverse_lock_guard<nmos::write_lock> unlock{ lock };
+            }
+            catch (const std::exception& e)
+            {
+                slog::log<slog::severities::error>(gate, SLOG_FLF) << "Unlock error: " << e.what();
+            }
+
+            if (!outgoing_messages.empty()) slog::log<slog::severities::info>(gate, SLOG_FLF) << "Sending " << outgoing_messages.size() << " websocket messages";
+
+            for (auto& outgoing_message : outgoing_messages)
+            {
+                // hmmm, no way to cancel this currently...
+                auto send = listener.send(outgoing_message.first, outgoing_message.second).then([&](pplx::task<void> finally)
+                {
+                    try
+                    {
+                        finally.get();
+                    }
+                    catch (const web::websockets::websocket_exception& e)
+                    {
+                        slog::log<slog::severities::error>(gate, SLOG_FLF) << "WebSocket error: " << e.what() << " [" << e.error_code() << "]";
+                    }
+                });
+                // current websocket_listener implementation is synchronous in any case, but just to make clear...
+                // for now, wait for the message to be sent
+                send.wait();
             }
         }
     }

--- a/Development/nmos/tai.h
+++ b/Development/nmos/tai.h
@@ -1,9 +1,10 @@
 #ifndef NMOS_TAI_H
 #define NMOS_TAI_H
 
-#include <chrono>
 #include <cstdint>
 #include <tuple>
+#include "bst/shared_mutex.h" // for bst::nano
+#include "slog/all_in_one.h" // for bst::chrono
 
 namespace nmos
 {
@@ -31,19 +32,19 @@ namespace nmos
     struct tai_clock
     {
         // "It is suggested (although not mandated) that these timestamps are stored with nanosecond resolution."
-        typedef std::nano period;
+        typedef bst::nano period;
 
         // Given this rep, this clock has a future range of only 292 years. Good enough.
         typedef int64_t rep;
 
-        typedef std::chrono::duration<rep, period> duration;
-        typedef std::chrono::time_point<tai_clock, duration> time_point;
+        typedef bst::chrono::duration<rep, period> duration;
+        typedef bst::chrono::time_point<tai_clock, duration> time_point;
 
         // "It is important that there are no duplicate creation or update timestamps stored against resources."
         // See https://specs.amwa.tv/is-04/releases/v1.2.0/docs/2.5._APIs_-_Query_Parameters.html#pagination
         // Unfortunately, this clock is based on the system_clock, so may not produce monotonically increasing
         // time points; nmos::strictly_increasing_update is used to prevent duplicate values in nmos::resources
-        static const bool is_steady = std::chrono::system_clock::is_steady;
+        static const bool is_steady = bst::chrono::system_clock::is_steady;
 
         static time_point now()
         {
@@ -70,16 +71,16 @@ namespace nmos
             // and https://cr.yp.to/proto/utctai.html
             // and https://www.iers.org/SharedDocs/News/EN/BulletinC.html
             // and https://www.ietf.org/timezones/data/leap-seconds.list
-            static const duration tai_offset = std::chrono::seconds(37);
+            static const duration tai_offset = bst::chrono::seconds(37);
 
-            return time_point(tai_offset + std::chrono::system_clock::now().time_since_epoch());
+            return time_point(tai_offset + bst::chrono::system_clock::now().time_since_epoch());
         }
     };
 
     inline tai tai_from_duration(const tai_clock::duration& d)
     {
-        const auto sec = std::chrono::duration_cast<std::chrono::seconds>(d);
-        const auto nan = std::chrono::duration_cast<std::chrono::nanoseconds>(d) - sec;
+        const auto sec = bst::chrono::duration_cast<bst::chrono::seconds>(d);
+        const auto nan = bst::chrono::duration_cast<bst::chrono::nanoseconds>(d) - sec;
 
         return{ sec.count(), nan.count() };
     }
@@ -91,9 +92,9 @@ namespace nmos
 
     inline tai_clock::duration duration_from_tai(const tai& tai)
     {
-        const auto sec = std::chrono::seconds(tai.seconds);
-        const auto nan = std::chrono::nanoseconds(tai.nanoseconds);
-        return std::chrono::duration_cast<tai_clock::duration>(sec + nan);
+        const auto sec = bst::chrono::seconds(tai.seconds);
+        const auto nan = bst::chrono::nanoseconds(tai.nanoseconds);
+        return bst::chrono::duration_cast<tai_clock::duration>(sec + nan);
     }
 
     inline tai_clock::time_point time_point_from_tai(const tai& tai)

--- a/Development/nmos/test/condition_variable_test.cpp
+++ b/Development/nmos/test/condition_variable_test.cpp
@@ -52,15 +52,11 @@ namespace
 
         for (;;)
         {
-            if (nmos::details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown; }))
-            {
-                ++waken_up_count;
+            nmos::details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown; });
 
-                if (shutdown)
-                {
-                    break;
-                }
-            }
+            ++waken_up_count;
+
+            if (shutdown) break;
         }
 
         BST_REQUIRE_EQUAL(1, waken_up_count);

--- a/Development/nmos/test/condition_variable_test.cpp
+++ b/Development/nmos/test/condition_variable_test.cpp
@@ -1,8 +1,8 @@
 // The first "test" is of course whether the header compiles standalone
 #include <iostream>
-#include "nmos/thread_utils.h" // for wait_until
 #include "nmos/mutex.h"
 #include "nmos/tai.h"
+#include "nmos/thread_utils.h" // for wait_until
 
 #include "bst/test/test.h"
 

--- a/Development/nmos/test/condition_variable_test.cpp
+++ b/Development/nmos/test/condition_variable_test.cpp
@@ -1,0 +1,129 @@
+// The first "test" is of course whether the header compiles standalone
+#include <iostream>
+#include "nmos/thread_utils.h" // for wait_until
+#include "nmos/mutex.h"
+#include "nmos/tai.h"
+
+#include "bst/test/test.h"
+
+namespace
+{
+    struct test_model
+    {
+        // mutex to be used to protect the members of the model from simultaneous access by multiple threads
+        mutable nmos::mutex mutex;
+
+        // condition to be used to wait for, and notify other threads about, changes to any member of the model
+        // including the shutdown flag
+        mutable nmos::condition_variable condition;
+
+        bool shutdown{ false };
+
+        nmos::read_lock read_lock() const { return nmos::read_lock{ mutex }; }
+        nmos::write_lock write_lock() const { return nmos::write_lock{ mutex }; }
+        void notify() const { return condition.notify_all(); }
+    };
+
+    test_model model;
+
+    void lock_then_unlock()
+    {
+        try
+        {
+            auto lock = model.write_lock();
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        catch (...)
+        {
+            // ignore lock failure
+        }
+        std::cerr << "*";
+    }
+
+    void wait()
+    {
+        int waken_up_count{ 0 };
+
+        auto lock = model.write_lock();
+        auto& condition = model.condition;
+        auto& shutdown = model.shutdown;
+
+        auto earliest_necessary_update = (nmos::tai_clock::time_point::max)();
+
+        for (;;)
+        {
+            if (nmos::details::wait_until(condition, lock, earliest_necessary_update, [&] { return shutdown; }))
+            {
+                ++waken_up_count;
+
+                if (shutdown)
+                {
+                    break;
+                }
+            }
+        }
+
+        BST_REQUIRE_EQUAL(1, waken_up_count);
+    }
+
+    void shutdown(const std::chrono::seconds& pause_for)
+    {
+        for (;;)
+        {
+            std::this_thread::sleep_for(pause_for);
+
+            try
+            {
+                auto lock = model.write_lock();
+                model.shutdown = true;
+                break;
+            }
+            catch (...)
+            {
+                // ignore lock failure
+            }
+        }
+
+        BST_CHECK(true);
+
+        model.notify();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testConditionVariableWait)
+{
+    const auto max_threads{ 500 };
+
+    // start a wait thread
+    std::thread wait_thread(wait);
+
+    // start a large number of lock_then_unlock threads to exhaust the lock limit
+    std::vector<std::thread> threads;
+    for (auto idx = 0; idx < max_threads; idx++)
+    {
+        threads.push_back(std::thread(lock_then_unlock));
+    }
+
+    // send a lot of notifications to wake up the wait thread
+    // to wake the wait thread when lock limit is exhausted
+    for (auto idx = 0; idx < 100; idx++)
+    {
+        model.notify();
+    }
+
+    // start the thread to pause 1 second before signal a shutdown
+    std::thread shutdown_thread(shutdown, std::chrono::seconds{ 1 });
+
+    shutdown_thread.join();
+    wait_thread.join();
+
+    for (auto idx = 0; idx < max_threads; idx++)
+    {
+        threads[idx].join();
+    }
+
+    std::cerr << "\n";
+
+    BST_CHECK(true);
+}

--- a/Development/nmos/thread_utils.h
+++ b/Development/nmos/thread_utils.h
@@ -1,7 +1,7 @@
 #ifndef NMOS_THREAD_UTILS_H
 #define NMOS_THREAD_UTILS_H
 
-#include "slog/all_in_one.h"
+#include <thread>
 
 namespace nmos
 {

--- a/Development/nmos/thread_utils.h
+++ b/Development/nmos/thread_utils.h
@@ -1,7 +1,7 @@
 #ifndef NMOS_THREAD_UTILS_H
 #define NMOS_THREAD_UTILS_H
 
-#include <thread>
+#include "slog/all_in_one.h"
 
 namespace nmos
 {
@@ -29,8 +29,18 @@ namespace nmos
         {
             if ((TimePoint::max)() == tp)
             {
-                condition.wait(lock, predicate);
-                return true;
+                // note, the try-catch block is here because Windows boost::condition_variable_any::wait can throw
+                // an expectation once boost::shared_mutex has reached the maximum number of exclusive_waiting locks
+                try
+                {
+                    condition.wait(lock, predicate);
+                    return true;
+                }
+                catch (...)
+                {
+                    // wait failed, return false
+                }
+                return false;
             }
             else
             {
@@ -39,9 +49,9 @@ namespace nmos
         }
 
         template <typename ConditionVariable, typename Lock, typename Rep, typename Period, typename Predicate>
-        inline bool wait_for(ConditionVariable& condition, Lock& lock, const std::chrono::duration<Rep, Period>& duration, Predicate predicate)
+        inline bool wait_for(ConditionVariable& condition, Lock& lock, const bst::chrono::duration<Rep, Period>& duration, Predicate predicate)
         {
-            if ((std::chrono::duration<Rep, Period>::max)() == duration)
+            if ((bst::chrono::duration<Rep, Period>::max)() == duration)
             {
                 condition.wait(lock, predicate);
                 return true;
@@ -50,7 +60,7 @@ namespace nmos
             {
                 // using wait_until as a workaround for bug in VS2015, resolved in VS2017
                 // see https://developercommunity.visualstudio.com/content/problem/274532/bug-in-visual-studio-2015-implementation-of-stdcon.html
-                return condition.wait_until(lock, std::chrono::steady_clock::now() + duration, predicate);
+                return condition.wait_until(lock, bst::chrono::steady_clock::now() + duration, predicate);
             }
         }
 
@@ -70,9 +80,9 @@ namespace nmos
         }
 
         template <typename ConditionVariable, typename Lock, typename Rep, typename Period>
-        inline auto wait_for(ConditionVariable& condition, Lock& lock, const std::chrono::duration<Rep, Period>& duration) -> decltype(condition.wait_for(lock, duration))
+        inline auto wait_for(ConditionVariable& condition, Lock& lock, const bst::chrono::duration<Rep, Period>& duration) -> decltype(condition.wait_for(lock, duration))
         {
-            if ((std::chrono::duration<Rep, Period>::max)() == duration)
+            if ((bst::chrono::duration<Rep, Period>::max)() == duration)
             {
                 condition.wait(lock);
                 typedef decltype(condition.wait_for(lock, duration)) cv_status;
@@ -80,7 +90,7 @@ namespace nmos
             }
             else
             {
-                return condition.wait_until(lock, std::chrono::steady_clock::now() + duration);
+                return condition.wait_until(lock, bst::chrono::steady_clock::now() + duration);
             }
         }
 


### PR DESCRIPTION
Windows `boost::condition_variable_any::wait` would throw nested lock exceptions when `boost::shared_mutex` has reached the
maximum number of exclusive_waiting locks. This problem occurs inside the `boost::basic_condition_variable::do_wait_until`
when `relocker` is out of scope. This could cause program termination due to unhandled exceptions.
@garethsb reports this problem in #315.