### PR TITLE
GitHub Ubuntu 20.04 LTS runner is removed on 2025-04-15

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
         install_mdns: [false, true]
         use_conan: [true]
         force_cpprest_asio: [false]
@@ -27,7 +27,7 @@ jobs:
           # install_mdns is only meaningful on Linux
           - os: windows-2019
             enable_authorization: false
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             enable_authorization: false
           - os: windows-2019
             install_mdns: true
@@ -36,7 +36,7 @@ jobs:
             dns_sd_mode: unicast
           # for now, exclude unicast DNS-SD with mDNSResponder due to
           # intermittent *** buffer overflow detected *** in mdnsd
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             install_mdns: true
             dns_sd_mode: unicast
             enable_authorization: true
@@ -53,13 +53,13 @@ jobs:
             force_cpprest_asio: true
             dns_sd_mode: multicast
             enable_authorization: false
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             install_mdns: false
             use_conan: true
             force_cpprest_asio: false
             dns_sd_mode: multicast
             enable_authorization: true
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             install_mdns: false
             use_conan: true
             force_cpprest_asio: false
@@ -594,7 +594,7 @@ jobs:
   make_badges:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     needs: [build_and_test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/src/build-test.yml
+++ b/.github/workflows/src/build-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
         install_mdns: [false, true]
         use_conan: [true]
         force_cpprest_asio: [false]
@@ -27,7 +27,7 @@ jobs:
           # install_mdns is only meaningful on Linux
           - os: windows-2019
             enable_authorization: false
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             enable_authorization: false
           - os: windows-2019
             install_mdns: true
@@ -36,7 +36,7 @@ jobs:
             dns_sd_mode: unicast
           # for now, exclude unicast DNS-SD with mDNSResponder due to
           # intermittent *** buffer overflow detected *** in mdnsd
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             install_mdns: true
             dns_sd_mode: unicast
             enable_authorization: true
@@ -53,13 +53,13 @@ jobs:
             force_cpprest_asio: true
             dns_sd_mode: multicast
             enable_authorization: false
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             install_mdns: false
             use_conan: true
             force_cpprest_asio: false
             dns_sd_mode: multicast
             enable_authorization: true
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             install_mdns: false
             use_conan: true
             force_cpprest_asio: false
@@ -108,7 +108,7 @@ jobs:
   make_badges:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     needs: [build_and_test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ The following configurations, defined by the [build-test](.github/workflows/src/
 
 | Platform | Version                   | Build Options                      | Test Options                                                       |
 |----------|---------------------------|------------------------------------|--------------------------------------------------------------------|
-| Linux    | Ubuntu 22.04 (GCC 11.2.0) | Avahi                              | Secure Communications<br/>Multicast DNS-SD                         |
+| Linux    | Ubuntu 24.04 (GCC 13.2.0) | Avahi                              | Secure Communications<br/>Multicast DNS-SD                         |
+| Linux    | Ubuntu 24.04 (GCC 13.2.0) | Avahi                              | Secure Communications<br/>IS-10 Authorization<br/>Multicast DNS-SD |
 | Linux    | Ubuntu 22.04 (GCC 11.2.0) | Avahi                              | Secure Communications<br/>IS-10 Authorization<br/>Multicast DNS-SD |
-| Linux    | Ubuntu 20.04 (GCC 9.4.0)  | Avahi                              | Secure Communications<br/>IS-10 Authorization<br/>Multicast DNS-SD |
-| Linux    | Ubuntu 20.04 (GCC 9.4.0)  | Avahi                              | Secure Communications<br/>IS-10 Authorization<br/>Unicast DNS-SD   |
-| Linux    | Ubuntu 20.04 (GCC 9.4.0)  | mDNSResponder                      | Secure Communications<br/>IS-10 Authorization<br/>Multicast DNS-SD |
+| Linux    | Ubuntu 22.04 (GCC 11.2.0) | Avahi                              | Secure Communications<br/>IS-10 Authorization<br/>Unicast DNS-SD   |
+| Linux    | Ubuntu 22.04 (GCC 11.2.0) | mDNSResponder                      | Secure Communications<br/>IS-10 Authorization<br/>Multicast DNS-SD |
 | Linux    | Ubuntu 14.04 (GCC 4.8.4)  | mDNSResponder, not using Conan     | Secure Communications<br/>IS-10 Authorization<br/>Multicast DNS-SD |
 | Windows  | Server 2019 (VS 2019)     | Bonjour (mDNSResponder), WinHTTP   | Secure Communications<br/>IS-10 Authorization<br/>Multicast DNS-SD |
 | Windows  | Server 2022 (VS 2022)     | Bonjour (mDNSResponder), ASIO      | Secure Communications<br/>Multicast DNS-SD                         |


### PR DESCRIPTION
The `Ubuntu 20.04 LTS runner` is removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101.
Up Ubuntu 22.04 runner to 24.04 and Ubuntu 20.04 runner to 22.04.