### PR TITLE
Fix `nmos-cpp-registry` and `nmos-cpp-node` startup without config JSON

### DIFF
--- a/Development/nmos/model.h
+++ b/Development/nmos/model.h
@@ -23,7 +23,7 @@ namespace nmos
         mutable nmos::condition_variable shutdown_condition;
 
         // application-wide configuration
-        nmos::settings settings;
+        nmos::settings settings = web::json::value::object();
 
         // flag indicating whether shutdown has been initiated
         bool shutdown = false;


### PR DESCRIPTION
Thank you to Niitsu, Keita-san from Sony, for reporting this issue, as no config JSON is provided to start nmos-cpp-registry and nmos-cpp-node.

Issue:
1. registry_model.settings/node_model.settings are default-constructed as null.
2. When no command-line arguments are supplied, no settings are loaded.
3. `validate_registry_settings`/`validate_node_implementation_settings` are called with a null JSON value.
4. Schema validation fails because the root type is not an object.

Solution:
- Initialise settings as an empty JSON object in `base_model` (nmos/model.h).