### PR TITLE
Windows RDS becomes unresponsive when many devices connect

### DIFF
--- a/Development/nmos/thread_utils.h
+++ b/Development/nmos/thread_utils.h
@@ -15,7 +15,21 @@ namespace nmos
         public:
             typedef BasicLockable mutex_type;
             explicit reverse_lock_guard(mutex_type& m) : m(m) { m.unlock(); }
-            ~reverse_lock_guard() { m.lock(); }
+            ~reverse_lock_guard()
+            {
+                for (;;)
+                {
+                    try
+                    {
+                        m.lock();
+                        break;
+                    }
+                    catch (...)
+                    {
+                        // ignore exception
+                    }
+                }
+            }
             reverse_lock_guard(const reverse_lock_guard&) = delete;
             reverse_lock_guard& operator=(const reverse_lock_guard&) = delete;
         private:


### PR DESCRIPTION
In Windows, there is a maximum number of exclusive locks that can be held. Once it reaches the maximum value, the lock will throw a lock exception. Although the registration API can handle the exception, many of the nmos-cpp threads, such as `send_events_ws_messages_thread` and `erase_expired_events_resources_thread`, will terminate because they do not handle the exception. This makes RDS unresponsive.  To resolve this issue, it is essential to ensure that the exception is handled correctly. 