### PR TITLE
Replace fatal log with severe log

### DIFF
--- a/Development/nmos/control_protocol_utils.cpp
+++ b/Development/nmos/control_protocol_utils.cpp
@@ -1375,7 +1375,7 @@ namespace nmos
             else
             {
                 // should never happen
-                slog::log<slog::severities::fatal>(gate, SLOG_FLF) << "Invalid logic found in activate monitor oid: " << oid;
+                slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Invalid logic found in activate monitor oid: " << oid;
             }
             return false;
         }
@@ -1404,7 +1404,7 @@ namespace nmos
             else
             {
                 // should never happen
-                slog::log<slog::severities::fatal>(gate, SLOG_FLF) << "Invalid logic found in deactivate monitor oid: " << oid;
+                slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Invalid logic found in deactivate monitor oid: " << oid;
             }
             return false;
         }


### PR DESCRIPTION
Thanks to @garethsb for pointing out that there are a couple of fatal logs that can be replaced with the severe log. Even when those errors occur, we still want the application to continue running, not terminate.