### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository contains an implementation of the [AMWA Networked Media Open Spe
 For more information about AMWA, NMOS and the Networked Media Incubator, please refer to <https://www.amwa.tv/>.
 
 - The [nmos module](Development/nmos) includes implementations of the NMOS Node, Registration and Query APIs, the NMOS Connection API, and so on.
-- The [nmos-cpp-registry application](Development/nmos-cpp-registry) provides a simple but functional instance of an NMOS Registration & Discovery System (RDS), utilising the nmos module.
+- The [nmos-cpp-registry application](Development/nmos-cpp-registry) provides a simple but functional instance of an NMOS Registration & Discovery System (RDS), utilizing the nmos module.
 - The [nmos-cpp-node application](Development/nmos-cpp-node) provides an example NMOS Node, also utilising the nmos module.
 
 The [repository structure](Documents/Repository-Structure.md), and the [external dependencies](Documents/Dependencies.md), are outlined in the documentation.


### PR DESCRIPTION
In the README under the description of the "nmos-cpp-registry application", the word "utilising" is used (British English). Depending on the style guide you want (e.g., if you expect American English throughout), it would be better to change it to "utilizing" for consistency if the rest is in American English.