### PR TITLE
Additional workaround for VS2026 (MSVC Build Tools v14.51)

### DIFF
--- a/Development/nmos/filesystem_route.cpp
+++ b/Development/nmos/filesystem_route.cpp
@@ -3,7 +3,14 @@
 #include <boost/algorithm/string/erase.hpp>
 #include "bst/filesystem.h"
 
+// From VS2026, or more precisely, MSVC Build Tools v14.51, std::ios_base::_Openprot is removed
+// Its replacement, std::ios_base::_Default_open_prot was introduced way back in VS 2019
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
+#include <ios>
+#define _Openprot _Default_open_prot
+#endif
 #include "cpprest/filestream.h"
+
 #include "nmos/slog.h"
 
 namespace nmos


### PR DESCRIPTION
cpprestsdk uses `std::ios_base::_Openprot` which has been removed by https://github.com/microsoft/STL/commit/e2ef398685f7e470dbaeaf65ff919de72bda7489.

So, compiling nmos-cpp, we get:

```
  filesystem_route.cpp
  ...
C:\Users\runneradmin\.conan2\p\b\cppre31cf1ba1181d5\p\include\cpprest\filestream.h(1015,102): error C2039: '_Openprot': is not a member of 'std::ios_base' [D:\a\nvnmos\nvnmos\build\build-nmos-cpp\nmos-cpp.vcxproj]
  (compiling source file '../../../nmos-cpp/Development/nmos/filesystem_route.cpp')
      C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Tools\MSVC\14.51.36231\include\xiosbase(76,53):
      see declaration of 'std::ios_base'
      C:\Users\runneradmin\.conan2\p\b\cppre31cf1ba1181d5\p\include\cpprest\filestream.h(1015,102):
      the template instantiation context (the oldest one first) is
          D:\a\nvnmos\nmos-cpp\Development\nmos\filesystem_route.cpp(103,79):
          see instantiation of default argument expression required for 'Concurrency::task<Concurrency::streams::basic_istream<uint8_t>> Concurrency::streams::file_stream<uint8_t>::open_istream(const utility::string_t &,std::ios_base::openmode,int)'
  
C:\Users\runneradmin\.conan2\p\b\cppre31cf1ba1181d5\p\include\cpprest\filestream.h(1015,102): error C2065: '_Openprot': undeclared identifier [D:\a\nvnmos\nvnmos\build\build-nmos-cpp\nmos-cpp.vcxproj]
  (compiling source file '../../../nmos-cpp/Development/nmos/filesystem_route.cpp')
```

That will need a patch in the cpprestsdk conan recipe, and/or a fork, because [Microsoft/cpprestsdk](https://github.com/Microsoft/cpprestsdk) is archived since 1 June 2026. This fix ensures nmos-cpp `filesystem_route.cpp` should compile from source whether or not that happens though.