### PR TITLE
Update embedded IS-05 MXL schemas to match BCP-007-03

### DIFF
--- a/Development/third_party/is-05/v1.2-dev/APIs/schemas/constraints-schema-mxl.json
+++ b/Development/third_party/is-05/v1.2-dev/APIs/schemas/constraints-schema-mxl.json
@@ -1,14 +1,14 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "description": "Used to express the dynamic constraints on MXL transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object. See BCP-007-03.",
+  "description": "Used to express the dynamic constraints on MXL transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object.",
   "required": [
     "mxl_domain_id",
     "mxl_flow_id"
   ],
   "additionalProperties": false,
   "patternProperties": {
-    "^ext_[a-zA-Z0-9_]+$": {
+    "^ext_[a-zA-Z0-9_]+$":{
       "$ref": "constraint-schema.json#/definitions/constraint"
     }
   },

--- a/Development/third_party/is-05/v1.2-dev/APIs/schemas/receiver_transport_params_mxl.json
+++ b/Development/third_party/is-05/v1.2-dev/APIs/schemas/receiver_transport_params_mxl.json
@@ -9,9 +9,9 @@
         "string",
         "null"
       ],
-      "description": "MXL domain identity (UUID). Use auto to select from constraints.",
+      "description": "Specifies the MXL Domain ID where the MXL Flow will be located. The Receiver lists allowed Domain IDs in the constraints endpoint. Where the Domain is not yet determined, implementations use null. MXL Receivers accept null for an unconfigured Receiver. MXL Receivers support the literal auto for the single-domain case and, where appropriate, in multi-domain deployments. In replicated topologies, the selected Domain may differ in identity from an origin Domain (for example permissions, security context, or administrative boundary), provided it yields a valid operational configuration. Where auto cannot be resolved to a valid value for /active in the current operating context, the Receiver may reject the request or activation. The constraints endpoint does not list auto as an available option.",
       "anyOf": [{
-          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-9a-f][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         {
           "pattern": "^auto$"
@@ -26,9 +26,9 @@
         "string",
         "null"
       ],
-      "description": "MXL flow identity for the read operation. Need not match the IS-04 Flow id. BCP-007-03: null or UUID only; the literal auto is not used for receivers.",
+      "description": "Specifies the MXL Flow ID for the MXL read operation. The Receiver lists allowed Flow IDs in the constraints endpoint. Where the flow is not yet determined, implementations use null. MXL Receivers accept null for an unconfigured Receiver as the MXL Flow ID may be unknown until the Receiver has been suitably patched. The literal auto is not used for this parameter.",
       "anyOf": [{
-          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-9a-f][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         {
           "type": "null"

--- a/Development/third_party/is-05/v1.2-dev/APIs/schemas/sender_transport_params_mxl.json
+++ b/Development/third_party/is-05/v1.2-dev/APIs/schemas/sender_transport_params_mxl.json
@@ -9,9 +9,9 @@
         "string",
         "null"
       ],
-      "description": "MXL domain identity (UUID). Use auto to select from constraints.",
+      "description": "Specifies the MXL Domain ID where the MXL Flow will be located. The Sender lists allowed Domain IDs in the constraints endpoint. Where the Domain is not yet determined, implementations use null. MXL Senders accept null where the MXL Domain is unknown a priori in a multi-domain system. MXL Senders support `auto` where the Sender can resolve the Domain without a Controller-supplied Domain ID. Where `auto` cannot be resolved to a valid value for /active in the current operating context, the Sender may reject the request or activation. The constraints endpoint does not list `auto` as an available option.",
       "anyOf": [{
-          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-9a-f][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         {
           "pattern": "^auto$"
@@ -26,9 +26,9 @@
         "string",
         "null"
       ],
-      "description": "MXL flow identity for the write operation. Need not match the IS-04 Flow id. Use auto to select from constraints.",
+      "description": "Specifies the MXL Flow ID for the MXL write operation. The Sender lists allowed Flow IDs in the constraints endpoint. Where the flow is not yet determined, implementations use null. MXL Senders accept null including where the MXL Flow is not yet configured. MXL Senders support `auto` where the Sender resolves the MXL Flow ID (for example when only one MXL Flow applies). Where `auto` cannot be resolved to a valid value for /active in the current operating context, the Sender may reject the request or activation. The constraints endpoint does not list auto as an available option.",
       "anyOf": [{
-          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-9a-f][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         {
           "pattern": "^auto$"


### PR DESCRIPTION
Align `mxl_domain_id` and `mxl_flow_id` descriptions and UUID patterns (RFC 9562 versions 1-15) with the current BCP-007-03 transport parameter schemas. Tidy `constraints-schema-mxl.json` description and formatting to match sibling constraints-schema files.