### PR TITLE
Enhance Monitor Status callback to include monitor information

### DIFF
--- a/Development/nmos-cpp-node/node_implementation.cpp
+++ b/Development/nmos-cpp-node/node_implementation.cpp
@@ -2121,11 +2121,13 @@ nmos::control_protocol_property_changed_handler make_node_implementation_control
     };
 }
 
-// Example Control Protocol WebSocket API Receiver Status Monitor callback to get network interface controller lost packet counters
-nmos::get_packet_counters_handler make_node_implementation_get_lost_packet_counters_handler()
+// Example Control Protocol WebSocket API Receiver/Sender Status Monitor callback to get network interface controller lost packet counters
+nmos::get_packet_counters_handler make_node_implementation_get_lost_packet_counters_handler(slog::base_gate& gate)
 {
-    return []()
+    return [&gate](const nmos::resource& resource)
     {
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "Lost package counters of " << nmos::fields::nc::role(resource.data);
+
         return boost::copy_range<std::vector<nmos::nc::counter>>(impl::nic_packet_counters | boost::adaptors::transformed([](const impl::nic_packet_counter& counter)
         {
             return nmos::nc::counter{ counter.lost_packet_counter.name, counter.lost_packet_counter.value, counter.lost_packet_counter.description };
@@ -2134,10 +2136,12 @@ nmos::get_packet_counters_handler make_node_implementation_get_lost_packet_count
 }
 
 // Example Control Protocol WebSocket API Receiver Status Monitor callback to get network interface controller late packet counters
-nmos::get_packet_counters_handler make_node_implementation_get_late_packet_counters_handler()
+nmos::get_packet_counters_handler make_node_implementation_get_late_packet_counters_handler(slog::base_gate& gate)
 {
-    return []()
+    return [&gate](const nmos::resource& resource)
     {
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "Late package counters of " << nmos::fields::nc::role(resource.data);
+
         return boost::copy_range<std::vector<nmos::nc::counter>>(impl::nic_packet_counters | boost::adaptors::transformed([](const impl::nic_packet_counter& counter)
         {
             return nmos::nc::counter{ counter.late_packet_counter.name, counter.late_packet_counter.value, counter.late_packet_counter.description };
@@ -2145,11 +2149,13 @@ nmos::get_packet_counters_handler make_node_implementation_get_late_packet_count
     };
 }
 
-// Example Control Protocol WebSocket API Receiver Status Monitor callback to reset network interface controller packet counters
-nmos::reset_monitor_handler make_node_implementation_reset_monitor_handler()
+// Example Control Protocol WebSocket API Receiver/Sender Status Monitor callback to reset network interface controller packet counters
+nmos::reset_monitor_handler make_node_implementation_reset_monitor_handler(slog::base_gate& gate)
 {
-    return []()
+    return [&gate](const nmos::resource& resource)
     {
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "Reset package counters of " << nmos::fields::nc::role(resource.data);
+
         for (auto& counter : impl::nic_packet_counters)
         {
             counter.lost_packet_counter.value = 0;
@@ -2394,7 +2400,7 @@ nmos::experimental::node_implementation make_node_implementation(nmos::node_mode
         .on_get_read_only_modification_allow_list(make_get_read_only_modification_allow_list_handler(gate)) // may be omitted if either IS-14 not required, or IS-14 Rebuild functionality not required
         .on_remove_device_model_object(make_remove_device_model_object_handler()) // may be omitted if either IS-14 not required, or IS-14 Rebuild functionality not required
         .on_create_device_model_object(make_create_device_model_object_handler(gate)) // may be omitted if either IS-14 not required, or IS-14 Rebuild functionality not required
-        .on_get_lost_packet_counters(make_node_implementation_get_lost_packet_counters_handler()) // may be omitted if IS-12/BCP-008-1 not required
-        .on_get_late_packet_counters(make_node_implementation_get_late_packet_counters_handler()) // may be omitted if IS-12/BCP-008-1 not required
-        .on_reset_monitor(make_node_implementation_reset_monitor_handler()); // may be omitted if IS-12/BCP-008-1 not required
+        .on_get_lost_packet_counters(make_node_implementation_get_lost_packet_counters_handler(gate)) // may be omitted if IS-12/BCP-008-1 not required
+        .on_get_late_packet_counters(make_node_implementation_get_late_packet_counters_handler(gate)) // may be omitted if IS-12/BCP-008-1 not required
+        .on_reset_monitor(make_node_implementation_reset_monitor_handler(gate)); // may be omitted if IS-12/BCP-008-1 not required
 }

--- a/Development/nmos/control_protocol_handlers.h
+++ b/Development/nmos/control_protocol_handlers.h
@@ -57,8 +57,8 @@ namespace nmos
                 : name(name), value(value), description(description) {}
         };
     }
-    typedef std::function<std::vector<nc::counter>(void)> get_packet_counters_handler;
-    typedef std::function<void(void)> reset_monitor_handler;
+    typedef std::function<std::vector<nc::counter>(const nmos::resource&)> get_packet_counters_handler;
+    typedef std::function<void(const nmos::resource&)> reset_monitor_handler;
 
     namespace experimental
     {

--- a/Development/nmos/control_protocol_methods.cpp
+++ b/Development/nmos/control_protocol_methods.cpp
@@ -677,17 +677,17 @@ namespace nmos
             return details::make_method_result_error({nc_method_status::parameter_error}, U("name not found"));
         }
 
-        // NcReceiverMonitor methods implementation
+        // NcReceiverMonitor and NcSenderMonitor methods implementation
         namespace details
         {
-            web::json::value get_packet_counters(bool is_deprecated, get_packet_counters_handler get_packet_counters)
+            web::json::value get_packet_counters(const nmos::resource& resource, bool is_deprecated, get_packet_counters_handler get_packet_counters)
             {
                 using web::json::value;
                 using web::json::value_from_elements;
 
                 if (get_packet_counters)
                 {
-                    const auto counters = get_packet_counters();
+                    const auto counters = get_packet_counters(resource);
                     auto nc_counter_sequence = value_from_elements(counters | boost::adaptors::transformed([](const nc::counter& counter)
                     {
                         return web::json::value_of({
@@ -705,19 +705,19 @@ namespace nmos
         }
 
         // Gets the lost packet counters
-        web::json::value get_lost_packet_counters(nmos::resources& /*resources*/, const nmos::resource& /*resource*/, const web::json::value& /*arguments*/, bool is_deprecated, get_packet_counters_handler get_lost_packet_counters, slog::base_gate& gate)
+        web::json::value get_lost_packet_counters(nmos::resources& /*resources*/, const nmos::resource& resource, const web::json::value& /*arguments*/, bool is_deprecated, get_packet_counters_handler get_lost_packet_counters, slog::base_gate& gate)
         {
             slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Gets the lost packet counters";
 
-            return details::get_packet_counters(is_deprecated, get_lost_packet_counters);
+            return details::get_packet_counters(resource, is_deprecated, get_lost_packet_counters);
         }
 
         // Gets the late packet counters
-        web::json::value get_late_packet_counters(nmos::resources& /*resources*/, const nmos::resource& /*resource*/, const web::json::value& /*arguments*/, bool is_deprecated, get_packet_counters_handler get_late_packet_counters, slog::base_gate& gate)
+        web::json::value get_late_packet_counters(nmos::resources& /*resources*/, const nmos::resource& resource, const web::json::value& /*arguments*/, bool is_deprecated, get_packet_counters_handler get_late_packet_counters, slog::base_gate& gate)
         {
             slog::log<slog::severities::more_info>(gate, SLOG_FLF) << "Gets the late packet counters";
 
-            return details::get_packet_counters(is_deprecated, get_late_packet_counters);
+            return details::get_packet_counters(resource, is_deprecated, get_late_packet_counters);
         }
 
         // Resets the packet counters and messages
@@ -786,7 +786,7 @@ namespace nmos
 
             if (reset_monitor)
             {
-                reset_monitor();
+                reset_monitor(resource);
             }
 
             return details::make_method_result({is_deprecated ? nmos::nc_method_status::method_deprecated : nc_method_status::ok});

--- a/Development/nmos/test/control_protocol_utils_test.cpp
+++ b/Development/nmos/test/control_protocol_utils_test.cpp
@@ -323,7 +323,7 @@ BST_TEST_CASE(testActivateDeactivateReceiverMonitor)
 
     bool reset_monitor_called = false;
 
-    nmos::reset_monitor_handler reset_monitor = [&reset_monitor_called]()
+    nmos::reset_monitor_handler reset_monitor = [&reset_monitor_called](const nmos::resource&)
     {
         // check that the property changed handler gets called
         reset_monitor_called = true;
@@ -685,7 +685,7 @@ BST_TEST_CASE(testActivateDeactivateSenderMonitor)
 
     bool reset_monitor_called = false;
 
-    nmos::reset_monitor_handler reset_monitor = [&reset_monitor_called]()
+    nmos::reset_monitor_handler reset_monitor = [&reset_monitor_called](const nmos::resource&)
     {
         // check that the property changed handler gets called
         reset_monitor_called = true;
@@ -825,7 +825,7 @@ BST_TEST_CASE(testSetMonitorStatusWithDelay)
     bool reset_monitor_called = false;
     bool monitor_status_pending_called = false;
 
-    nmos::reset_monitor_handler reset_monitor = [&reset_monitor_called]()
+    nmos::reset_monitor_handler reset_monitor = [&reset_monitor_called](const nmos::resource&)
     {
         // check that the property changed handler gets called
         reset_monitor_called = true;


### PR DESCRIPTION
Currently, the callback handlers exposed by nmos-cpp return information for all Interfaces, regardless of whether they have an associated Status Monitor. It is making it impossible to display the Interface information associated with a specific Monitor.

**Current callback**
```
typedef std::function<std::vector<nc::counter>(void)> get_packet_counters_handler;
typedef std::function<void(void)> reset_monitor_handler;
```
**Updated callback**
```
typedef std::function<std::vector<nc::counter>(const nmos::resource&)> get_packet_counters_handler;
typedef std::function<void(const nmos::resource&)> reset_monitor_handler;
```