### PR TITLE
IS-12 Bug Fix: Stop resource events being sent to control clients

### DIFF
--- a/Development/nmos/control_protocol_methods.cpp
+++ b/Development/nmos/control_protocol_methods.cpp
@@ -335,7 +335,7 @@ namespace nmos
                     // do notification that the specified property has changed
                     if (property_changed)
                     {
-                        property_changed(resource, nmos::fields::nc::name(property), index);
+                        property_changed(resource, nmos::fields::nc::name(property), -1);
                     }
 
                 }, make_property_changed_event(nmos::fields::nc::oid(resource.data), { { details::parse_nc_property_id(property_id), nc_property_change_type::type::sequence_item_removed, nc_id(index) } }));

--- a/Development/nmos/control_protocol_ws_api.cpp
+++ b/Development/nmos/control_protocol_ws_api.cpp
@@ -499,6 +499,10 @@ namespace nmos
 
                 for (const auto& event : nmos::fields::message_grain_data(grain->data).as_array())
                 {
+                    // Only send control events to the control client
+                    if (event.has_field(U("pre")) || event.has_field(U("post"))) {
+                        continue;
+                    }
                     web::websockets::websocket_outgoing_message message;
 
                     slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "outgoing_message: " << event.serialize();

--- a/Development/nmos/control_protocol_ws_api.cpp
+++ b/Development/nmos/control_protocol_ws_api.cpp
@@ -500,14 +500,13 @@ namespace nmos
                 for (const auto& event : nmos::fields::message_grain_data(grain->data).as_array())
                 {
                     // Only send control events to the control client
-                    if (event.has_field(U("pre")) || event.has_field(U("post"))) {
-                        continue;
-                    }
-                    web::websockets::websocket_outgoing_message message;
+                    if (event.has_field(U("messageType")) && (event.has_field(U("subscriptions")) || event.has_field(U("responses")) || event.has_field(U("notifications")) || event.has_field(U("status")))) {
+                        web::websockets::websocket_outgoing_message message;
 
-                    slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "outgoing_message: " << event.serialize();
-                    message.set_utf8_message(utility::us2s(event.serialize()));
-                    outgoing_messages.push_back({ websocket.second, message });
+                        slog::log<slog::severities::too_much_info>(gate, SLOG_FLF) << "outgoing_message: " << event.serialize();
+                        message.set_utf8_message(utility::us2s(event.serialize()));
+                        outgoing_messages.push_back({ websocket.second, message });
+                    }
                 }
 
                 // reset the grain for next time


### PR DESCRIPTION
- IS-12 re-uses the data grain subscription mechanism for sending notifications to IS-12 Clients
- A side effect (bug) is that any resource events generated, for instance by deleting an NMOS resource, are also sent to the IS-12 Client
- This is unexpected as IS-12 Clients are only expecting IS-12 notifications
- Bug fix ignores resource events in the control protocol WebSocket subscription handling
- **This raises the question: could IS-12 notifications be inadvertently sent over IS-07 event and tally WebSocket when both are in use?**