### PR TITLE
Fix SDP session ID length limitation

### DIFF
--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -1624,4 +1624,14 @@ namespace nmos
     {
         details::validate_sdp_parameters(details::format_constraints, sdp_params, details::get_format(sdp_params), details::get_format_parameters(sdp_params), receiver);
     }
+
+    // Validate the numeric string
+    const utility::string_t& valid_numeric_string(const utility::string_t& s)
+    {
+        if (!std::all_of(s.begin(), s.end(), ::isdigit))
+        {
+            throw std::invalid_argument("not a numeric string");
+        }
+        return s;
+    }
 }

--- a/Development/nmos/sdp_utils.cpp
+++ b/Development/nmos/sdp_utils.cpp
@@ -1628,7 +1628,7 @@ namespace nmos
     // Validate the numeric string
     const utility::string_t& valid_numeric_string(const utility::string_t& s)
     {
-        if (!std::all_of(s.begin(), s.end(), ::isdigit))
+        if (!std::all_of(s.begin(), s.end(), [](utility::char_t c) { return std::isdigit(c); }))
         {
             throw std::invalid_argument("not a numeric string");
         }

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <map>
 #include <stdexcept>
+#include <boost/lexical_cast.hpp>
 #include "bst/any.h"
 #include "bst/optional.h"
 #include "cpprest/basic_utils.h"
@@ -88,7 +89,7 @@ namespace nmos
             origin_t() : session_id(), session_version() {}
             origin_t(const utility::string_t& user_name, uint64_t session_id, uint64_t session_version)
                 : user_name(user_name)
-                , session_id(std::to_wstring(session_id))
+                , session_id(boost::lexical_cast<utility::string_t>(session_id))
                 , session_version(session_version)
             {}
             origin_t(const utility::string_t& user_name, const utility::string_t& session_id, uint64_t session_version)

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -84,24 +84,31 @@ namespace nmos
         {
             utility::string_t user_name;
             utility::string_t session_id;
-            uint64_t session_version;
+            utility::string_t session_version;
 
             origin_t() : session_id(), session_version() {}
             origin_t(const utility::string_t& user_name, uint64_t session_id, uint64_t session_version)
                 : user_name(user_name)
                 , session_id(boost::lexical_cast<utility::string_t>(session_id))
-                , session_version(session_version)
+                , session_version(boost::lexical_cast<utility::string_t>(session_version))
             {}
-            origin_t(const utility::string_t& user_name, const utility::string_t& session_id, uint64_t session_version)
+            origin_t(const utility::string_t& user_name, const utility::string_t& session_id, const utility::string_t& session_version)
                 : user_name(user_name)
                 , session_version(session_version)
             {
                 // validate session_id is a numeric string
                 if (!std::all_of(session_id.begin(), session_id.end(), ::isdigit))
                 {
-                    throw std::invalid_argument("session_id must be a numeric string");
+                    throw std::invalid_argument("session id must be a numeric string");
                 }
                 this->session_id = session_id;
+
+                // validate session_version is a numeric string
+                if (!std::all_of(session_version.begin(), session_version.end(), ::isdigit))
+                {
+                    throw std::invalid_argument("session version must be a numeric string");
+                }
+                this->session_version = session_version;
             }
             origin_t(const utility::string_t& user_name, uint64_t session_id_version)
                 : origin_t{ user_name, session_id_version, session_id_version }

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -82,19 +82,28 @@ namespace nmos
         struct origin_t
         {
             utility::string_t user_name;
-            uint64_t session_id;
+            utility::string_t session_id;
             uint64_t session_version;
 
             origin_t() : session_id(), session_version() {}
             origin_t(const utility::string_t& user_name, uint64_t session_id, uint64_t session_version)
                 : user_name(user_name)
-                , session_id(session_id)
+                , session_id(std::to_wstring(session_id))
                 , session_version(session_version)
             {}
-            origin_t(const utility::string_t& user_name, uint64_t session_id_version)
+            origin_t(const utility::string_t& user_name, const utility::string_t& session_id, uint64_t session_version)
                 : user_name(user_name)
-                , session_id(session_id_version)
-                , session_version(session_id_version)
+                , session_version(session_version)
+            {
+                // validate session_id is a numeric string
+                if (!std::all_of(session_id.begin(), session_id.end(), ::isdigit))
+                {
+                    throw std::invalid_argument("session_id must be a numeric string");
+                }
+                this->session_id = session_id;
+            }
+            origin_t(const utility::string_t& user_name, uint64_t session_id_version)
+                : origin_t{ user_name, session_id_version, session_id_version }
             {}
         } origin;
 

--- a/Development/nmos/sdp_utils.h
+++ b/Development/nmos/sdp_utils.h
@@ -5,7 +5,6 @@
 #include <functional>
 #include <map>
 #include <stdexcept>
-#include <boost/lexical_cast.hpp>
 #include "bst/any.h"
 #include "bst/optional.h"
 #include "cpprest/basic_utils.h"
@@ -64,6 +63,11 @@ namespace nmos
     // Validate the SDP parameters against a receiver for "video/raw", "audio/L", "video/smpte291" or "video/SMPTE2022-6"
     void validate_sdp_parameters(const web::json::value& receiver, const sdp_parameters& sdp_params);
 
+    // sdp_parameters helper functions
+
+    // Validate the numeric string
+    const utility::string_t& valid_numeric_string(const utility::string_t& s);
+
     // Format-specific types
 
     struct video_raw_parameters;
@@ -86,30 +90,17 @@ namespace nmos
             utility::string_t session_id;
             utility::string_t session_version;
 
-            origin_t() : session_id(), session_version() {}
+            origin_t() {}
             origin_t(const utility::string_t& user_name, uint64_t session_id, uint64_t session_version)
                 : user_name(user_name)
-                , session_id(boost::lexical_cast<utility::string_t>(session_id))
-                , session_version(boost::lexical_cast<utility::string_t>(session_version))
+                , session_id(utility::conversions::details::to_string_t(session_id))
+                , session_version(utility::conversions::details::to_string_t(session_version))
             {}
             origin_t(const utility::string_t& user_name, const utility::string_t& session_id, const utility::string_t& session_version)
                 : user_name(user_name)
-                , session_version(session_version)
-            {
-                // validate session_id is a numeric string
-                if (!std::all_of(session_id.begin(), session_id.end(), ::isdigit))
-                {
-                    throw std::invalid_argument("session id must be a numeric string");
-                }
-                this->session_id = session_id;
-
-                // validate session_version is a numeric string
-                if (!std::all_of(session_version.begin(), session_version.end(), ::isdigit))
-                {
-                    throw std::invalid_argument("session version must be a numeric string");
-                }
-                this->session_version = session_version;
-            }
+                , session_id(valid_numeric_string(session_id))
+                , session_version(valid_numeric_string(session_version))
+            {}
             origin_t(const utility::string_t& user_name, uint64_t session_id_version)
                 : origin_t{ user_name, session_id_version, session_id_version }
             {}

--- a/Development/sdp/json.h
+++ b/Development/sdp/json.h
@@ -21,7 +21,7 @@ namespace sdp
         const web::json::field_as_value origin{ U("origin") };
         const web::json::field_as_string user_name{ U("user_name") };
         const web::json::field_as_string session_id{ U("session_id") };
-        const web::json::field<uint64_t> session_version{ U("session_version") };
+        const web::json::field_as_string session_version{ U("session_version") };
         const web::json::field_as_string network_type{ U("network_type") }; // see sdp::network_types
         const web::json::field_as_string address_type{ U("address_type") }; // see sdp::address_types
         const web::json::field_as_string unicast_address{ U("unicast_address") };

--- a/Development/sdp/json.h
+++ b/Development/sdp/json.h
@@ -20,7 +20,7 @@ namespace sdp
         // See https://tools.ietf.org/html/rfc4566#section-5.2
         const web::json::field_as_value origin{ U("origin") };
         const web::json::field_as_string user_name{ U("user_name") };
-        const web::json::field<uint64_t> session_id{ U("session_id") };
+        const web::json::field_as_string session_id{ U("session_id") };
         const web::json::field<uint64_t> session_version{ U("session_version") };
         const web::json::field_as_string network_type{ U("network_type") }; // see sdp::network_types
         const web::json::field_as_string address_type{ U("address_type") }; // see sdp::address_types

--- a/Development/sdp/sdp_grammar.cpp
+++ b/Development/sdp/sdp_grammar.cpp
@@ -5,6 +5,7 @@
 #include "bst/regex.h"
 #include "cpprest/basic_utils.h"
 #include "cpprest/json_visit.h"
+#include "nmos/sdp_utils.h"
 #include "sdp/json.h"
 
 namespace sdp
@@ -75,8 +76,16 @@ namespace sdp
         }
         inline web::json::value digits2jns(const std::string& s)
         {
-            if (!std::all_of(s.begin(), s.end(), ::isdigit)) throw sdp_parse_error("expected a sequence of digits");
-            return s2js(s);
+            utility::string_t numeric_string;
+            try
+            {
+                numeric_string = nmos::valid_numeric_string(utility::s2us(s));
+            }
+            catch (...)
+            {
+                throw sdp_parse_error("expected a sequence of digits");
+            }
+            return s2js(utility::us2s(numeric_string));
         }
 
         // find the first delimiter in str, beginning at pos, and return the substring from pos to the delimiter (or end)
@@ -107,7 +116,7 @@ namespace sdp
 
         const converter digits_converter{ jn2s, digits2jn };
 
-        const converter long_digits_converter{ jns2s, digits2jns };
+        const converter big_digits_converter{ jns2s, digits2jns };
 
         // <key>[<separator><value>]
         converter key_value_converter(char separator, const std::pair<utility::string_t, converter>& key_converter, const std::pair<utility::string_t, converter>& value_converter)
@@ -303,8 +312,8 @@ namespace sdp
             'o',
             object_converter({
                 { sdp::fields::user_name, string_converter },
-                { sdp::fields::session_id, long_digits_converter },
-                { sdp::fields::session_version, long_digits_converter },
+                { sdp::fields::session_id, big_digits_converter },
+                { sdp::fields::session_version, big_digits_converter },
                 { sdp::fields::network_type, string_converter },
                 { sdp::fields::address_type, string_converter },
                 { sdp::fields::unicast_address, string_converter }

--- a/Development/sdp/sdp_grammar.cpp
+++ b/Development/sdp/sdp_grammar.cpp
@@ -2,7 +2,6 @@
 #include "sdp/sdp.h"
 
 #include <stdexcept>
-#include <boost/lexical_cast.hpp>
 #include "bst/regex.h"
 #include "cpprest/basic_utils.h"
 #include "cpprest/json_visit.h"
@@ -77,12 +76,7 @@ namespace sdp
         inline web::json::value digits2jns(const std::string& s)
         {
             if (!std::all_of(s.begin(), s.end(), ::isdigit)) throw sdp_parse_error("expected a sequence of digits");
-
-            uint64_t v;
-            std::istringstream is(s);
-            is >> v;
-            if (is.fail() || !is.eof()) return s2js(s);
-            return web::json::value(boost::lexical_cast<utility::string_t>(v));
+            return s2js(s);
         }
 
         // find the first delimiter in str, beginning at pos, and return the substring from pos to the delimiter (or end)

--- a/Development/sdp/sdp_grammar.cpp
+++ b/Development/sdp/sdp_grammar.cpp
@@ -310,7 +310,7 @@ namespace sdp
             object_converter({
                 { sdp::fields::user_name, string_converter },
                 { sdp::fields::session_id, long_digits_converter },
-                { sdp::fields::session_version, digits_converter },
+                { sdp::fields::session_version, long_digits_converter },
                 { sdp::fields::network_type, string_converter },
                 { sdp::fields::address_type, string_converter },
                 { sdp::fields::unicast_address, string_converter }

--- a/Development/sdp/sdp_grammar.cpp
+++ b/Development/sdp/sdp_grammar.cpp
@@ -2,6 +2,7 @@
 #include "sdp/sdp.h"
 
 #include <stdexcept>
+#include <boost/lexical_cast.hpp>
 #include "bst/regex.h"
 #include "cpprest/basic_utils.h"
 #include "cpprest/json_visit.h"
@@ -81,7 +82,7 @@ namespace sdp
             std::istringstream is(s);
             is >> v;
             if (is.fail() || !is.eof()) return s2js(s);
-            return web::json::value(std::to_wstring(v));
+            return web::json::value(boost::lexical_cast<utility::string_t>(v));
         }
 
         // find the first delimiter in str, beginning at pos, and return the substring from pos to the delimiter (or end)

--- a/Development/sdp/sdp_grammar.cpp
+++ b/Development/sdp/sdp_grammar.cpp
@@ -68,6 +68,22 @@ namespace sdp
             return web::json::value(v);
         }
 
+        inline std::string jns2s(const web::json::value& v)
+        {
+            if (v.is_number()) return jn2s(v);
+            else return js2s(v);
+        }
+        inline web::json::value digits2jns(const std::string& s)
+        {
+            if (!std::all_of(s.begin(), s.end(), ::isdigit)) throw sdp_parse_error("expected a sequence of digits");
+
+            uint64_t v;
+            std::istringstream is(s);
+            is >> v;
+            if (is.fail() || !is.eof()) return s2js(s);
+            return web::json::value(std::to_wstring(v));
+        }
+
         // find the first delimiter in str, beginning at pos, and return the substring from pos to the delimiter (or end)
         // set pos to the end of the delimiter
         inline std::string substr_find(const std::string& str, std::string::size_type& pos, const std::string& delimiter = {})
@@ -95,6 +111,8 @@ namespace sdp
         const converter number_converter{ jn2s, s2jn };
 
         const converter digits_converter{ jn2s, digits2jn };
+
+        const converter long_digits_converter{ jns2s, digits2jns };
 
         // <key>[<separator><value>]
         converter key_value_converter(char separator, const std::pair<utility::string_t, converter>& key_converter, const std::pair<utility::string_t, converter>& value_converter)
@@ -290,7 +308,7 @@ namespace sdp
             'o',
             object_converter({
                 { sdp::fields::user_name, string_converter },
-                { sdp::fields::session_id, digits_converter },
+                { sdp::fields::session_id, long_digits_converter },
                 { sdp::fields::session_version, digits_converter },
                 { sdp::fields::network_type, string_converter },
                 { sdp::fields::address_type, string_converter },

--- a/Development/sdp/test/sdp_test.cpp
+++ b/Development/sdp/test/sdp_test.cpp
@@ -100,7 +100,7 @@ a=mid:SECONDARY
         { sdp::fields::protocol_version, 0 },
         { sdp::fields::origin, web::json::value_of({
             { sdp::fields::user_name, U("-") },
-            { sdp::fields::session_id, 3745911798u },
+            { sdp::fields::session_id, U("3745911798") },
             { sdp::fields::session_version, 3745911798u },
             { sdp::fields::network_type, sdp::network_types::internet.name },
             { sdp::fields::address_type, sdp::address_types::IP4.name },
@@ -346,7 +346,7 @@ a=framerate:59.94
         { sdp::fields::protocol_version, 0 },
         { sdp::fields::origin, web::json::value_of({
             { sdp::fields::user_name, U("-") },
-            { sdp::fields::session_id, 0 },
+            { sdp::fields::session_id, U("0") },
             { sdp::fields::session_version, 0 },
             { sdp::fields::network_type, sdp::network_types::internet.name },
             { sdp::fields::address_type, sdp::address_types::IP4.name },
@@ -570,4 +570,20 @@ a=fmtp:96)";
     {
         BST_REQUIRE_THROW(sdp::parse_session_description(test_sdp + bp), std::runtime_error);
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testSdpSessionId)
+{
+    const std::string before = "v=0\r\no=- ";
+    const std::string after = " 42 IN IP4 10.0.0.1\r\ns= \r\nt=0 0\r\n";
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "0" + after));
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "007" + after));
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "18446744073709551615" + after));  // session id to UINT64_MAX
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "184467440737095516150" + after)); // session id larger than UINT64_MAX
+    // an invalid session id results in "sdp parse error - expected a sequence of digits at line 2"
+    BST_REQUIRE_THROW(sdp::parse_session_description(before + "foo" + after), std::runtime_error);
+    BST_REQUIRE_THROW(sdp::parse_session_description(before + "0foo" + after), std::runtime_error);
+    BST_REQUIRE_THROW(sdp::parse_session_description(before + "0.0" + after), std::runtime_error);
+    BST_REQUIRE_THROW(sdp::parse_session_description(before + "0x0" + after), std::runtime_error);
 }

--- a/Development/sdp/test/sdp_test.cpp
+++ b/Development/sdp/test/sdp_test.cpp
@@ -589,7 +589,7 @@ BST_TEST_CASE(testSdpSessionId)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
-BST_TEST_CASE(testSdpSessionVesrion)
+BST_TEST_CASE(testSdpSessionVersion)
 {
     const std::string before = "v=0\r\no=- 42 ";
     const std::string after = " IN IP4 10.0.0.1\r\ns= \r\nt=0 0\r\n";

--- a/Development/sdp/test/sdp_test.cpp
+++ b/Development/sdp/test/sdp_test.cpp
@@ -101,7 +101,7 @@ a=mid:SECONDARY
         { sdp::fields::origin, web::json::value_of({
             { sdp::fields::user_name, U("-") },
             { sdp::fields::session_id, U("3745911798") },
-            { sdp::fields::session_version, 3745911798u },
+            { sdp::fields::session_version, U("3745911798") },
             { sdp::fields::network_type, sdp::network_types::internet.name },
             { sdp::fields::address_type, sdp::address_types::IP4.name },
             { sdp::fields::unicast_address, U("192.168.9.142") }
@@ -347,7 +347,7 @@ a=framerate:59.94
         { sdp::fields::origin, web::json::value_of({
             { sdp::fields::user_name, U("-") },
             { sdp::fields::session_id, U("0") },
-            { sdp::fields::session_version, 0 },
+            { sdp::fields::session_version, U("0") },
             { sdp::fields::network_type, sdp::network_types::internet.name },
             { sdp::fields::address_type, sdp::address_types::IP4.name },
             { sdp::fields::unicast_address, U("192.0.2.0") }
@@ -580,8 +580,24 @@ BST_TEST_CASE(testSdpSessionId)
     BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "0" + after));
     BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "007" + after));
     BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "18446744073709551615" + after));  // session id to UINT64_MAX
-    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "184467440737095516150" + after)); // session id larger than UINT64_MAX
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "184467440737095516150" + after)); // session id greater than UINT64_MAX
     // an invalid session id results in "sdp parse error - expected a sequence of digits at line 2"
+    BST_REQUIRE_THROW(sdp::parse_session_description(before + "foo" + after), std::runtime_error);
+    BST_REQUIRE_THROW(sdp::parse_session_description(before + "0foo" + after), std::runtime_error);
+    BST_REQUIRE_THROW(sdp::parse_session_description(before + "0.0" + after), std::runtime_error);
+    BST_REQUIRE_THROW(sdp::parse_session_description(before + "0x0" + after), std::runtime_error);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+BST_TEST_CASE(testSdpSessionVesrion)
+{
+    const std::string before = "v=0\r\no=- 42 ";
+    const std::string after = " IN IP4 10.0.0.1\r\ns= \r\nt=0 0\r\n";
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "0" + after));
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "007" + after));
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "18446744073709551615" + after));  // session version to UINT64_MAX
+    BST_REQUIRE_NO_THROW(sdp::parse_session_description(before + "184467440737095516150" + after)); // session version greater than UINT64_MAX
+    // an invalid session version results in "sdp parse error - expected a sequence of digits at line 2"
     BST_REQUIRE_THROW(sdp::parse_session_description(before + "foo" + after), std::runtime_error);
     BST_REQUIRE_THROW(sdp::parse_session_description(before + "0foo" + after), std::runtime_error);
     BST_REQUIRE_THROW(sdp::parse_session_description(before + "0.0" + after), std::runtime_error);


### PR DESCRIPTION
According to the [RFC 4566 5.2. Origin](https://tools.ietf.org/html/rfc4566#section-5.2)
```
<sess-id> is a numeric string such that the tuple of <username>,
 
<sess-id>, <nettype>, <addrtype>, and <unicast-address> forms a
 
globally unique identifier for the session.  The method of
 
<sess-id> allocation is up to the creating tool, but it has been
 
suggested that a Network Time Protocol (NTP) format timestamp be
 
used to ensure uniqueness [[13](https://datatracker.ietf.org/doc/html/rfc4566#ref-13)].
```
The current implementation limit for the session ID is UINT64_MAX (18446744073709551615), i.e., its maximum length is 20 digits. To fulfill the RFC above, the string should not be limited in length. 