### PR TITLE
Fix Windows CI host IP discovery on windows-2022 runners.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -122,16 +122,22 @@ jobs:
       run: |
         # set compiler to cl.exe to avoid building with gcc.
         echo "CMAKE_COMPILER_ARGS=-DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe" >> $env:GITHUB_ENV
-        # disable unused network interface
-        netsh interface set interface name="vEthernet (nat)" admin=DISABLED
-        # get host IP address
+        # disable unused network interface (may not exist on windows-2022 runners)
+        $nat = Get-NetAdapter -Name 'vEthernet (nat)' -ErrorAction SilentlyContinue
+        if ($nat) {
+          netsh interface set interface name="vEthernet (nat)" admin=DISABLED
+        }
+        # get host IP address (avoid Get-NetIPConfiguration which fails when multiple adapters map to one interface)
+        $ifIndex = (
+          Get-NetRoute -DestinationPrefix '0.0.0.0/0' |
+          Sort-Object RouteMetric |
+          Select-Object -First 1
+        ).InterfaceIndex
         $env:hostip = (
-          Get-NetIPConfiguration |
-          Where-Object {
-              $_.IPv4DefaultGateway -ne $null -and
-              $_.NetAdapter.Status -ne "Disconnected"
-          }
-        ).IPv4Address.IPAddress
+          Get-NetIPAddress -InterfaceIndex $ifIndex -AddressFamily IPv4 |
+          Where-Object { $_.IPAddress -notlike '169.254.*' } |
+          Select-Object -First 1
+        ).IPAddress
         echo "HOST_IP_ADDRESS=$env:hostip" >> $env:GITHUB_ENV
         ipconfig
         # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode

--- a/.github/workflows/src/build-setup.yml
+++ b/.github/workflows/src/build-setup.yml
@@ -24,16 +24,22 @@
   run: |
     # set compiler to cl.exe to avoid building with gcc.
     echo "CMAKE_COMPILER_ARGS=-DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe" >> $env:GITHUB_ENV
-    # disable unused network interface
-    netsh interface set interface name="vEthernet (nat)" admin=DISABLED
-    # get host IP address
+    # disable unused network interface (may not exist on windows-2022 runners)
+    $nat = Get-NetAdapter -Name 'vEthernet (nat)' -ErrorAction SilentlyContinue
+    if ($nat) {
+      netsh interface set interface name="vEthernet (nat)" admin=DISABLED
+    }
+    # get host IP address (avoid Get-NetIPConfiguration which fails when multiple adapters map to one interface)
+    $ifIndex = (
+      Get-NetRoute -DestinationPrefix '0.0.0.0/0' |
+      Sort-Object RouteMetric |
+      Select-Object -First 1
+    ).InterfaceIndex
     $env:hostip = (
-      Get-NetIPConfiguration |
-      Where-Object {
-          $_.IPv4DefaultGateway -ne $null -and
-          $_.NetAdapter.Status -ne "Disconnected"
-      }
-    ).IPv4Address.IPAddress
+      Get-NetIPAddress -InterfaceIndex $ifIndex -AddressFamily IPv4 |
+      Where-Object { $_.IPAddress -notlike '169.254.*' } |
+      Select-Object -First 1
+    ).IPAddress
     echo "HOST_IP_ADDRESS=$env:hostip" >> $env:GITHUB_ENV
     ipconfig
     # add the CRL Distribution Point to hosts so that it's discoverable when running the AMWA test suite in mDNS mode


### PR DESCRIPTION
Get-NetIPConfiguration fails when multiple adapters map to one interface; use the default route and Get-NetIPAddress instead, and only disable vEthernet (nat) when present.