### PR TITLE
Add BCP-006-01-01 test suite testing to CI

### DIFF
--- a/Development/slog/all_in_one.h
+++ b/Development/slog/all_in_one.h
@@ -1027,7 +1027,7 @@ namespace slog
     class log_statement
     {
     public:
-        log_statement(severity level, const char* file, int line, const char* function, bool pert, const int& count = 0)
+        log_statement(severity level, const char* file, int line, const char* function, bool pert, const int& count = count_unused())
             : pert_(pert)
             , count_(count)
             , message_()
@@ -1060,6 +1060,7 @@ namespace slog
         const log_message& message() const { return *message_; }
 
     protected:
+        static const int& count_unused() { static const int zero = 0; return zero; }
         template <typename LoggingGateway>
         void log(LoggingGateway& gate) const { if (pert_) gate.log(*message_); }
 
@@ -1103,7 +1104,7 @@ namespace slog
     class nolog_statement
     {
     public:
-        nolog_statement(severity level, const char* file, int line, const char* function, bool pert, const int& nocount = 0)
+        nolog_statement(severity level, const char* file, int line, const char* function, bool pert, const int& nocount = count_unused())
         {}
 
         // Insertion operators for stream-based logging
@@ -1120,6 +1121,7 @@ namespace slog
         bool pertinent() const { return false; }
 
     protected:
+        static const int& count_unused() { static const int zero = 0; return zero; }
         template <typename LoggingGateway>
         void log(LoggingGateway& gate) const {}
 
@@ -1150,7 +1152,7 @@ namespace slog
             using log_statement::pertinent;
             using log_statement::log;
 
-            logw(log_gate& gate, severity level, const char* file, int line, const char* function, bool pert = true, const int& count = 0)
+            logw(log_gate& gate, severity level, const char* file, int line, const char* function, bool pert = true, const int& count = log_statement::count_unused())
                 : log_statement(level, file, line, function, pert && gate.pertinent(level), count)
                 , uncaught_exceptions_(pertinent() ? uncaught_exceptions() : -1)
                 , gate_(gate)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The [AMWA NMOS API Testing Tool](https://github.com/AMWA-TV/nmos-testing) is aut
 
 **Test Suite/Status:**
 [![BCP-003-01][BCP-003-01-badge]][BCP-003-01-sheet]
+[![BCP-006-01-01][BCP-006-01-01-badge][BCP-006-01-01-sheet]
 [![IS-04-01][IS-04-01-badge]][IS-04-01-sheet]
 [![IS-04-02][IS-04-02-badge]][IS-04-02-sheet]
 [![IS-04-03][IS-04-03-badge]][IS-04-03-sheet]
@@ -93,6 +94,7 @@ The [AMWA NMOS API Testing Tool](https://github.com/AMWA-TV/nmos-testing) is aut
 [![IS-12-01][IS-12-01-badge]][IS-12-01-sheet]
 
 [BCP-003-01-badge]: https://raw.githubusercontent.com/sony/nmos-cpp/badges/BCP-003-01.svg
+[BCP-006-01-01-badge]: https://raw.githubusercontent.com/sony/nmos-cpp/badges/BCP-006-01-01.svg
 [IS-04-01-badge]: https://raw.githubusercontent.com/sony/nmos-cpp/badges/IS-04-01.svg
 [IS-04-02-badge]: https://raw.githubusercontent.com/sony/nmos-cpp/badges/IS-04-02.svg
 [IS-04-03-badge]: https://raw.githubusercontent.com/sony/nmos-cpp/badges/IS-04-03.svg
@@ -106,6 +108,7 @@ The [AMWA NMOS API Testing Tool](https://github.com/AMWA-TV/nmos-testing) is aut
 [IS-09-02-badge]: https://raw.githubusercontent.com/sony/nmos-cpp/badges/IS-09-02.svg
 [IS-12-01-badge]: https://raw.githubusercontent.com/sony/nmos-cpp/badges/IS-12-01.svg
 [BCP-003-01-sheet]: https://docs.google.com/spreadsheets/d/1UgZoI0lGCMDn9-zssccf2Azil3WN6jogroMT8Wh6H64/edit#gid=468090822
+[BCP-006-01-01-sheet]: https://docs.google.com/spreadsheets/d/1UgZoI0lGCMDn9-zssccf2Azil3WN6jogroMT8Wh6H64/edit?gid=367598532
 [IS-04-01-sheet]: https://docs.google.com/spreadsheets/d/1UgZoI0lGCMDn9-zssccf2Azil3WN6jogroMT8Wh6H64/edit#gid=0
 [IS-04-02-sheet]: https://docs.google.com/spreadsheets/d/1UgZoI0lGCMDn9-zssccf2Azil3WN6jogroMT8Wh6H64/edit#gid=1838684224
 [IS-04-03-sheet]: https://docs.google.com/spreadsheets/d/1UgZoI0lGCMDn9-zssccf2Azil3WN6jogroMT8Wh6H64/edit#gid=1174955447

--- a/Sandbox/run_nmos_testing.sh
+++ b/Sandbox/run_nmos_testing.sh
@@ -65,7 +65,8 @@ registry_params=",\
   \"label\":\"nmos-cpp-registry\"\
   "
 node_params=",\
-  \"label\":\"nmos-cpp-node\"\
+  \"label\":\"nmos-cpp-node\",\
+  \"video_type\": \"video/jxsv\"\
   "
   
 if [[ "${config_secure}" == "True" ]]; then
@@ -145,6 +146,7 @@ else
   # test_33, test_33_1
   (( expected_disabled_IS_04_02+=16 ))
   (( expected_disabled_IS_09_01+=7 ))
+  (( expected_disabled_BCP_006_01_01+=7 ))
 fi
 
 "${node_command}" "{\"how_many\":6,\"http_port\":1080 ${common_params} ${node_params}}" > ${results_dir}/nodeoutput 2>&1 &

--- a/Sandbox/run_nmos_testing.sh
+++ b/Sandbox/run_nmos_testing.sh
@@ -37,6 +37,7 @@ expected_disabled_IS_09_02=0
 expected_disabled_IS_04_02=0
 expected_disabled_IS_09_01=0
 expected_disabled_IS_12_01=3
+expected_disabled_BCP_006_01_01=0
 
 config_secure=`${run_python} -c $'from nmostesting import Config\nprint(Config.ENABLE_HTTPS)'` || (echo "error running python"; exit 1)
 config_dns_sd_mode=`${run_python} -c $'from nmostesting import Config\nprint(Config.DNS_SD_MODE)'` || (echo "error running python"; exit 1)
@@ -213,6 +214,8 @@ do_run_test IS-08-02 $expected_disabled_IS_08_02 --host "${host}" "${host}" --po
 do_run_test IS-09-02 $expected_disabled_IS_09_02 --host "${host}" null --port 0 0 --version null v1.0
 
 do_run_test IS-12-01 $expected_disabled_IS_12_01 --host "${host}" "${host}" null null --port 1080 1082 0 0 --version v1.3 v1.0 v1.0 v1.0 --urlpath null x-nmos/ncp/v1.0 null null --ignore auto_ms05_1.2.2 auto_ms05_NcConnectionStatus test_ms05_05
+
+do_run_test BCP-006-01-01 $expected_disabled_BCP_006_01_01 --host "${host}" --port 1080 --version v1.3
 
 # Run Registry tests (leave Node running)
 "${registry_command}" "{\"pri\":0,\"http_port\":8088 ${common_params} ${registry_params}}" > ${results_dir}/registryoutput 2>&1 &


### PR DESCRIPTION
- Include the BCP-006-01-01 test suite to the CI NMOS Testing tool tests.
- Add badge to front page README.md 
- Tab has been added to test results spreadsheet and linked to badge
- Note: the `video_type`  in the Node config has been set to `jxsv` to satisfy the BCP-006-01-01 tests but with no adverse effects for other test suites
