### PR TITLE
IS-12: Fix sequence item removed bug

### DIFF
--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -1706,10 +1706,15 @@ nmos::control_protocol_property_changed_handler make_node_implementation_control
             // sequence property
             slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "Property: " << property_name << " index " << index << " has value changed to " << resource.data.at(property_name).at(index).serialize();
         }
-        else
+        else if (index == -1)
         {
             // non-sequence property
             slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "Property: " << property_name << " has value changed to " << resource.data.at(property_name).serialize();
+        }
+        else if (index == -2)
+        {
+            // sequence property removed
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "Property: " << property_name << " has sequence item removed. Value changed to " << resource.data.at(property_name).serialize();
         }
     };
 }

--- a/Development/nmos/control_protocol_handlers.h
+++ b/Development/nmos/control_protocol_handlers.h
@@ -33,6 +33,7 @@ namespace nmos
 
     // a control_protocol_property_changed_handler is a notification that the specified (IS-12) property has changed
     // index is set to -1 for non-sequence property
+    // index is set to -2 when a sequence item had been removed
     // this callback should not throw exceptions, as the relevant property will already has been changed and those changes will not be rolled back
     typedef std::function<void(const nmos::resource& resource, const utility::string_t& property_name, int index)> control_protocol_property_changed_handler;
 

--- a/Development/nmos/control_protocol_methods.cpp
+++ b/Development/nmos/control_protocol_methods.cpp
@@ -335,7 +335,7 @@ namespace nmos
                     // do notification that the specified property has changed
                     if (property_changed)
                     {
-                        property_changed(resource, nmos::fields::nc::name(property), index);
+                        property_changed(resource, nmos::fields::nc::name(property), -2);
                     }
 
                 }, make_property_changed_event(nmos::fields::nc::oid(resource.data), { { details::parse_nc_property_id(property_id), nc_property_change_type::type::sequence_item_removed, nc_id(index) } }));


### PR DESCRIPTION
- Example property changed handler was attempting to read a removed value causing an exception.
- Item removed is now explicitly indicated to the property changed handler.