### PR TITLE
Prevent needrestart from breaking Avahi mDNS in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -212,6 +212,10 @@ jobs:
         echo -e "$hostip crl.testsuite.nmos.tv\n$hostip ocsp.testsuite.nmos.tv" | sudo tee -a /etc/hosts > /dev/null
         # re-synchronize the package index
         sudo apt-get update -q
+        # GitHub-hosted runners are ephemeral; needrestart can restart avahi-daemon,
+        # systemd-networkd, systemd-resolved, etc. during later apt installs (e.g. when
+        # a libc upgrade is pulled in), leaving mDNS broken for unit tests. Remove it.
+        sudo apt-get autopurge -y needrestart
 
     - name: ubuntu mdns install
       if: runner.os == 'Linux' && matrix.install_mdns == true
@@ -267,13 +271,33 @@ jobs:
       if: runner.os == 'Linux' && matrix.install_mdns == false
       run: |
         sudo apt-get install -f libavahi-compat-libdnssd-dev libnss-mdns avahi-utils
+        # install Name Service Cache Daemon to speed up repeated mDNS name discovery
+        # (do this before configuring Avahi so any package work finishes first)
+        sudo apt-get install -f nscd
         echo "CTEST_EXTRA_ARGS=$CTEST_EXTRA_ARGS -E testMdnsAdvertiseAddress" >> $GITHUB_ENV
         echo "CTEST_EXPECTED_FAILURES=$CTEST_EXPECTED_FAILURES -R testMdnsAdvertiseAddress" >> $GITHUB_ENV
         # make avahi only respond on the "eth0" interface
         sudo sed -i 's/#*allow-interfaces=.*/allow-interfaces=eth0/g' /etc/avahi/avahi-daemon.conf
         sudo systemctl restart avahi-daemon
-        # install Name Service Cache Daemon to speed up repeated mDNS name discovery
-        sudo apt-get install -f nscd
+        # verify local publish/browse works before spending time on the build
+        avahi-publish -s ci-selftest _nmos-test._tcp 8080 &
+        publish_pid=$!
+        found=
+        for _ in $(seq 1 30); do
+          if avahi-browse -pt _nmos-test._tcp 2>/dev/null | grep -q ci-selftest; then
+            found=1
+            break
+          fi
+          sleep 1
+        done
+        kill "$publish_pid" 2>/dev/null || true
+        wait "$publish_pid" 2>/dev/null || true
+        if [ -z "$found" ]; then
+          systemctl status avahi-daemon --no-pager || true
+          journalctl -u avahi-daemon --no-pager -n 100 || true
+          echo "::error::avahi-daemon cannot browse locally published services"
+          exit 1
+        fi
         # force dependency on avahi
         echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_AVAHI:BOOL=\"1\"" >> $GITHUB_ENV
 

--- a/.github/workflows/src/build-setup.yml
+++ b/.github/workflows/src/build-setup.yml
@@ -114,6 +114,10 @@
     echo -e "$hostip crl.testsuite.nmos.tv\n$hostip ocsp.testsuite.nmos.tv" | sudo tee -a /etc/hosts > /dev/null
     # re-synchronize the package index
     sudo apt-get update -q
+    # GitHub-hosted runners are ephemeral; needrestart can restart avahi-daemon,
+    # systemd-networkd, systemd-resolved, etc. during later apt installs (e.g. when
+    # a libc upgrade is pulled in), leaving mDNS broken for unit tests. Remove it.
+    sudo apt-get autopurge -y needrestart
 
 - name: ubuntu mdns install
   if: runner.os == 'Linux' && matrix.install_mdns == true
@@ -169,13 +173,33 @@
   if: runner.os == 'Linux' && matrix.install_mdns == false
   run: |
     sudo apt-get install -f libavahi-compat-libdnssd-dev libnss-mdns avahi-utils
+    # install Name Service Cache Daemon to speed up repeated mDNS name discovery
+    # (do this before configuring Avahi so any package work finishes first)
+    sudo apt-get install -f nscd
     echo "CTEST_EXTRA_ARGS=$CTEST_EXTRA_ARGS -E testMdnsAdvertiseAddress" >> $GITHUB_ENV
     echo "CTEST_EXPECTED_FAILURES=$CTEST_EXPECTED_FAILURES -R testMdnsAdvertiseAddress" >> $GITHUB_ENV
     # make avahi only respond on the "eth0" interface
     sudo sed -i 's/#*allow-interfaces=.*/allow-interfaces=eth0/g' /etc/avahi/avahi-daemon.conf
     sudo systemctl restart avahi-daemon
-    # install Name Service Cache Daemon to speed up repeated mDNS name discovery
-    sudo apt-get install -f nscd
+    # verify local publish/browse works before spending time on the build
+    avahi-publish -s ci-selftest _nmos-test._tcp 8080 &
+    publish_pid=$!
+    found=
+    for _ in $(seq 1 30); do
+      if avahi-browse -pt _nmos-test._tcp 2>/dev/null | grep -q ci-selftest; then
+        found=1
+        break
+      fi
+      sleep 1
+    done
+    kill "$publish_pid" 2>/dev/null || true
+    wait "$publish_pid" 2>/dev/null || true
+    if [ -z "$found" ]; then
+      systemctl status avahi-daemon --no-pager || true
+      journalctl -u avahi-daemon --no-pager -n 100 || true
+      echo "::error::avahi-daemon cannot browse locally published services"
+      exit 1
+    fi
     # force dependency on avahi
     echo "CMAKE_EXTRA_ARGS=${{ env.CMAKE_EXTRA_ARGS }} -DNMOS_CPP_USE_AVAHI:BOOL=\"1\"" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Summary
- Intermittent Ubuntu Avahi CI failures (`testMdnsBrowseAPIs` / `testMdnsResolveAPIs`) were caused by `needrestart` restarting `avahi-daemon`, `systemd-networkd`, `systemd-resolved`, and related services mid-job when an apt install (notably `nscd`) pulled in a libc upgrade. Registrations still succeeded, but browse saw zero services.
- Purge `needrestart` early on Linux runners (ephemeral VMs do not need it).
- Move Avahi config/restart to after all apt installs in the Avahi setup step.
- Add a local `avahi-publish` / `avahi-browse` self-check so a broken daemon fails fast with journal output instead of after a long `ctest` run.

## Considered options
- **Wait for services after apt:** Rejected. `needrestart` already blocks until its `systemctl restart` finishes; the failing run still had a stably broken Avahi minutes later. Waiting cannot fix a bad steady state.
- **`NEEDRESTART_MODE: l` in the workflow `env` block:** Rejected as insufficient by itself. Plain `sudo apt-get` resets the environment, so the mode often never reaches `needrestart`. Equivalent behaviour needs `sudo NEEDRESTART_MODE=l .`, `sudo -E`, or a conf.d drop-in on every apt path.
- **conf.d list-only (`$nrconf{restart} = "l"`):** Workable, but leaving `needrestart` installed still allows future footguns. For throwaway runners, removing the package is simpler and covers every later apt step.
- **Purge `needrestart` (chosen):** One early `apt-get autopurge` eliminates the failure mode with no sudo/env caveats.

## Follow-on
- Consider dropping `nscd` entirely. It is only installed to speed up repeated name discovery, is deprecated upstream in glibc, and was the package that pulled the libc upgrade which triggered `needrestart`. Left in place here to keep this PR focused on the Avahi breakage.

## Test plan
- [x] Confirm Ubuntu Avahi multicast matrix jobs pass (browse/resolve no longer fail with zero results).
- [x] Confirm Ubuntu mDNSResponder jobs still pass after `needrestart` purge.
- [ ] If Avahi is broken, confirm the new self-check fails early and dumps `systemctl status` / `journalctl -u avahi-daemon`.