### PR TITLE
Validate HSTS max-age parsing

### DIFF
--- a/Development/cpprest/http_utils.cpp
+++ b/Development/cpprest/http_utils.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
+#include <limits>
 #include <map>
 #include <set>
 #include <boost/algorithm/string/predicate.hpp>
@@ -519,8 +521,13 @@ namespace web
                 // required
                 const auto max_age = find_directive(directives, U("max-age"));
                 if (directives.end() == max_age) throw std::invalid_argument("invalid Strict-Transport-Security header, missing max-age");
-                // hm, invalid value is treated as 0
-                result.max_age = utility::istringstreamed(max_age->second, 0u);
+                if (max_age->second.empty() || !std::all_of(max_age->second.begin(), max_age->second.end(), [](utility::char_t c) { return U('0') <= c && c <= U('9'); }))
+                {
+                    throw std::invalid_argument("invalid Strict-Transport-Security header, invalid max-age");
+                }
+                const auto parsed_max_age = utility::istringstreamed<std::uint64_t>(max_age->second, (std::numeric_limits<std::uint64_t>::max)());
+                if (parsed_max_age > (std::numeric_limits<decltype(result.max_age)>::max)()) throw std::invalid_argument("invalid Strict-Transport-Security header, invalid max-age");
+                result.max_age = static_cast<decltype(result.max_age)>(parsed_max_age);
 
                 // optional
                 const auto include_sub_domains = find_directive(directives, U("includeSubDomains"));

--- a/Development/cpprest/test/http_utils_test.cpp
+++ b/Development/cpprest/test/http_utils_test.cpp
@@ -218,6 +218,5 @@ BST_TEST_CASE(testMakeHSTSHeaderParseHSTSHeader)
     BST_REQUIRE_THROW(web::http::experimental::parse_hsts_header(U("max-age=\"31536000")), std::invalid_argument);
     // missing max-age which is required
     BST_REQUIRE_THROW(web::http::experimental::parse_hsts_header(U("includeSubDomains")), std::invalid_argument);
-    // hm, invalid max-age
-    //BST_REQUIRE_THROW(web::http::experimental::parse_hsts_header(U("max-age=meow")), std::invalid_argument);
+    BST_REQUIRE_THROW(web::http::experimental::parse_hsts_header(U("max-age=meow")), std::invalid_argument);
 }


### PR DESCRIPTION
Reject invalid Strict-Transport-Security max-age values instead of treating them as zero.

This adds validation for non-numeric and out-of-range max-age values and allows the existing unit test coverage for invalid max age input

Fixes #492
 